### PR TITLE
Refactor the src/dirtree.c file into smaller chunks, one for the pr_conf...

### DIFF
--- a/Make.rules.in
+++ b/Make.rules.in
@@ -62,23 +62,24 @@ DEFINES=$(PLATFORM)
 # options.
 MODULE_LIBS_FILE=$(top_builddir)/module-libs.txt
 
-OBJS=main.o timers.o sets.o pool.o privs.o str.o table.o regexp.o dirtree.o \
-     expr.o support.o netaddr.o inet.o child.o parser.o log.o lastlog.o \
-     xferlog.o bindings.o netacl.o class.o scoreboard.o help.o feat.o netio.o \
-     cmd.o response.o data.o modules.o stash.o display.o auth.o fsio.o \
-     mkhome.o ctrls.o event.o var.o throttle.o session.o trace.o encode.o \
-     proctitle.o filter.o pidfile.o env.o version.o rlimit.o wtmp.o memcache.o
+OBJS=main.o timers.o sets.o pool.o privs.o str.o table.o regexp.o configdb.o \
+     dirtree.o expr.o support.o netaddr.o inet.o child.o parser.o log.o \
+     lastlog.o xferlog.o bindings.o netacl.o class.o scoreboard.o help.o \
+     feat.o netio.o cmd.o response.o data.o modules.o stash.o display.o \
+     auth.o fsio.o mkhome.o ctrls.o event.o var.o throttle.o session.o \
+     trace.o encode.o proctitle.o filter.o pidfile.o env.o version.o \
+     rlimit.o wtmp.o memcache.o
 
 BUILD_OBJS=src/main.o src/timers.o src/sets.o src/pool.o src/privs.o src/str.o \
-           src/table.o src/regexp.o src/dirtree.o src/expr.o src/support.o \
-           src/netaddr.o src/inet.o src/child.o src/parser.o src/log.o \
-           src/lastlog.o src/xferlog.o src/bindings.o src/netacl.o src/class.o \
-           src/scoreboard.o src/help.o src/feat.o src/netio.o src/cmd.o \
-           src/response.o src/data.o src/modules.o src/stash.o src/display.o \
-           src/auth.o src/fsio.o src/mkhome.o src/ctrls.o src/event.o \
-           src/var.o src/throttle.o src/session.o src/trace.o src/encode.o \
-           src/proctitle.o src/filter.o src/pidfile.o src/env.o src/version.o \
-           src/rlimit.o src/wtmp.o src/memcache.o
+           src/table.o src/regexp.o src/configdb.o src/dirtree.o src/expr.o \
+           src/support.o src/netaddr.o src/inet.o src/child.o src/parser.o \
+           src/log.o src/lastlog.o src/xferlog.o src/bindings.o src/netacl.o \
+           src/class.o src/scoreboard.o src/help.o src/feat.o src/netio.o \
+           src/cmd.o src/response.o src/data.o src/modules.o src/stash.o \
+           src/display.o src/auth.o src/fsio.o src/mkhome.o src/ctrls.o \
+           src/event.o src/var.o src/throttle.o src/session.o src/trace.o \
+           src/encode.o src/proctitle.o src/filter.o src/pidfile.o src/env.o \
+           src/version.o src/rlimit.o src/wtmp.o src/memcache.o
 
 SHARED_MODULE_DIRS=@SHARED_MODULE_DIRS@
 SHARED_MODULE_LIBS=@SHARED_MODULE_LIBS@

--- a/include/configdb.h
+++ b/include/configdb.h
@@ -1,0 +1,142 @@
+/*
+ * ProFTPD - FTP server daemon
+ * Copyright (c) 2014 The ProFTPD Project team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, Public Flood Software/MacGyver aka Habeeb J. Dihu
+ * and other respective copyright holders give permission to link this program
+ * with OpenSSL, and distribute the resulting executable, without including
+ * the source code for OpenSSL in the source distribution.
+ */
+
+/* Configuration database API. */
+
+#ifndef PR_CONFIGDB_H
+#define PR_CONFIGDB_H
+
+#include "pool.h"
+#include "sets.h"
+#include "table.h"
+
+typedef struct config_struc config_rec;
+struct server_struc;
+
+struct config_struc {
+  struct config_struc *next, *prev;
+
+  int config_type;
+  unsigned int config_id;
+
+  struct pool_rec *pool;	/* Memory pool for this object */
+  xaset_t *set;			/* The set we are stored in */
+  char *name;
+  int argc;
+  void **argv;
+
+  long flags;			/* Flags */
+
+  struct server_struc *server;	/* Server this config element is attached to */
+  config_rec *parent;		/* Our parent configuration record */
+  xaset_t *subset;		/* Sub-configuration */
+};
+
+#define CONF_ROOT		(1 << 0) /* No conf record */
+#define CONF_DIR		(1 << 1) /* Per-Dir configuration */
+#define CONF_ANON		(1 << 2) /* Anon. FTP configuration */
+#define CONF_LIMIT		(1 << 3) /* Limits commands available */
+#define CONF_VIRTUAL		(1 << 4) /* Virtual host */
+#define CONF_DYNDIR		(1 << 5) /* .ftpaccess file */
+#define CONF_GLOBAL		(1 << 6) /* "Global" context (applies to main server and ALL virtualhosts */
+#define CONF_CLASS		(1 << 7) /* Class context */
+#define CONF_NAMED		(1 << 8) /* Named virtual host */
+#define CONF_USERDATA		(1 << 14) /* Runtime user data */
+#define CONF_PARAM		(1 << 15) /* config/args pair */
+
+/* config_rec flags */
+#define CF_MERGEDOWN		(1 << 0) /* Merge option down */
+#define CF_MERGEDOWN_MULTI	(1 << 1) /* Merge down, allowing multiple instances */
+#define CF_DYNAMIC		(1 << 2) /* Dynamically added entry */
+#define CF_DEFER		(1 << 3) /* Defer hashing until authentication */
+#define CF_SILENT		(1 << 4) /* Do not print a config dump when merging */
+#define CF_MULTI		(1 << 5) /* Allow multiple instances, but do not merge down */
+
+/* The following macro determines the "highest" level available for
+ * configuration directives.  If a current dir_config is available, it's
+ * subset is used, otherwise anon config or main server
+ */
+
+#define CURRENT_CONF		(session.dir_config ? session.dir_config->subset \
+				 : (session.anon_config ? session.anon_config->subset \
+                                    : main_server->conf))
+#define TOPLEVEL_CONF		(session.anon_config ? session.anon_config->subset : main_server->conf)
+
+/* Prototypes */
+
+config_rec *add_config_set(xaset_t **, const char *);
+config_rec *add_config(struct server_struc *, const char *);
+config_rec *add_config_param(const char *, int, ...);
+config_rec *add_config_param_str(const char *, int, ...);
+config_rec *add_config_param_set(xaset_t **, const char *, int, ...);
+config_rec *pr_conf_add_server_config_param_str(struct server_struc *,
+  const char *, int, ...);
+
+/* Flags used when searching for specific config_recs in the in-memory
+ * config database, particularly when 'recurse' is TRUE.
+ */
+#define PR_CONFIG_FIND_FL_SKIP_ANON		0x001
+#define PR_CONFIG_FIND_FL_SKIP_DIR		0x002
+#define PR_CONFIG_FIND_FL_SKIP_LIMIT		0x004
+#define PR_CONFIG_FIND_FL_SKIP_DYNDIR		0x008
+
+config_rec *find_config_next(config_rec *, config_rec *, int,
+  const char *, int);
+config_rec *find_config_next2(config_rec *, config_rec *, int,
+  const char *, int, unsigned long);
+config_rec *find_config(xaset_t *, int, const char *, int);
+config_rec *find_config2(xaset_t *, int, const char *, int, unsigned long);
+void find_config_set_top(config_rec *);
+
+int remove_config(xaset_t *, const char *, int);
+
+#define PR_CONFIG_FL_INSERT_HEAD	0x001
+config_rec *pr_config_add_set(xaset_t **, const char *, int);
+config_rec *pr_config_add(struct server_struc *, const char *, int);
+
+/* Returns the assigned ID for the provided directive name, or zero
+ * if no ID mapping was found.
+ */
+unsigned int pr_config_get_id(const char *name);
+
+/* Assigns a unique ID for the given configuration directive.  The
+ * mapping of directive to ID is stored in a lookup table, so that
+ * searching of the config database by directive name can be done using
+ * ID comparisons rather than string comparisons.
+ *
+ * Returns the ID assigned for the given directive, or zero if there was an
+ * error.
+ */
+unsigned int pr_config_set_id(const char *name);
+
+void *get_param_ptr(xaset_t *, const char *, int);
+void *get_param_ptr_next(const char *, int);
+
+void pr_config_merge_down(xaset_t *, int);
+void pr_config_dump(void (*)(const char *, ...), xaset_t *, char *);
+
+/* Internal use only. */
+void init_config(void);
+
+#endif /* PR_CONFIGDB_H */

--- a/src/configdb.c
+++ b/src/configdb.c
@@ -1,0 +1,931 @@
+/*
+ * ProFTPD - FTP server daemon
+ * Copyright (c) 2014 The ProFTPD Project team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, Public Flood Software/MacGyver aka Habeeb J. Dihu
+ * and other respective copyright holders give permission to link this program
+ * with OpenSSL, and distribute the resulting executable, without including
+ * the source code for OpenSSL in the source distribution.
+ */
+
+/* Configuration database implementation. */
+
+#include "conf.h"
+#include "privs.h"
+
+#ifdef HAVE_ARPA_INET_H
+# include <arpa/inet.h>
+#endif
+
+/* From src/pool.c */
+extern pool *global_config_pool;
+
+/* Used by find_config_* */
+static xaset_t *find_config_top = NULL;
+
+static void config_dumpf(const char *, ...);
+
+static config_rec *last_param_ptr = NULL;
+
+static pool *config_tab_pool = NULL;
+static pr_table_t *config_tab = NULL;
+static unsigned int config_id = 0;
+
+static const char *trace_channel = "config";
+
+/* Adds a config_rec to the specified set */
+config_rec *pr_config_add_set(xaset_t **set, const char *name, int flags) {
+  pool *conf_pool = NULL, *set_pool = NULL;
+  config_rec *c, *parent = NULL;
+
+  if (set == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+ 
+  if (!*set) {
+
+    /* Allocate a subpool from permanent_pool for the set. */
+    set_pool = make_sub_pool(permanent_pool);
+    pr_pool_tag(set_pool, "config set pool");
+
+    *set = xaset_create(set_pool, NULL);
+    (*set)->pool = set_pool;
+
+    /* Now, make a subpool for the config_rec to be allocated.  The default
+     * pool size (PR_TUNABLE_NEW_POOL_SIZE, 512 by default) is a bit large
+     * for config_rec pools; use a smaller size.
+     */
+    conf_pool = pr_pool_create_sz(set_pool, 128);
+
+  } else {
+
+    /* Find the parent set for the config_rec to be allocated. */
+    if ((*set)->xas_list) {
+      parent = ((config_rec *) ((*set)->xas_list))->parent;
+    }
+
+    /* Now, make a subpool for the config_rec to be allocated.  The default
+     * pool size (PR_TUNABLE_NEW_POOL_SIZE, 512 by default) is a bit large
+     * for config_rec pools; use a smaller size.  Allocate the subpool
+     * from the parent's pool.
+     */
+    conf_pool = pr_pool_create_sz((*set)->pool, 128);
+  }
+
+  pr_pool_tag(conf_pool, "config_rec pool");
+
+  c = (config_rec *) pcalloc(conf_pool, sizeof(config_rec));
+  c->pool = conf_pool;
+  c->set = *set;
+  c->parent = parent;
+
+  if (name) {
+    c->name = pstrdup(conf_pool, name);
+    c->config_id = pr_config_set_id(c->name);
+  }
+
+  if (flags & PR_CONFIG_FL_INSERT_HEAD) {
+    xaset_insert(*set, (xasetmember_t *) c);
+    
+  } else {
+    xaset_insert_end(*set, (xasetmember_t *) c);
+  }
+
+  return c;
+}
+
+config_rec *add_config_set(xaset_t **set, const char *name) {
+  return pr_config_add_set(set, name, 0);
+}
+
+/* Adds a config_rec to the given server.  If no server is specified, the
+ * config_rec is added to the current "level".
+ */
+config_rec *pr_config_add(server_rec *s, const char *name, int flags) {
+  config_rec *parent = NULL, *c = NULL;
+  pool *p = NULL;
+  xaset_t **set = NULL;
+
+  if (s == NULL) {
+    s = pr_parser_server_ctxt_get();
+  }
+
+  c = pr_parser_config_ctxt_get();
+
+  if (c) {
+    parent = c;
+    p = c->pool;
+    set = &c->subset;
+
+  } else {
+    parent = NULL;
+
+    if (s->conf == NULL ||
+        s->conf->xas_list == NULL) {
+
+      p = make_sub_pool(s->pool);
+      pr_pool_tag(p, "pr_config_add() subpool");
+
+    } else {
+      p = ((config_rec *) s->conf->xas_list)->pool;
+    }
+
+    set = &s->conf;
+  }
+
+  if (!*set) {
+    *set = xaset_create(p, NULL);
+  }
+
+  c = pr_config_add_set(set, name, flags);
+  c->parent = parent;
+
+  return c;
+}
+
+config_rec *add_config(server_rec *s, const char *name) {
+  return pr_config_add(s, name, 0);
+}
+
+static void config_dumpf(const char *fmt, ...) {
+  char buf[PR_TUNABLE_BUFFER_SIZE] = {'\0'};
+  va_list msg;
+
+  va_start(msg, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, msg);
+  va_end(msg);
+
+  buf[sizeof(buf)-1] = '\0';
+
+  pr_log_debug(DEBUG5, "%s", buf);
+}
+
+void pr_config_dump(void (*dumpf)(const char *, ...), xaset_t *s,
+    char *indent) {
+  config_rec *c = NULL;
+
+  if (dumpf == NULL) {
+    dumpf = config_dumpf;
+  }
+
+  if (s == NULL) {
+    return;
+  }
+
+  if (indent == NULL) {
+    indent = "";
+  }
+
+  for (c = (config_rec *) s->xas_list; c; c = c->next) {
+    pr_signals_handle();
+
+    /* Don't display directives whose name starts with an underscore. */
+    if (c->name != NULL &&
+        *(c->name) != '_') {
+      dumpf("%s%s", indent, c->name);
+    }
+
+    if (c->subset) {
+      pr_config_dump(dumpf, c->subset, pstrcat(c->pool, indent, " ", NULL));
+    }
+  }
+}
+
+static const char *config_type_str(int config_type) {
+  const char *type = "(unknown)";
+
+  switch (config_type) {
+    case CONF_ROOT:
+      type = "CONF_ROOT";
+      break;
+
+    case CONF_DIR:
+      type = "CONF_DIR";
+      break;
+
+    case CONF_ANON:
+      type = "CONF_ANON";
+      break;
+
+    case CONF_LIMIT:
+      type = "CONF_LIMIT";
+      break;
+
+    case CONF_VIRTUAL:
+      type = "CONF_VIRTUAL";
+      break;
+
+    case CONF_DYNDIR:
+      type = "CONF_DYNDIR";
+      break;
+
+    case CONF_GLOBAL:
+      type = "CONF_GLOBAL";
+      break;
+
+    case CONF_CLASS:
+      type = "CONF_CLASS";
+      break;
+
+    case CONF_NAMED:
+      type = "CONF_NAMED";
+      break;
+
+    case CONF_USERDATA:
+      type = "CONF_USERDATA";
+      break;
+
+    case CONF_PARAM:
+      type = "CONF_PARAM";
+      break;
+  };
+
+  return type;
+}
+
+/* Compare two different config_recs to see if they are the same.  Note
+ * that "same" here has to be very specific.
+ *
+ * Returns 0 if the two config_recs are the same, and 1 if they differ, and
+ * -1 if there was an error.
+ */
+static int config_cmp(const config_rec *a, const char *a_name,
+    const config_rec *b, const char *b_name) {
+
+  if (a == NULL ||
+      b == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (a->config_type != b->config_type) {
+    pr_trace_msg(trace_channel, 18,
+      "configs '%s' and '%s' have mismatched config_type (%s != %s)",
+      a_name, b_name, config_type_str(a->config_type),
+      config_type_str(b->config_type));
+    return 1;
+  }
+
+  if (a->flags != b->flags) {
+    pr_trace_msg(trace_channel, 18,
+      "configs '%s' and '%s' have mismatched flags (%ld != %ld)",
+      a_name, b_name, a->flags, b->flags);
+    return 1;
+  }
+
+  if (a->argc != b->argc) {
+    pr_trace_msg(trace_channel, 18,
+      "configs '%s' and '%s' have mismatched argc (%d != %d)",
+      a_name, b_name, a->argc, b->argc);
+    return 1;
+  }
+
+  if (a->argc > 0) {
+    register unsigned int i;
+
+    for (i = 0; i < a->argc; i++) {
+      if (a->argv[i] != b->argv[i]) {
+        pr_trace_msg(trace_channel, 18,
+          "configs '%s' and '%s' have mismatched argv[%u] (%p != %p)",
+          a_name, b_name, i, a->argv[i], b->argv[i]);
+        return 1;
+      }
+    }
+  }
+
+  if (a->config_id != b->config_id) {
+    pr_trace_msg(trace_channel, 18,
+      "configs '%s' and '%s' have mismatched config_id (%d != %d)",
+      a_name, b_name, a->config_id, b->config_id);
+    return 1;
+  }
+
+  /* Save the string comparison for last, to try to save some CPU. */
+  if (strcmp(a->name, b->name) != 0) {
+    pr_trace_msg(trace_channel, 18,
+      "configs '%s' and '%s' have mismatched name ('%s' != '%s')",
+      a_name, b_name, a->name, b->name);
+    return 1;
+  }
+
+  return 0;
+}
+
+static config_rec *copy_config_from(const config_rec *src, config_rec *dst) {
+  config_rec *c;
+  int cargc;
+  void **cargv, **sargv;
+
+  if (src == NULL ||
+      dst == NULL) {
+    return NULL;
+  }
+
+  /* If the destination parent config_rec doesn't already have a subset
+   * container, allocate one.
+   */
+  if (dst->subset == NULL) {
+    dst->subset = xaset_create(dst->pool, NULL);
+  }
+
+  c = pr_config_add_set(&dst->subset, src->name, 0);
+  c->config_type = src->config_type;
+  c->flags = src->flags;
+  c->config_id = src->config_id;
+
+  c->argc = src->argc;
+  c->argv = pcalloc(c->pool, (src->argc + 1) * sizeof(void *));
+
+  cargc = c->argc;
+  cargv = c->argv;
+  sargv = src->argv;
+
+  while (cargc--) {
+    pr_signals_handle();
+    *cargv++ = *sargv++;
+  }
+
+  *cargv = NULL; 
+  return c;
+}
+
+void pr_config_merge_down(xaset_t *s, int dynamic) {
+  config_rec *c, *dst;
+
+  if (s == NULL ||
+      s->xas_list == NULL) {
+    return;
+  }
+
+  for (c = (config_rec *) s->xas_list; c; c = c->next) {
+    pr_signals_handle();
+
+    if ((c->flags & CF_MERGEDOWN) ||
+        (c->flags & CF_MERGEDOWN_MULTI)) {
+
+      for (dst = (config_rec *) s->xas_list; dst; dst = dst->next) {
+        if (dst->config_type == CONF_ANON ||
+           dst->config_type == CONF_DIR) {
+
+          /* If an option of the same name/type is found in the
+           * next level down, it overrides, so we don't merge.
+           */
+          if ((c->flags & CF_MERGEDOWN) &&
+              find_config(dst->subset, c->config_type, c->name, FALSE)) {
+            continue;
+          }
+
+          if (dynamic) {
+            /* If we are doing a dynamic merge (i.e. .ftpaccess files) then
+             * we do not need to re-merge the static configs that are already
+             * there.  Otherwise we are creating copies needlessly of any
+             * config_rec marked with the CF_MERGEDOWN_MULTI flag, which
+             * adds to the memory usage/processing time.
+             *
+             * If neither the src or the dst config have the CF_DYNAMIC
+             * flag, it's a static config, and we can skip this merge and move
+             * on.  Otherwise, we can merge it.
+             */
+            if (!(c->flags & CF_DYNAMIC) && !(dst->flags & CF_DYNAMIC)) {
+              continue;
+            }
+          }
+
+          /* We want to scan the config_recs contained in dst's subset to see
+           * if we can find another config_rec that duplicates the one we want
+           * to merge into dst.
+           */
+          if (dst->subset != NULL) {
+              config_rec *r = NULL;
+            int merge = TRUE;
+
+            for (r = (config_rec *) dst->subset->xas_list; r; r = r->next) {
+              pr_signals_handle();
+
+              if (config_cmp(r, r->name, c, c->name) == 0) {
+                merge = FALSE;
+
+                pr_trace_msg(trace_channel, 15,
+                  "found duplicate '%s' record in '%s', skipping merge",
+                  r->name, dst->name);
+                break;
+              }
+            }
+
+            if (merge) {
+              (void) copy_config_from(c, dst);
+            }
+ 
+          } else {
+            /* No existing subset in dst; we can merge this one in. */
+            (void) copy_config_from(c, dst);
+          }
+        }
+      }
+    }
+  }
+
+  /* Top level merged, recursively merge lower levels */
+  for (c = (config_rec *) s->xas_list; c; c = c->next) {
+    if (c->subset &&
+        (c->config_type == CONF_ANON ||
+         c->config_type == CONF_DIR)) {
+      pr_config_merge_down(c->subset, dynamic);
+    }
+  }
+}
+
+config_rec *find_config_next2(config_rec *prev, config_rec *c, int type,
+    const char *name, int recurse, unsigned long flags) {
+  config_rec *top = c;
+  unsigned int cid = 0;
+  size_t namelen = 0;
+
+  /* We do two searches (if recursing) so that we find the "deepest"
+   * level first.
+   */
+
+  if (c == NULL &&
+      prev == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  if (prev == NULL) {
+    prev = top;
+  }
+
+  if (name != NULL) {
+    cid = pr_config_get_id(name);
+    namelen = strlen(name);
+  }
+
+  if (recurse) {
+    do {
+      config_rec *res = NULL;
+
+      pr_signals_handle();
+
+      for (c = top; c; c = c->next) {
+        if (c->subset &&
+            c->subset->xas_list) {
+          config_rec *subc = NULL;
+
+          for (subc = (config_rec *) c->subset->xas_list;
+               subc;
+               subc = subc->next) {
+            pr_signals_handle();
+
+            if (subc->config_type == CONF_ANON &&
+                (flags & PR_CONFIG_FIND_FL_SKIP_ANON)) {
+              /* Skip <Anonymous> config_rec */
+              continue;
+            }
+
+            if (subc->config_type == CONF_DIR &&
+                (flags & PR_CONFIG_FIND_FL_SKIP_DIR)) {
+              /* Skip <Directory> config_rec */
+              continue;
+            }
+
+            if (subc->config_type == CONF_LIMIT &&
+                (flags & PR_CONFIG_FIND_FL_SKIP_LIMIT)) {
+              /* Skip <Limit> config_rec */
+              continue;
+            }
+
+            if (subc->config_type == CONF_DYNDIR &&
+                (flags & PR_CONFIG_FIND_FL_SKIP_DYNDIR)) {
+              /* Skip .ftpaccess config_rec */
+              continue;
+            }
+
+            res = find_config_next2(NULL, subc, type, name, recurse + 1, flags);
+            if (res) {
+              return res;
+            }
+          }
+        }
+      }
+
+      /* If deep recursion yielded no match try the current subset.
+       *
+       * NOTE: the string comparison here is specifically case sensitive.
+       * The config_rec names are supplied by the modules and intentionally
+       * case sensitive (they shouldn't be verbatim from the config file)
+       * Do NOT change this to strcasecmp(), no matter how tempted you are
+       * to do so, it will break stuff. ;)
+       */
+      for (c = top; c; c = c->next) {
+        pr_signals_handle();
+
+        if (type == -1 ||
+            type == c->config_type) {
+
+          if (name == NULL) {
+            return c;
+          }
+
+          if (cid != 0 &&
+              cid == c->config_id) {
+            return c;
+          }
+
+          if (strncmp(name, c->name, namelen + 1) == 0) {
+            return c;
+          }
+        }
+      }
+
+      /* Restart the search at the previous level if required */
+      if (prev->parent &&
+          recurse == 1 &&
+          prev->parent->next &&
+          prev->parent->set != find_config_top) {
+        prev = top = prev->parent->next;
+        c = top;
+        continue;
+      }
+
+      break;
+    } while (TRUE);
+
+  } else {
+    for (c = top; c; c = c->next) {
+      pr_signals_handle();
+
+      if (type == -1 ||
+          type == c->config_type) {
+
+        if (name == NULL) {
+          return c;
+        }
+
+        if (cid != 0 &&
+            cid == c->config_id) {
+          return c;
+        }
+
+        if (strncmp(name, c->name, namelen + 1) == 0) {
+          return c;
+        }
+      }
+    }
+  }
+
+  errno = ENOENT;
+  return NULL;
+}
+
+config_rec *find_config_next(config_rec *prev, config_rec *c, int type,
+    const char *name, int recurse) {
+  return find_config_next2(prev, c, type, name, recurse, 0UL);
+}
+
+void find_config_set_top(config_rec *c) {
+  if (c &&
+      c->parent) {
+    find_config_top = c->parent->set;
+
+  } else {
+    find_config_top = NULL;
+  }
+}
+
+config_rec *find_config2(xaset_t *set, int type, const char *name,
+  int recurse, unsigned long flags) {
+
+  if (set == NULL ||
+      set->xas_list == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  find_config_set_top((config_rec *) set->xas_list);
+
+  return find_config_next2(NULL, (config_rec *) set->xas_list, type, name,
+    recurse, flags);
+}
+
+config_rec *find_config(xaset_t *set, int type, const char *name, int recurse) {
+  return find_config2(set, type, name, recurse, 0UL);
+}
+
+void *get_param_ptr(xaset_t *set, const char *name, int recurse) {
+  config_rec *c;
+
+  if (set == NULL) {
+    last_param_ptr = NULL;
+    errno = ENOENT;
+    return NULL;
+  }
+
+  c = find_config(set, CONF_PARAM, name, recurse);
+  if (c &&
+      c->argc) {
+    last_param_ptr = c;
+    return c->argv[0];
+  }
+
+  last_param_ptr = NULL;
+  errno = ENOENT;
+  return NULL;
+}
+
+void *get_param_ptr_next(const char *name, int recurse) {
+  config_rec *c;
+
+  if (!last_param_ptr ||
+      !last_param_ptr->next) {
+    last_param_ptr = NULL;
+    errno = ENOENT; 
+    return NULL;
+  }
+
+  c = find_config_next(last_param_ptr, last_param_ptr->next, CONF_PARAM,
+    name, recurse);
+  if (c &&
+      c->argv) {
+    last_param_ptr = c;
+    return c->argv[0];
+  }
+
+  last_param_ptr = NULL;
+  errno = ENOENT;
+  return NULL;
+}
+
+int remove_config(xaset_t *set, const char *name, int recurse) {
+  server_rec *s;
+  config_rec *c;
+  int found = 0;
+  xaset_t *found_set;
+
+  s = pr_parser_server_ctxt_get();
+  if (s == NULL) {
+    s = main_server;
+  }
+
+  while ((c = find_config(set, -1, name, recurse)) != NULL) {
+    pr_signals_handle();
+
+    found++;
+
+    found_set = c->set;
+    xaset_remove(found_set, (xasetmember_t *) c);
+
+    /* If the set is empty, and has no more contained members in the xas_list,
+     * destroy the set.
+     */
+    if (!found_set->xas_list) {
+
+      /* First, set any pointers to the container of the set to NULL. */
+      if (c->parent &&
+          c->parent->subset == found_set) {
+        c->parent->subset = NULL;
+
+      } else if (s && s->conf == found_set) {
+        s->conf = NULL;
+      }
+
+      /* Next, destroy the set's pool, which destroys the set as well. */
+      destroy_pool(found_set->pool);
+
+    } else {
+      /* If the set was not empty, destroy only the requested config_rec. */
+      destroy_pool(c->pool);
+    }
+  }
+
+  return found;
+}
+
+config_rec *add_config_param_set(xaset_t **set, const char *name,
+    int num, ...) {
+  config_rec *c;
+  void **argv;
+  va_list ap;
+
+  c = pr_config_add_set(set, name, 0);
+  if (c == NULL) {
+    return NULL;
+  }
+
+  c->config_type = CONF_PARAM;
+  c->argc = num;
+  c->argv = pcalloc(c->pool, (num+1) * sizeof(void *));
+
+  argv = c->argv;
+  va_start(ap,num);
+
+  while (num-- > 0) {
+    *argv++ = va_arg(ap, void *);
+  }
+
+  va_end(ap);
+
+  return c;
+}
+
+config_rec *add_config_param_str(const char *name, int num, ...) {
+  config_rec *c = pr_config_add(NULL, name, 0);
+  char *arg = NULL;
+  void **argv = NULL;
+  va_list ap;
+
+  if (c) {
+    c->config_type = CONF_PARAM;
+    c->argc = num;
+    c->argv = pcalloc(c->pool, (num+1) * sizeof(char *));
+
+    argv = c->argv;
+    va_start(ap, num);
+
+    while (num-- > 0) {
+      arg = va_arg(ap, char *);
+      if (arg) {
+        *argv++ = pstrdup(c->pool, arg);
+
+      } else {
+        *argv++ = NULL;
+      }
+    }
+
+    va_end(ap);
+  }
+
+  return c;
+}
+
+config_rec *pr_conf_add_server_config_param_str(server_rec *s, const char *name,
+    int num, ...) {
+  config_rec *c = pr_config_add(s, name, 0);
+  char *arg = NULL;
+  void **argv = NULL;
+  va_list ap;
+
+  if (c) {
+    c->config_type = CONF_PARAM;
+    c->argc = num;
+    c->argv = pcalloc(c->pool, (num+1) * sizeof(char *));
+
+    argv = c->argv;
+    va_start(ap, num);
+
+    while (num-- > 0) {
+      arg = va_arg(ap, char *);
+      if (arg) {
+        *argv++ = pstrdup(c->pool, arg);
+
+      } else {
+        *argv++ = NULL;
+      }
+    }
+
+    va_end(ap);
+  }
+
+  return c;
+}
+
+config_rec *add_config_param(const char *name, int num, ...) {
+  config_rec *c;
+  void **argv;
+  va_list ap;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  c = pr_config_add(NULL, name, 0);
+  if (c) {
+    c->config_type = CONF_PARAM;
+    c->argc = num;
+    c->argv = pcalloc(c->pool, (num+1) * sizeof(void*));
+
+    argv = c->argv;
+    va_start(ap, num);
+
+    while (num-- > 0) {
+      *argv++ = va_arg(ap, void *);
+    }
+
+    va_end(ap);
+  }
+
+  return c;
+}
+
+unsigned int pr_config_get_id(const char *name) {
+  void *ptr = NULL;
+  unsigned int id = 0;
+
+  if (!name) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  if (!config_tab) {
+    errno = EPERM;
+    return 0;
+  }
+
+  ptr = pr_table_get(config_tab, name, NULL);
+  if (ptr == NULL) {
+    errno = ENOENT;
+    return 0;
+  }
+
+  id = *((unsigned int *) ptr);
+  return id;
+}
+
+unsigned int pr_config_set_id(const char *name) {
+  unsigned int *ptr = NULL;
+  unsigned int id;
+
+  if (!name) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  if (!config_tab) {
+    errno = EPERM;
+    return 0;
+  }
+
+  ptr = pr_table_pcalloc(config_tab, sizeof(unsigned int));
+  *ptr = ++config_id;
+
+  if (pr_table_add(config_tab, name, ptr, sizeof(unsigned int *)) < 0) {
+    if (errno == EEXIST) {
+      id = pr_config_get_id(name);
+
+    } else {
+      pr_log_debug(DEBUG0, "error adding '%s' to config ID table: %s",
+        name, strerror(errno));
+      return 0;
+    }
+
+  } else {
+    id = *ptr;
+  }
+
+  return id;
+}
+
+void init_config(void) {
+
+  /* Make sure global_config_pool is destroyed */
+  if (global_config_pool) {
+    destroy_pool(global_config_pool);
+    global_config_pool = NULL;
+  }
+
+  if (config_tab) {
+    /* Clear the existing config ID table.  This needs to happen when proftpd
+     * is restarting.
+     */
+    if (pr_table_empty(config_tab) < 0) {
+      pr_log_debug(DEBUG0, "error emptying config ID table: %s",
+        strerror(errno));
+    }
+
+    if (pr_table_free(config_tab) < 0) {
+      pr_log_debug(DEBUG0, "error destroying config ID table: %s",
+        strerror(errno));
+    }
+
+    config_tab = pr_table_alloc(config_tab_pool, 0);
+
+    /* Reset the ID counter as well.  Otherwise, an exceedingly long-lived
+     * proftpd, restarted many times, has the possibility of overflowing
+     * the counter data type.
+     */
+    config_id = 0;
+
+  } else {
+
+    config_tab_pool = make_sub_pool(permanent_pool);
+    pr_pool_tag(config_tab_pool, "Config Table Pool");
+    config_tab = pr_table_alloc(config_tab_pool, 0);
+  }
+
+  return;
+}

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2013 The ProFTPD Project team
+ * Copyright (c) 2001-2014 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,16 +48,6 @@ static int tcp_rcvbufsz = 0;
 static int tcp_sndbufsz = 0;
 static int xfer_bufsz = 0;
 
-/* From src/pool.c */
-extern pool *global_config_pool;
-
-/* Used by find_config_* */
-static xaset_t *find_config_top = NULL;
-
-static void config_dumpf(const char *, ...);
-static void merge_down(xaset_t *, int);
-
-static config_rec *_last_param_ptr = NULL;
 static unsigned char _kludge_disable_umask = 0;
 
 /* We have two different lists for Defines.  The 'perm' pool/list are
@@ -69,10 +59,6 @@ static array_header *defines_list = NULL;
 
 static pool *defines_perm_pool = NULL;
 static array_header *defines_perm_list = NULL;
-
-static pool *config_tab_pool = NULL;
-static pr_table_t *config_tab = NULL;
-static unsigned int config_id = 0;
 
 static int allow_dyn_config(const char *path) {
   config_rec *c = NULL;
@@ -554,116 +540,6 @@ void kludge_enable_umask(void) {
   _kludge_disable_umask = FALSE;
 }
 
-/* Adds a config_rec to the specified set */
-config_rec *pr_config_add_set(xaset_t **set, const char *name, int flags) {
-  pool *conf_pool = NULL, *set_pool = NULL;
-  config_rec *c, *parent = NULL;
-
-  if (!*set) {
-
-    /* Allocate a subpool from permanent_pool for the set. */
-    set_pool = make_sub_pool(permanent_pool);
-    pr_pool_tag(set_pool, "config set pool");
-
-    *set = xaset_create(set_pool, NULL);
-    (*set)->pool = set_pool;
-
-    /* Now, make a subpool for the config_rec to be allocated.  The default
-     * pool size (PR_TUNABLE_NEW_POOL_SIZE, 512 by default) is a bit large
-     * for config_rec pools; use a smaller size.
-     */
-    conf_pool = pr_pool_create_sz(set_pool, 128);
-
-  } else {
-
-    /* Find the parent set for the config_rec to be allocated. */
-    if ((*set)->xas_list)
-      parent = ((config_rec *) ((*set)->xas_list))->parent;
-
-    /* Now, make a subpool for the config_rec to be allocated.  The default
-     * pool size (PR_TUNABLE_NEW_POOL_SIZE, 512 by default) is a bit large
-     * for config_rec pools; use a smaller size.  Allocate the subpool
-     * from the parent's pool.
-     */
-    conf_pool = pr_pool_create_sz((*set)->pool, 128);
-  }
-
-  pr_pool_tag(conf_pool, "config_rec pool");
-
-  c = (config_rec *) pcalloc(conf_pool, sizeof(config_rec));
-
-  c->pool = conf_pool;
-  c->set = *set;
-  c->parent = parent;
-
-  if (name) {
-    c->name = pstrdup(conf_pool, name);
-    c->config_id = pr_config_set_id(c->name);
-  }
-
-  if (flags & PR_CONFIG_FL_INSERT_HEAD) {
-    xaset_insert(*set, (xasetmember_t *) c);
-    
-  } else {
-    xaset_insert_end(*set, (xasetmember_t *) c);
-  }
-
-  return c;
-}
-
-config_rec *add_config_set(xaset_t **set, const char *name) {
-  return pr_config_add_set(set, name, 0);
-}
-
-/* Adds a config_rec to the given server.  If no server is specified, the
- * config_rec is added to the current "level".
- */
-config_rec *pr_config_add(server_rec *s, const char *name, int flags) {
-  config_rec *parent = NULL, *c = NULL;
-  pool *p = NULL;
-  xaset_t **set = NULL;
-
-  if (s == NULL) {
-    s = pr_parser_server_ctxt_get();
-  }
-
-  c = pr_parser_config_ctxt_get();
-
-  if (c) {
-    parent = c;
-    p = c->pool;
-    set = &c->subset;
-
-  } else {
-    parent = NULL;
-
-    if (s->conf == NULL ||
-        s->conf->xas_list == NULL) {
-
-      p = make_sub_pool(s->pool);
-      pr_pool_tag(p, "pr_config_add() subpool");
-
-    } else {
-      p = ((config_rec *) s->conf->xas_list)->pool;
-    }
-
-    set = &s->conf;
-  }
-
-  if (!*set) {
-    *set = xaset_create(p, NULL);
-  }
-
-  c = pr_config_add_set(set, name, flags);
-  c->parent = parent;
-
-  return c;
-}
-
-config_rec *add_config(server_rec *s, const char *name) {
-  return pr_config_add(s, name, 0);
-}
-
 /* Per-directory configuration */
 
 static size_t _strmatch(register char *s1, register char *s2) {
@@ -807,16 +683,18 @@ config_rec *dir_match_path(pool *p, char *path) {
     tmplen = strlen(tmp);
   }
 
-  if (*(tmp + tmplen - 1) == '/' && tmplen > 1)
+  if (*(tmp + tmplen - 1) == '/' && tmplen > 1) {
     *(tmp + tmplen - 1) = '\0';
+  }
 
   if (session.anon_config) {
     res = recur_match_path(p, session.anon_config->subset, tmp);
 
     if (!res) {
       if (session.chroot_path &&
-          !strncmp(session.chroot_path, tmp, strlen(session.chroot_path)))
+          !strncmp(session.chroot_path, tmp, strlen(session.chroot_path))) {
         return NULL;
+      }
     }
   }
 
@@ -1853,7 +1731,7 @@ void build_dyn_config(pool *p, const char *_path, struct stat *stp,
 
       if (res == 0) {
         d->config_type = CONF_DIR;
-        merge_down(*set, TRUE);
+        pr_config_merge_down(*set, TRUE);
 
         pr_trace_msg("ftpaccess", 3, "fixing up directory configs");
         fixup_dirs(main_server, CF_SILENT);
@@ -1873,7 +1751,7 @@ void build_dyn_config(pool *p, const char *_path, struct stat *stp,
         d &&
         set) {
       pr_trace_msg("ftpaccess", 6, "adding config for '%s'", ftpaccess_name);
-      merge_down(*set, FALSE);
+      pr_config_merge_down(*set, FALSE);
     }
 
     if (!recurse)
@@ -2410,46 +2288,6 @@ static void reorder_dirs(xaset_t *set, int flags) {
   }
 }
 
-static void config_dumpf(const char *fmt, ...) {
-  char buf[PR_TUNABLE_BUFFER_SIZE] = {'\0'};
-  va_list msg;
-
-  va_start(msg, fmt);
-  vsnprintf(buf, sizeof(buf), fmt, msg);
-  va_end(msg);
-
-  buf[sizeof(buf)-1] = '\0';
-
-  pr_log_debug(DEBUG5, "%s", buf);
-}
-
-void pr_config_dump(void (*dumpf)(const char *, ...), xaset_t *s,
-    char *indent) {
-  config_rec *c = NULL;
-
-  if (s == NULL) {
-    return;
-  }
-
-  if (indent == NULL) {
-    indent = "";
-  }
-
-  for (c = (config_rec *) s->xas_list; c; c = c->next) {
-    pr_signals_handle();
-
-    /* Don't display directives whose name starts with an underscore. */
-    if (c->name != NULL &&
-        *(c->name) != '_') {
-      dumpf("%s%s", indent, c->name);
-    }
-
-    if (c->subset) {
-      pr_config_dump(dumpf, c->subset, pstrcat(c->pool, indent, " ", NULL));
-    }
-  }
-}
-
 #ifdef PR_USE_DEVEL
 void pr_dirs_dump(void (*dumpf)(const char *, ...), xaset_t *s, char *indent) {
   config_rec *c;
@@ -2480,247 +2318,6 @@ void pr_dirs_dump(void (*dumpf)(const char *, ...), xaset_t *s, char *indent) {
 }
 #endif /* PR_USE_DEVEL */
 
-static const char *config_type_str(int config_type) {
-  const char *type = "(unknown)";
-
-  switch (config_type) {
-    case CONF_ROOT:
-      type = "CONF_ROOT";
-      break;
-
-    case CONF_DIR:
-      type = "CONF_DIR";
-      break;
-
-    case CONF_ANON:
-      type = "CONF_ANON";
-      break;
-
-    case CONF_LIMIT:
-      type = "CONF_LIMIT";
-      break;
-
-    case CONF_VIRTUAL:
-      type = "CONF_VIRTUAL";
-      break;
-
-    case CONF_DYNDIR:
-      type = "CONF_DYNDIR";
-      break;
-
-    case CONF_GLOBAL:
-      type = "CONF_GLOBAL";
-      break;
-
-    case CONF_CLASS:
-      type = "CONF_CLASS";
-      break;
-
-    case CONF_NAMED:
-      type = "CONF_NAMED";
-      break;
-
-    case CONF_USERDATA:
-      type = "CONF_USERDATA";
-      break;
-
-    case CONF_PARAM:
-      type = "CONF_PARAM";
-      break;
-  };
-
-  return type;
-}
-
-/* Compare two different config_recs to see if they are the same.  Note
- * that "same" here has to be very specific.
- *
- * Returns 0 if the two config_recs are the same, and 1 if they differ, and
- * -1 if there was an error.
- */
-static int config_cmp(const config_rec *a, const char *a_name,
-    const config_rec *b, const char *b_name) {
-  const char *trace_channel = "config";
-
-  if (a == NULL ||
-      b == NULL) {
-    errno = EINVAL;
-    return -1;
-  }
-
-  if (a->config_type != b->config_type) {
-    pr_trace_msg(trace_channel, 18,
-      "configs '%s' and '%s' have mismatched config_type (%s != %s)",
-      a_name, b_name, config_type_str(a->config_type),
-      config_type_str(b->config_type));
-    return 1;
-  }
-
-  if (a->flags != b->flags) {
-    pr_trace_msg(trace_channel, 18,
-      "configs '%s' and '%s' have mismatched flags (%ld != %ld)",
-      a_name, b_name, a->flags, b->flags);
-    return 1;
-  }
-
-  if (a->argc != b->argc) {
-    pr_trace_msg(trace_channel, 18,
-      "configs '%s' and '%s' have mismatched argc (%d != %d)",
-      a_name, b_name, a->argc, b->argc);
-    return 1;
-  }
-
-  if (a->argc > 0) {
-    register unsigned int i;
-
-    for (i = 0; i < a->argc; i++) {
-      if (a->argv[i] != b->argv[i]) {
-        pr_trace_msg(trace_channel, 18,
-          "configs '%s' and '%s' have mismatched argv[%u] (%p != %p)",
-          a_name, b_name, i, a->argv[i], b->argv[i]);
-        return 1;
-      }
-    }
-  }
-
-  if (a->config_id != b->config_id) {
-    pr_trace_msg(trace_channel, 18,
-      "configs '%s' and '%s' have mismatched config_id (%d != %d)",
-      a_name, b_name, a->config_id, b->config_id);
-    return 1;
-  }
-
-  /* Save the string comparison for last, to try to save some CPU. */
-  if (strcmp(a->name, b->name) != 0) {
-    pr_trace_msg(trace_channel, 18,
-      "configs '%s' and '%s' have mismatched name ('%s' != '%s')",
-      a_name, b_name, a->name, b->name);
-    return 1;
-  }
-
-  return 0;
-}
-
-static config_rec *copy_config_from(const config_rec *src, config_rec *dst) {
-  config_rec *c;
-  int cargc;
-  void **cargv, **sargv;
-
-  if (src == NULL ||
-      dst == NULL) {
-    return NULL;
-  }
-
-  /* If the destination parent config_rec doesn't already have a subset
-   * container, allocate one.
-   */
-  if (dst->subset == NULL) {
-    dst->subset = xaset_create(dst->pool, NULL);
-  }
-
-  c = pr_config_add_set(&dst->subset, src->name, 0);
-  c->config_type = src->config_type;
-  c->flags = src->flags;
-  c->config_id = src->config_id;
-
-  c->argc = src->argc;
-  c->argv = pcalloc(c->pool, (src->argc + 1) * sizeof(void *));
-
-  cargc = c->argc;
-  cargv = c->argv;
-  sargv = src->argv;
-
-  while (cargc--) {
-    pr_signals_handle();
-    *cargv++ = *sargv++;
-  }
-
-  *cargv = NULL; 
-  return c;
-}
-
-static void merge_down(xaset_t *s, int dynamic) {
-  config_rec *c, *dst;
-
-  if (s == NULL ||
-      s->xas_list == NULL)
-    return;
-
-  for (c = (config_rec *) s->xas_list; c; c = c->next) {
-    if ((c->flags & CF_MERGEDOWN) ||
-        (c->flags & CF_MERGEDOWN_MULTI)) {
-
-      for (dst = (config_rec *) s->xas_list; dst; dst = dst->next) {
-        if (dst->config_type == CONF_ANON ||
-           dst->config_type == CONF_DIR) {
-
-          /* If an option of the same name/type is found in the
-           * next level down, it overrides, so we don't merge.
-           */
-          if ((c->flags & CF_MERGEDOWN) &&
-              find_config(dst->subset, c->config_type, c->name, FALSE))
-            continue;
-
-          if (dynamic) {
-            /* If we are doing a dynamic merge (i.e. .ftpaccess files) then
-             * we do not need to re-merge the static configs that are already
-             * there.  Otherwise we are creating copies needlessly of any
-             * config_rec marked with the CF_MERGEDOWN_MULTI flag, which
-             * adds to the memory usage/processing time.
-             *
-             * If neither the src or the dst config have the CF_DYNAMIC
-             * flag, it's a static config, and we can skip this merge and move
-             * on.  Otherwise, we can merge it.
-             */
-            if (!(c->flags & CF_DYNAMIC) && !(dst->flags & CF_DYNAMIC)) {
-              continue;
-            }
-          }
-
-          /* We want to scan the config_recs contained in dst's subset to see
-           * if we can find another config_rec that duplicates the one we want
-           * to merge into dst.
-           */
-          if (dst->subset != NULL) {
-              config_rec *r = NULL;
-            int merge = TRUE;
-
-            for (r = (config_rec *) dst->subset->xas_list; r; r = r->next) {
-              pr_signals_handle();
-
-              if (config_cmp(r, r->name, c, c->name) == 0) {
-                merge = FALSE;
-
-                pr_trace_msg("config", 15,
-                  "found duplicate '%s' record in '%s', skipping merge",
-                  r->name, dst->name);
-                break;
-              }
-            }
-
-            if (merge) {
-              (void) copy_config_from(c, dst);
-            }
- 
-          } else {
-            /* No existing subset in dst; we can merge this one in. */
-            (void) copy_config_from(c, dst);
-          }
-        }
-      }
-    }
-  }
-
-  /* Top level merged, recursively merge lower levels */
-  for (c = (config_rec *) s->xas_list; c; c = c->next) {
-    if (c->subset &&
-        (c->config_type == CONF_ANON ||
-         c->config_type == CONF_DIR)) {
-      merge_down(c->subset, dynamic);
-    }
-  }
-}
-
 /* Iterate through <Directory> blocks inside of anonymous and
  * resolve each one.
  */
@@ -2728,8 +2325,9 @@ void resolve_anonymous_dirs(xaset_t *clist) {
   config_rec *c;
   char *realdir;
 
-  if (!clist)
+  if (!clist) {
     return;
+  }
 
   for (c = (config_rec *) clist->xas_list; c; c = c->next) {
     if (c->config_type == CONF_DIR) {
@@ -2740,13 +2338,15 @@ void resolve_anonymous_dirs(xaset_t *clist) {
 
         } else {
           realdir = dir_canonical_path(c->pool, c->argv[1]);
-          if (realdir)
+          if (realdir) {
             c->argv[1] = realdir;
+          }
         }
       }
 
-      if (c->subset)
+      if (c->subset) {
         resolve_anonymous_dirs(c->subset);
+      }
     }
   }
 }
@@ -2808,8 +2408,9 @@ static void copy_recur(xaset_t **set, pool *p, config_rec *c,
   int argc;
   void **argv, **sargv;
 
-  if (!*set)
+  if (!*set) {
     *set = xaset_create(p, NULL);
+  }
 
   newconf = pr_config_add_set(set, c->name, 0);
   newconf->config_type = c->config_type;
@@ -2823,28 +2424,37 @@ static void copy_recur(xaset_t **set, pool *p, config_rec *c,
     sargv = c->argv;
     argc = newconf->argc;
 
-    while (argc--)
+    while (argc--) {
       *argv++ = *sargv++;
+    }
 
-    if (argv)
+    if (argv) {
       *argv++ = NULL;
+    }
   }
 
-  if (c->subset)
-    for (c = (config_rec *) c->subset->xas_list; c; c = c->next)
+  if (c->subset) {
+    for (c = (config_rec *) c->subset->xas_list; c; c = c->next) {
+      pr_signals_handle();
       copy_recur(&newconf->subset, p, c, newconf);
+    }
+  }
 }
 
 static void copy_global_to_all(xaset_t *set) {
   server_rec *s;
   config_rec *c;
 
-  if (!set || !set->xas_list)
+  if (!set || !set->xas_list) {
     return;
+  }
 
-  for (c = (config_rec *) set->xas_list; c; c = c->next)
-    for (s = (server_rec *) server_list->xas_list; s; s = s->next)
+  for (c = (config_rec *) set->xas_list; c; c = c->next) {
+    for (s = (server_rec *) server_list->xas_list; s; s = s->next) {
+      pr_signals_handle();
       copy_recur(&s->conf, s->pool, c, NULL);
+    }
+  }
 }
 
 static void fixup_globals(xaset_t *list) {
@@ -2857,8 +2467,9 @@ static void fixup_globals(xaset_t *list) {
      * context.
      */
     if (!s->conf ||
-        !s->conf->xas_list)
+        !s->conf->xas_list) {
       continue;
+    }
 
     for (c = (config_rec *) s->conf->xas_list; c; c = cnext) {
       cnext = c->next;
@@ -2869,8 +2480,9 @@ static void fixup_globals(xaset_t *list) {
          * (including this one), then pull the block "out of play".
          */
         if (c->subset &&
-            c->subset->xas_list)
+            c->subset->xas_list) {
           copy_global_to_all(c->subset);
+        }
 
         xaset_remove(s->conf, (xasetmember_t *) c);
 
@@ -2900,372 +2512,15 @@ void fixup_dirs(server_rec *s, int flags) {
   reorder_dirs(s->conf, flags);
 
   /* Merge mergeable configuration items down. */
-  merge_down(s->conf, FALSE);
+  pr_config_merge_down(s->conf, FALSE);
 
   if (!(flags & CF_SILENT)) {
     pr_log_debug(DEBUG5, "%s", "");
     pr_log_debug(DEBUG5, "Config for %s:", s->ServerName);
-    pr_config_dump(config_dumpf, s->conf, NULL);
+    pr_config_dump(NULL, s->conf, NULL);
   }
 
   return;
-}
-
-config_rec *find_config_next2(config_rec *prev, config_rec *c, int type,
-    const char *name, int recurse, unsigned long flags) {
-  config_rec *top = c;
-  unsigned int cid = 0;
-  size_t namelen = 0;
-
-  /* We do two searches (if recursing) so that we find the "deepest"
-   * level first.
-   */
-
-  if (c == NULL &&
-      prev == NULL) {
-    return NULL;
-  }
-
-  if (prev == NULL) {
-    prev = top;
-  }
-
-  if (name != NULL) {
-    cid = pr_config_get_id(name);
-    namelen = strlen(name);
-  }
-
-  if (recurse) {
-    do {
-      config_rec *res = NULL;
-
-      pr_signals_handle();
-
-      for (c = top; c; c = c->next) {
-        if (c->subset &&
-            c->subset->xas_list) {
-          config_rec *subc = NULL;
-
-          for (subc = (config_rec *) c->subset->xas_list;
-               subc;
-               subc = subc->next) {
-            pr_signals_handle();
-
-            if (subc->config_type == CONF_ANON &&
-                (flags & PR_CONFIG_FIND_FL_SKIP_ANON)) {
-              /* Skip <Anonymous> config_rec */
-              continue;
-            }
-
-            if (subc->config_type == CONF_DIR &&
-                (flags & PR_CONFIG_FIND_FL_SKIP_DIR)) {
-              /* Skip <Directory> config_rec */
-              continue;
-            }
-
-            if (subc->config_type == CONF_LIMIT &&
-                (flags & PR_CONFIG_FIND_FL_SKIP_LIMIT)) {
-              /* Skip <Limit> config_rec */
-              continue;
-            }
-
-            if (subc->config_type == CONF_DYNDIR &&
-                (flags & PR_CONFIG_FIND_FL_SKIP_DYNDIR)) {
-              /* Skip .ftpaccess config_rec */
-              continue;
-            }
-
-            res = find_config_next2(NULL, subc, type, name, recurse + 1, flags);
-            if (res)
-              return res;
-          }
-        }
-      }
-
-      /* If deep recursion yielded no match try the current subset.
-       *
-       * NOTE: the string comparison here is specifically case sensitive.
-       * The config_rec names are supplied by the modules and intentionally
-       * case sensitive (they shouldn't be verbatim from the config file)
-       * Do NOT change this to strcasecmp(), no matter how tempted you are
-       * to do so, it will break stuff. ;)
-       */
-      for (c = top; c; c = c->next) {
-        if (type == -1 ||
-            type == c->config_type) {
-
-          if (name == NULL) {
-            return c;
-          }
-
-          if (cid != 0 &&
-              cid == c->config_id) {
-            return c;
-          }
-
-          if (strncmp(name, c->name, namelen + 1) == 0) {
-            return c;
-          }
-        }
-      }
-
-      /* Restart the search at the previous level if required */
-      if (prev->parent &&
-          recurse == 1 &&
-          prev->parent->next &&
-          prev->parent->set != find_config_top) {
-        prev = top = prev->parent->next;
-        c = top;
-        continue;
-      }
-
-      break;
-    } while (TRUE);
-
-  } else {
-    for (c = top; c; c = c->next) {
-      if (type == -1 ||
-          type == c->config_type) {
-
-        if (name == NULL) {
-          return c;
-        }
-
-        if (cid != 0 &&
-            cid == c->config_id) {
-          return c;
-        }
-
-        if (strncmp(name, c->name, namelen + 1) == 0)
-          return c;
-      }
-    }
-  }
-
-  return NULL;
-}
-
-config_rec *find_config_next(config_rec *prev, config_rec *c, int type,
-    const char *name, int recurse) {
-  return find_config_next2(prev, c, type, name, recurse, 0UL);
-}
-
-void find_config_set_top(config_rec *c) {
-  if (c &&
-      c->parent) {
-    find_config_top = c->parent->set;
-
-  } else {
-    find_config_top = NULL;
-  }
-}
-
-config_rec *find_config2(xaset_t *set, int type, const char *name,
-  int recurse, unsigned long flags) {
-
-  if (set == NULL ||
-      set->xas_list == NULL) {
-    return NULL;
-  }
-
-  find_config_set_top((config_rec *) set->xas_list);
-
-  return find_config_next2(NULL, (config_rec *) set->xas_list, type, name,
-    recurse, flags);
-}
-
-config_rec *find_config(xaset_t *set, int type, const char *name, int recurse) {
-  return find_config2(set, type, name, recurse, 0UL);
-}
-
-void *get_param_ptr(xaset_t *set, const char *name, int recurse) {
-  config_rec *c;
-
-  if (!set) {
-    _last_param_ptr = NULL;
-    return NULL;
-  }
-
-  c = find_config(set, CONF_PARAM, name, recurse);
-
-  if (c &&
-      c->argc) {
-    _last_param_ptr = c;
-    return c->argv[0];
-  }
-
-  _last_param_ptr = NULL;
-  return NULL;
-}
-
-void *get_param_ptr_next(const char *name,int recurse) {
-  config_rec *c;
-
-  if (!_last_param_ptr ||
-      !_last_param_ptr->next) {
-    _last_param_ptr = NULL;
-    return NULL;
-  }
-
-  c = find_config_next(_last_param_ptr, _last_param_ptr->next, CONF_PARAM,
-    name, recurse);
-
-  if (c &&
-      c->argv) {
-    _last_param_ptr = c;
-    return c->argv[0];
-  }
-
-  _last_param_ptr = NULL;
-  return NULL;
-}
-
-int remove_config(xaset_t *set, const char *name, int recurse) {
-  server_rec *s = pr_parser_server_ctxt_get();
-  config_rec *c;
-  int found = 0;
-  xaset_t *fset;
-
-  if (!s)
-    s = main_server;
-
-  while ((c = find_config(set, -1, name, recurse)) != NULL) {
-    found++;
-
-    fset = c->set;
-    xaset_remove(fset, (xasetmember_t *) c);
-
-    /* If the set is empty, and has no more contained members in the xas_list,
-     * destroy the set.
-     */
-    if (!fset->xas_list) {
-
-      /* First, set any pointers to the container of the set to NULL. */
-      if (c->parent && c->parent->subset == fset)
-        c->parent->subset = NULL;
-
-      else if (s->conf == fset)
-        s->conf = NULL;
-
-      /* Next, destroy the set's pool, which destroys the set as well. */
-      destroy_pool(fset->pool);
-
-    } else {
-
-      /* If the set was not empty, destroy only the requested config_rec. */
-      destroy_pool(c->pool);
-    }
-  }
-
-  return found;
-}
-
-config_rec *add_config_param_set(xaset_t **set, const char *name,
-    int num, ...) {
-  config_rec *c = pr_config_add_set(set, name, 0);
-  void **argv;
-  va_list ap;
-
-  if (c) {
-    c->config_type = CONF_PARAM;
-    c->argc = num;
-    c->argv = pcalloc(c->pool, (num+1) * sizeof(void *));
-
-    argv = c->argv;
-    va_start(ap,num);
-
-    while (num-- > 0)
-      *argv++ = va_arg(ap, void *);
-
-    va_end(ap);
-  }
-
-  return c;
-}
-
-config_rec *add_config_param_str(const char *name, int num, ...) {
-  config_rec *c = pr_config_add(NULL, name, 0);
-  char *arg = NULL;
-  void **argv = NULL;
-  va_list ap;
-
-  if (c) {
-    c->config_type = CONF_PARAM;
-    c->argc = num;
-    c->argv = pcalloc(c->pool, (num+1) * sizeof(char *));
-
-    argv = c->argv;
-    va_start(ap, num);
-
-    while (num-- > 0) {
-      arg = va_arg(ap, char *);
-      if (arg)
-        *argv++ = pstrdup(c->pool, arg);
-      else
-        *argv++ = NULL;
-    }
-
-    va_end(ap);
-  }
-
-  return c;
-}
-
-config_rec *pr_conf_add_server_config_param_str(server_rec *s, const char *name,
-    int num, ...) {
-  config_rec *c = pr_config_add(s, name, 0);
-  char *arg = NULL;
-  void **argv = NULL;
-  va_list ap;
-
-  if (c) {
-    c->config_type = CONF_PARAM;
-    c->argc = num;
-    c->argv = pcalloc(c->pool, (num+1) * sizeof(char *));
-
-    argv = c->argv;
-    va_start(ap, num);
-
-    while (num-- > 0) {
-      arg = va_arg(ap, char *);
-      if (arg)
-        *argv++ = pstrdup(c->pool, arg);
-      else
-        *argv++ = NULL;
-    }
-
-    va_end(ap);
-  }
-
-  return c;
-}
-
-config_rec *add_config_param(const char *name, int num, ...) {
-  config_rec *c;
-  void **argv;
-  va_list ap;
-
-  if (name == NULL) {
-    errno = EINVAL;
-    return NULL;
-  }
-
-  c = pr_config_add(NULL, name, 0);
-  if (c) {
-    c->config_type = CONF_PARAM;
-    c->argc = num;
-    c->argv = pcalloc(c->pool, (num+1) * sizeof(void*));
-
-    argv = c->argv;
-    va_start(ap, num);
-
-    while (num-- > 0)
-      *argv++ = va_arg(ap, void *);
-
-    va_end(ap);
-  }
-
-  return c;
 }
 
 static int config_filename_cmp(const void *a, const void *b) {
@@ -3338,12 +2593,15 @@ int parse_config_path(pool *p, const char *path) {
     file_list = make_array(p, 0, sizeof(char *));
 
     while ((dent = pr_fsio_readdir(dirh)) != NULL) {
+      pr_signals_handle();
+
       if (strncmp(dent->d_name, ".", 2) != 0 &&
           strncmp(dent->d_name, "..", 3) != 0 &&
           (!have_glob ||
-           pr_fnmatch(tmp, dent->d_name, PR_FNM_PERIOD) == 0))
+           pr_fnmatch(tmp, dent->d_name, PR_FNM_PERIOD) == 0)) {
         *((char **) push_array(file_list)) = pdircat(p, dup_path,
           dent->d_name, NULL);
+      }
     }
 
     pr_fsio_closedir(dirh);
@@ -3430,8 +2688,9 @@ int fixup_servers(xaset_t *list) {
           }
 #endif /* PR_USE_IPV6 */
 
-          if (ipstr)
+          if (ipstr) {
             pr_conf_add_server_config_param_str(s, "_bind", 1, ipstr);
+          }
         }
       }
  
@@ -3617,44 +2876,9 @@ static void set_tcp_bufsz(server_rec *s) {
   (void) close(sockfd);
 }
 
-void init_config(void) {
-  pool *conf_pool = make_sub_pool(permanent_pool);
-  pr_pool_tag(conf_pool, "Config Pool");
-
-  /* Make sure global_config_pool is destroyed */
-  if (global_config_pool) {
-    destroy_pool(global_config_pool);
-    global_config_pool = NULL;
-  }
-
-  if (config_tab) {
-    /* Clear the existing config ID table.  This needs to happen when proftpd
-     * is restarting.
-     */
-    if (pr_table_empty(config_tab) < 0) {
-      pr_log_debug(DEBUG0, "error emptying config ID table: %s",
-        strerror(errno));
-    }
-
-    if (pr_table_free(config_tab) < 0) {
-      pr_log_debug(DEBUG0, "error destroying config ID table: %s",
-        strerror(errno));
-    }
-
-    config_tab = pr_table_alloc(config_tab_pool, 0);
-
-    /* Reset the ID counter as well.  Otherwise, an exceedingly long-lived
-     * proftpd, restarted many times, has the possibility of overflowing
-     * the counter data type.
-     */
-    config_id = 0;
-
-  } else {
-
-    config_tab_pool = make_sub_pool(permanent_pool);
-    pr_pool_tag(config_tab_pool, "Config ID Table Pool");
-    config_tab = pr_table_alloc(config_tab_pool, 0);
-  }
+void init_dirtree(void) {
+  pool *dirtree_pool = make_sub_pool(permanent_pool);
+  pr_pool_tag(dirtree_pool, "Dirtree Pool");
 
   if (server_list) {
     server_rec *s, *s_next;
@@ -3681,18 +2905,18 @@ void init_config(void) {
    * why we create yet another subpool, reusing the conf_pool pointer.
    * The pool creation below is not redundant.
    */
-  server_list = xaset_create(conf_pool, NULL);
+  server_list = xaset_create(dirtree_pool, NULL);
 
-  conf_pool = make_sub_pool(permanent_pool);
-  pr_pool_tag(conf_pool, "main_server pool");
+  dirtree_pool = make_sub_pool(permanent_pool);
+  pr_pool_tag(dirtree_pool, "main_server pool");
 
-  main_server = (server_rec *) pcalloc(conf_pool, sizeof(server_rec));
+  main_server = (server_rec *) pcalloc(dirtree_pool, sizeof(server_rec));
   xaset_insert(server_list, (xasetmember_t *) main_server);
 
-  main_server->pool = conf_pool;
+  main_server->pool = dirtree_pool;
   main_server->set = server_list;
   main_server->sid = 1;
-  main_server->notes = pr_table_nalloc(conf_pool, 0, 8);
+  main_server->notes = pr_table_nalloc(dirtree_pool, 0, 8);
 
   /* TCP KeepAlive is enabled by default, with the system defaults. */
   main_server->tcp_keepalive = palloc(main_server->pool,
@@ -3710,8 +2934,7 @@ void init_config(void) {
   return;
 }
 
-/* These functions are used by modules to help parse configuration.
- */
+/* These functions are used by modules to help parse configuration. */
 
 unsigned char check_context(cmd_rec *cmd, int allowed) {
   int ctxt = (cmd->config && cmd->config->config_type != CONF_PARAM ?
@@ -3729,10 +2952,11 @@ char *get_context_name(cmd_rec *cmd) {
   static char cbuf[20];
 
   if (!cmd->config || cmd->config->config_type == CONF_PARAM) {
-    if (cmd->server->config_type == CONF_VIRTUAL)
+    if (cmd->server->config_type == CONF_VIRTUAL) {
       return "<VirtualHost>";
-    else
-      return "server config";
+    }
+
+    return "server config";
   }
 
   switch (cmd->config->config_type) {
@@ -3777,64 +3001,6 @@ char *get_full_cmd(cmd_rec *cmd) {
   return pr_cmd_get_displayable_str(cmd, NULL);
 }
 
-unsigned int pr_config_get_id(const char *name) {
-  void *ptr = NULL;
-  unsigned int id = 0;
-
-  if (!name) {
-    errno = EINVAL;
-    return 0;
-  }
-
-  if (!config_tab) {
-    errno = EPERM;
-    return 0;
-  }
-
-  ptr = pr_table_get(config_tab, name, NULL);
-  if (ptr == NULL) {
-    errno = ENOENT;
-    return 0;
-  }
-
-  id = *((unsigned int *) ptr);
-  return id;
-}
-
-unsigned int pr_config_set_id(const char *name) {
-  unsigned int *ptr = NULL;
-  unsigned int id;
-
-  if (!name) {
-    errno = EINVAL;
-    return 0;
-  }
-
-  if (!config_tab) {
-    errno = EPERM;
-    return 0;
-  }
-
-  ptr = pr_table_pcalloc(config_tab, sizeof(unsigned int));
-  *ptr = ++config_id;
-
-  if (pr_table_add(config_tab, name, ptr, sizeof(unsigned int *)) < 0) {
-    if (errno == EEXIST) {
-      id = pr_config_get_id(name);
-
-    } else {
-      pr_log_debug(DEBUG0, "error adding '%s' to config ID table: %s",
-        name, strerror(errno));
-      return 0;
-    }
-
-  } else {
-    id = *ptr;
-  }
-
-  return id;
-}
-
 int pr_config_get_xfer_bufsz(void) {
   return xfer_bufsz;
 }
@@ -3864,4 +3030,3 @@ int pr_config_get_server_xfer_bufsz(int direction) {
 
   return pr_config_get_xfer_bufsz2(direction);
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -899,6 +899,7 @@ static void core_restart_cb(void *d1, void *d2, void *d3, void *d4) {
     init_netaddr();
     init_class();
     init_config();
+    init_dirtree();
 
 #ifdef PR_USE_NLS
     encode_free();
@@ -2900,6 +2901,7 @@ int main(int argc, char *argv[], char **envp) {
   init_class();
   free_bindings();
   init_config();
+  init_dirtree();
   init_stash();
 
 #ifdef PR_USE_CTRLS

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -37,7 +37,9 @@ TEST_API_DEPS=\
   $(top_srcdir)/src/encode.o \
   $(top_srcdir)/src/trace.o \
   $(top_srcdir)/src/parser.o \
-  $(top_srcdir)/src/pidfile.o
+  $(top_srcdir)/src/pidfile.o \
+  $(top_srcdir)/src/configdb.o \
+  $(top_srcdir)/src/auth.o
 
 TEST_API_LIBS=-lcheck
 
@@ -68,6 +70,8 @@ TEST_API_OBJS=\
   api/trace.o \
   api/parser.o \
   api/pidfile.o \
+  api/configdb.o \
+  api/auth.o \
   api/stubs.o \
   api/tests.o
 

--- a/tests/api/auth.c
+++ b/tests/api/auth.c
@@ -1,0 +1,1017 @@
+/*
+ * ProFTPD - FTP server testsuite
+ * Copyright (c) 2014 The ProFTPD Project team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, The ProFTPD Project team and other respective
+ * copyright holders give permission to link this program with OpenSSL, and
+ * distribute the resulting executable, without including the source code for
+ * OpenSSL in the source distribution.
+ */
+
+/* Auth API tests */
+
+#include "tests.h"
+
+#define PR_TEST_AUTH_NAME	"unit_test"
+#define PR_TEST_AUTH_UID	500
+#define PR_TEST_AUTH_UID_STR	"500"
+#define PR_TEST_AUTH_GID	500
+#define PR_TEST_AUTH_GID_STR	"500"
+#define PR_TEST_AUTH_HOME	"/tmp"
+#define PR_TEST_AUTH_SHELL	"/bin/bash"
+
+static pool *p = NULL;
+
+static struct passwd test_pwd;
+static struct group test_grp;
+
+static unsigned int setpwent_count = 0;
+static unsigned int endpwent_count = 0;
+static unsigned int getpwent_count = 0;
+static unsigned int getpwnam_count = 0;
+static unsigned int getpwuid_count = 0;
+static unsigned int name2uid_count = 0;
+static unsigned int uid2name_count = 0;
+
+static unsigned int setgrent_count = 0;
+static unsigned int endgrent_count = 0;
+static unsigned int getgrent_count = 0;
+static unsigned int getgrnam_count = 0;
+static unsigned int getgrgid_count = 0;
+static unsigned int name2gid_count = 0;
+static unsigned int gid2name_count = 0;
+static unsigned int getgroups_count = 0;
+
+static module unit_tests_module = {
+  NULL, NULL,
+
+  /* Module API version */
+  0x20,
+
+  /* Module name */
+  "unit_tests",
+
+  /* Module configuration directive table */
+  NULL,
+
+  /* Module command handler table */
+  NULL,
+
+  /* Module authentication handler table */
+  NULL,
+
+  /* Module initialization function */
+  NULL,
+
+  /* Session initialization function */
+  NULL
+};
+
+MODRET handle_setpwent(cmd_rec *cmd) {
+  setpwent_count++;
+  return PR_HANDLED(cmd);
+}
+
+MODRET handle_endpwent(cmd_rec *cmd) {
+  endpwent_count++;
+  return PR_HANDLED(cmd);
+}
+
+MODRET handle_getpwent(cmd_rec *cmd) {
+  getpwent_count++;
+  return mod_create_data(cmd, &test_pwd);
+}
+
+MODRET handle_getpwnam(cmd_rec *cmd) {
+  const char *name;
+
+  name = cmd->argv[0];
+  getpwnam_count++;
+
+  if (strcmp(name, PR_TEST_AUTH_NAME) != 0) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, &test_pwd);
+}
+
+MODRET handle_getpwuid(cmd_rec *cmd) {
+  uid_t uid;
+
+  uid = *((uid_t *) cmd->argv[0]);
+  getpwuid_count++;
+
+  if (uid != PR_TEST_AUTH_UID) {
+    return PR_DECLINED(cmd);
+  }
+  
+  return mod_create_data(cmd, &test_pwd);
+}
+
+MODRET handle_name2uid(cmd_rec *cmd) {
+  const char *name;
+
+  name = cmd->argv[0];
+  name2uid_count++;
+
+  if (strcmp(name, PR_TEST_AUTH_NAME) != 0) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, (void *) &(test_pwd.pw_uid));
+}
+
+MODRET handle_uid2name(cmd_rec *cmd) {
+  uid_t uid;
+
+  uid = *((uid_t *) cmd->argv[0]);
+  uid2name_count++;
+
+  if (uid != PR_TEST_AUTH_UID) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, test_pwd.pw_name);
+}
+
+MODRET handle_setgrent(cmd_rec *cmd) {
+  setgrent_count++;
+  return PR_HANDLED(cmd);
+}
+
+MODRET handle_endgrent(cmd_rec *cmd) {
+  endgrent_count++;
+  return PR_HANDLED(cmd);
+}
+
+MODRET handle_getgrent(cmd_rec *cmd) {
+  getgrent_count++;
+  return mod_create_data(cmd, &test_grp);
+}
+
+MODRET handle_getgrnam(cmd_rec *cmd) {
+  const char *name;
+
+  name = cmd->argv[0];
+  getgrnam_count++;
+
+  if (strcmp(name, PR_TEST_AUTH_NAME) != 0) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, &test_grp);
+}
+
+MODRET handle_getgrgid(cmd_rec *cmd) {
+  gid_t gid;
+
+  gid = *((gid_t *) cmd->argv[0]);
+  getgrgid_count++;
+
+  if (gid != PR_TEST_AUTH_GID) {
+    return PR_DECLINED(cmd);
+  }
+  
+  return mod_create_data(cmd, &test_grp);
+}
+
+MODRET handle_name2gid(cmd_rec *cmd) {
+  const char *name;
+
+  name = cmd->argv[0];
+  name2gid_count++;
+
+  if (strcmp(name, PR_TEST_AUTH_NAME) != 0) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, (void *) &(test_grp.gr_gid));
+}
+
+MODRET handle_gid2name(cmd_rec *cmd) {
+  gid_t gid;
+
+  gid = *((gid_t *) cmd->argv[0]);
+  gid2name_count++;
+
+  if (gid != PR_TEST_AUTH_GID) {
+    return PR_DECLINED(cmd);
+  }
+
+  return mod_create_data(cmd, test_grp.gr_name);
+}
+
+MODRET handle_getgroups(cmd_rec *cmd) {
+  const char *name;
+  array_header *gids;
+
+  name = (char *) cmd->argv[0];
+
+  if (cmd->argv[1]) {
+    gids = (array_header *) cmd->argv[1];
+  }
+
+  getgroups_count++;
+
+  if (strcmp(name, PR_TEST_AUTH_NAME) != 0) {
+    return PR_DECLINED(cmd);
+  }
+
+  *((gid_t *) push_array(gids)) = PR_TEST_AUTH_GID;
+  return mod_create_data(cmd, (void *) &gids->nelts);
+}
+
+/* Fixtures */
+
+static void set_up(void) {
+  server_rec *s = NULL;
+
+  if (p == NULL) {
+    p = permanent_pool = make_sub_pool(NULL);
+  }
+
+  pr_trace_use_stderr(TRUE);
+  init_stash();
+  init_auth();
+
+  s = pcalloc(p, sizeof(server_rec));
+  tests_stubs_set_main_server(s);
+
+  test_pwd.pw_name = PR_TEST_AUTH_NAME;
+  test_pwd.pw_uid = PR_TEST_AUTH_UID;
+  test_pwd.pw_gid = PR_TEST_AUTH_GID;
+  test_pwd.pw_dir = PR_TEST_AUTH_HOME;
+  test_pwd.pw_shell = PR_TEST_AUTH_SHELL;
+
+  test_grp.gr_name = PR_TEST_AUTH_NAME;
+  test_grp.gr_gid = PR_TEST_AUTH_GID;
+
+  /* Reset counters. */
+  setpwent_count = 0;
+  endpwent_count = 0;
+  getpwent_count = 0;
+  getpwnam_count = 0;
+  getpwuid_count = 0;
+  name2uid_count = 0;
+  uid2name_count = 0;
+
+  setgrent_count = 0;
+  endgrent_count = 0;
+  getgrent_count = 0;
+  getgrnam_count = 0;
+  getgrgid_count = 0;
+  name2gid_count = 0;
+  gid2name_count = 0;
+  getgroups_count = 0;
+}
+
+static void tear_down(void) {
+  if (p) {
+    destroy_pool(p);
+    p = permanent_pool = NULL;
+  } 
+
+  tests_stubs_set_main_server(NULL);
+}
+
+/* Tests */
+
+START_TEST (auth_setpwent_test) {
+  int res;
+  authtable authtab;
+  char *sym_name = "setpwent";
+
+  pr_auth_setpwent(p);
+  fail_unless(setpwent_count == 0, "Expected call count 0, got %u",
+    setpwent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_setpwent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  pr_auth_setpwent(p);
+  fail_unless(setpwent_count == 1, "Expected call count 1, got %u",
+    setpwent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_endpwent_test) {
+  int res;
+  authtable authtab;
+  char *sym_name = "endpwent";
+
+  pr_auth_endpwent(p);
+  fail_unless(endpwent_count == 0, "Expected call count 0, got %u",
+    endpwent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_endpwent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  pr_auth_endpwent(p);
+  fail_unless(endpwent_count == 1, "Expected call count 1, got %u",
+    endpwent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getpwent_test) {
+  int res;
+  struct passwd *pw;
+  authtable authtab;
+  char *sym_name = "getpwent";
+
+  pw = pr_auth_getpwent(NULL);
+  fail_unless(pw == NULL, "Found pwent unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  pw = pr_auth_getpwent(p);
+  fail_unless(pw == NULL, "Found pwent unexpectedly");
+  fail_unless(getpwent_count == 0, "Expected call count 0, got %u",
+    getpwent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getpwent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  pw = pr_auth_getpwent(p);
+  fail_unless(pw != NULL, "Failed to find pwent: %s", strerror(errno));
+  fail_unless(getpwent_count == 1, "Expected call count 1, got %u",
+    getpwent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getpwnam_test) {
+  int res;
+  struct passwd *pw;
+  authtable authtab;
+  char *sym_name = "getpwnam";
+
+  pw = pr_auth_getpwnam(NULL, NULL);
+  fail_unless(pw == NULL, "Found pwnam unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NAME);
+  fail_unless(pw == NULL, "Found pwnam unexpectedly");
+  fail_unless(getpwnam_count == 0, "Expected call count 0, got %u",
+    getpwnam_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getpwnam;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NAME);
+  fail_unless(pw != NULL, "Failed to find pwnam: %s", strerror(errno));
+  fail_unless(getpwnam_count == 1, "Expected call count 1, got %u",
+    getpwnam_count);
+
+  mark_point();
+
+  pw = pr_auth_getpwnam(p, "other");
+  fail_unless(pw == NULL, "Found pwnam for user 'other' unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(getpwnam_count == 2, "Expected call count 2, got %u",
+    getpwnam_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getpwuid_test) {
+  int res;
+  struct passwd *pw;
+  authtable authtab;
+  char *sym_name = "getpwuid";
+
+  pw = pr_auth_getpwuid(NULL, -1);
+  fail_unless(pw == NULL, "Found pwuid unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  pw = pr_auth_getpwuid(p, PR_TEST_AUTH_UID);
+  fail_unless(pw == NULL, "Found pwuid unexpectedly");
+  fail_unless(getpwuid_count == 0, "Expected call count 0, got %u",
+    getpwuid_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getpwuid;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  pw = pr_auth_getpwuid(p, PR_TEST_AUTH_UID);
+  fail_unless(pw != NULL, "Failed to find pwuid: %s", strerror(errno));
+  fail_unless(getpwuid_count == 1, "Expected call count 1, got %u",
+    getpwuid_count);
+
+  mark_point();
+
+  pw = pr_auth_getpwuid(p, 5);
+  fail_unless(pw == NULL, "Found pwuid for UID 5 unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(getpwuid_count == 2, "Expected call count 2, got %u",
+    getpwuid_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_name2uid_test) {
+  int res;
+  uid_t uid;
+  authtable authtab;
+  char *sym_name = "name2uid";
+
+  uid = pr_auth_name2uid(NULL, NULL);
+  fail_unless(uid == (uid_t) -1, "Found UID unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
+  fail_unless(uid == (uid_t) -1, "Found UID unexpectedly");
+  fail_unless(name2uid_count == 0, "Expected call count 0, got %u",
+    name2uid_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_name2uid;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
+  fail_unless(uid == PR_TEST_AUTH_UID, "Expected UID %lu, got %lu",
+    (unsigned long) PR_TEST_AUTH_UID, (unsigned long) uid);
+  fail_unless(name2uid_count == 1, "Expected call count 1, got %u",
+    name2uid_count);
+
+  mark_point();
+
+  uid = pr_auth_name2uid(p, "other");
+  fail_unless(uid == (uid_t) -1, "Found UID for user 'other' unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(name2uid_count == 2, "Expected call count 2, got %u",
+    name2uid_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_uid2name_test) {
+  int res;
+  const char *name; 
+  authtable authtab;
+  char *sym_name = "uid2name";
+
+  name = pr_auth_uid2name(NULL, -1);
+  fail_unless(name == NULL, "Found name unexpectedly: %s", name);
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
+  fail_unless(name != NULL, "Failed to find name for UID %lu: %s",
+    (unsigned long) PR_TEST_AUTH_UID, strerror(errno));
+  fail_unless(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
+     "Expected name '%s', got '%s'", PR_TEST_AUTH_UID_STR, name);
+  fail_unless(uid2name_count == 0, "Expected call count 0, got %u",
+    uid2name_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_uid2name;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+    uid2name_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_setgrent_test) {
+  int res;
+  authtable authtab;
+  char *sym_name = "setgrent";
+
+  pr_auth_setgrent(p);
+  fail_unless(setgrent_count == 0, "Expected call count 0, got %u",
+    setgrent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_setgrent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  pr_auth_setgrent(p);
+  fail_unless(setgrent_count == 1, "Expected call count 1, got %u",
+    setgrent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_endgrent_test) {
+  int res;
+  authtable authtab;
+  char *sym_name = "endgrent";
+
+  pr_auth_endgrent(p);
+  fail_unless(endgrent_count == 0, "Expected call count 0, got %u",
+    endgrent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_endgrent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  pr_auth_endgrent(p);
+  fail_unless(endgrent_count == 1, "Expected call count 1, got %u",
+    endgrent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getgrent_test) {
+  int res;
+  struct group *gr;
+  authtable authtab;
+  char *sym_name = "getgrent";
+
+  gr = pr_auth_getgrent(NULL);
+  fail_unless(gr == NULL, "Found grent unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  gr = pr_auth_getgrent(p);
+  fail_unless(gr == NULL, "Found grent unexpectedly");
+  fail_unless(getgrent_count == 0, "Expected call count 0, got %u",
+    getgrent_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getgrent;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  gr = pr_auth_getgrent(p);
+  fail_unless(gr != NULL, "Failed to find grent: %s", strerror(errno));
+  fail_unless(getgrent_count == 1, "Expected call count 1, got %u",
+    getgrent_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getgrnam_test) {
+  int res;
+  struct group *gr;
+  authtable authtab;
+  char *sym_name = "getgrnam";
+
+  gr = pr_auth_getgrnam(NULL, NULL);
+  fail_unless(gr == NULL, "Found grnam unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  gr = pr_auth_getgrnam(p, PR_TEST_AUTH_NAME);
+  fail_unless(gr == NULL, "Found grnam unexpectedly");
+  fail_unless(getgrnam_count == 0, "Expected call count 0, got %u",
+    getgrnam_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getgrnam;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  gr = pr_auth_getgrnam(p, PR_TEST_AUTH_NAME);
+  fail_unless(gr != NULL, "Failed to find grnam: %s", strerror(errno));
+  fail_unless(getgrnam_count == 1, "Expected call count 1, got %u",
+    getgrnam_count);
+
+  mark_point();
+
+  gr = pr_auth_getgrnam(p, "other");
+  fail_unless(gr == NULL, "Found grnam for user 'other' unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(getgrnam_count == 2, "Expected call count 2, got %u",
+    getgrnam_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getgrgid_test) {
+  int res;
+  struct group *gr;
+  authtable authtab;
+  char *sym_name = "getgrgid";
+
+  gr = pr_auth_getgrgid(NULL, -1);
+  fail_unless(gr == NULL, "Found grgid unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  gr = pr_auth_getgrgid(p, PR_TEST_AUTH_GID);
+  fail_unless(gr == NULL, "Found grgid unexpectedly");
+  fail_unless(getgrgid_count == 0, "Expected call count 0, got %u",
+    getgrgid_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getgrgid;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  gr = pr_auth_getgrgid(p, PR_TEST_AUTH_GID);
+  fail_unless(gr != NULL, "Failed to find grgid: %s", strerror(errno));
+  fail_unless(getgrgid_count == 1, "Expected call count 1, got %u",
+    getgrgid_count);
+
+  mark_point();
+
+  gr = pr_auth_getgrgid(p, 5);
+  fail_unless(gr == NULL, "Found grgid for GID 5 unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(getgrgid_count == 2, "Expected call count 2, got %u",
+    getgrgid_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_name2gid_test) {
+  int res;
+  gid_t gid;
+  authtable authtab;
+  char *sym_name = "name2gid";
+
+  gid = pr_auth_name2gid(NULL, NULL);
+  fail_unless(gid == (gid_t) -1, "Found GID unexpectedly");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
+  fail_unless(gid == (gid_t) -1, "Found GID unexpectedly");
+  fail_unless(name2gid_count == 0, "Expected call count 0, got %u",
+    name2gid_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_name2gid;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
+  fail_unless(gid == PR_TEST_AUTH_GID, "Expected GID %lu, got %lu",
+    (unsigned long) PR_TEST_AUTH_GID, (unsigned long) gid);
+  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+    name2gid_count);
+
+  mark_point();
+
+  gid = pr_auth_name2gid(p, "other");
+  fail_unless(gid == (gid_t) -1, "Found GID for group 'other' unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+  fail_unless(name2gid_count == 2, "Expected call count 2, got %u",
+    name2gid_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_gid2name_test) {
+  int res;
+  const char *name; 
+  authtable authtab;
+  char *sym_name = "gid2name";
+
+  name = pr_auth_gid2name(NULL, -1);
+  fail_unless(name == NULL, "Found name unexpectedly: %s", name);
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
+  fail_unless(name != NULL, "Failed to find name for GID %lu: %s",
+    (unsigned long) PR_TEST_AUTH_GID, strerror(errno));
+  fail_unless(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
+     "Expected name '%s', got '%s'", PR_TEST_AUTH_GID_STR, name);
+  fail_unless(gid2name_count == 0, "Expected call count 0, got %u",
+    gid2name_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_gid2name;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+    gid2name_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_getgroups_test) {
+  int res;
+  const char *name; 
+  array_header *gids = NULL;
+  authtable authtab;
+  char *sym_name = "getgroups";
+
+  res = pr_auth_getgroups(NULL, NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null arguments");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  res = pr_auth_getgroups(p, PR_TEST_AUTH_NAME, &gids, NULL);
+  fail_unless(res < 0, "Found groups for '%s' unexpectedly", PR_TEST_AUTH_NAME);
+  fail_unless(getgroups_count == 0, "Expected call count 0, got %u",
+    getgroups_count);
+  mark_point();
+  
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_getgroups;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  res = pr_auth_getgroups(p, PR_TEST_AUTH_NAME, &gids, NULL);
+  fail_unless(res > 0, "Expected group count 1 for '%s', got %d: %s",
+    PR_TEST_AUTH_NAME, res, strerror(errno));
+  fail_unless(getgroups_count == 1, "Expected call count 1, got %u",
+    getgroups_count);
+
+  res = pr_auth_getgroups(p, "other", &gids, NULL);
+  fail_unless(res < 0, "Found groups for 'other' unexpectedly");
+  fail_unless(getgroups_count == 2, "Expected call count 2, got %u",
+    getgroups_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_cache_uid2name_test) {
+  int res;
+  const char *name; 
+  authtable authtab;
+  char *sym_name = "uid2name";
+
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_uid2name;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+    uid2name_count);
+
+  /* Call again; the call counter should NOT increment due to caching. */
+
+  name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+    uid2name_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+START_TEST (auth_cache_gid2name_test) {
+  int res;
+  const char *name; 
+  authtable authtab;
+  char *sym_name = "gid2name";
+
+  /* Load the appropriate AUTH symbol, and call it. */
+
+  memset(&authtab, 0, sizeof(authtab));
+  authtab.name = sym_name;
+  authtab.handler = handle_gid2name;
+  authtab.m = &unit_tests_module;
+  res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
+  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+    strerror(errno));
+
+  mark_point();
+
+  name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+    gid2name_count);
+
+  /* Call again; the call counter should NOT increment due to caching. */
+
+  name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
+  fail_unless(name != NULL, "Expected name, got null");
+  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+    "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
+  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+    gid2name_count);
+
+  pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &unit_tests_module);
+}
+END_TEST
+
+Suite *tests_get_auth_suite(void) {
+  Suite *suite;
+  TCase *testcase;
+
+  suite = suite_create("auth");
+
+  testcase = tcase_create("base");
+
+  tcase_add_checked_fixture(testcase, set_up, tear_down);
+
+  /* pwent* et al */
+  tcase_add_test(testcase, auth_setpwent_test);
+  tcase_add_test(testcase, auth_endpwent_test);
+  tcase_add_test(testcase, auth_getpwent_test);
+  tcase_add_test(testcase, auth_getpwnam_test);
+  tcase_add_test(testcase, auth_getpwuid_test);
+  tcase_add_test(testcase, auth_name2uid_test);
+  tcase_add_test(testcase, auth_uid2name_test);
+
+  /* grent* et al */
+  tcase_add_test(testcase, auth_setgrent_test);
+  tcase_add_test(testcase, auth_endgrent_test);
+  tcase_add_test(testcase, auth_getgrent_test);
+  tcase_add_test(testcase, auth_getgrnam_test);
+  tcase_add_test(testcase, auth_getgrgid_test);
+  tcase_add_test(testcase, auth_gid2name_test);
+  tcase_add_test(testcase, auth_name2gid_test);
+  tcase_add_test(testcase, auth_getgroups_test);
+
+  /* Caching tests */
+  tcase_add_test(testcase, auth_cache_uid2name_test);
+  tcase_add_test(testcase, auth_cache_gid2name_test);
+
+#if 0
+  /* Authorization */
+  tcase_add_test(testcase, auth_authenticate_test);
+  tcase_add_test(testcase, auth_authorize_test);
+  tcase_add_test(testcase, auth_check_test);
+  tcase_add_test(testcase, auth_requires_pass_test);
+
+  /* Auth modules */
+  tcase_add_test(testcase, auth_add_auth_only_module_test);
+  tcase_add_test(testcase, auth_remove_auth_only_module_test);
+  tcase_add_test(testcase, auth_clear_auth_only_modules_test);
+#endif
+
+  suite_add_tcase(suite, testcase);
+
+  return suite;
+}

--- a/tests/api/configdb.c
+++ b/tests/api/configdb.c
@@ -1,0 +1,386 @@
+/*
+ * ProFTPD - FTP server testsuite
+ * Copyright (c) 2014 The ProFTPD Project team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, The ProFTPD Project team and other respective
+ * copyright holders give permission to link this program with OpenSSL, and
+ * distribute the resulting executable, without including the source code for
+ * OpenSSL in the source distribution.
+ */
+
+/* Configuration API tests
+ */
+
+#include "tests.h"
+
+static pool *p = NULL;
+
+static void set_up(void) {
+  if (p == NULL) {
+    p = permanent_pool = make_sub_pool(NULL);
+  }
+
+  init_config();
+}
+
+static void tear_down(void) {
+  if (p) {
+    destroy_pool(p);
+    p = permanent_pool = NULL;
+  } 
+}
+
+START_TEST (add_remove_config_test) {
+  int res;
+  xaset_t *set = NULL;
+  const char *name = NULL;
+  config_rec *c = NULL;
+
+  res = remove_config(NULL, NULL, FALSE);
+  fail_unless(res == 0, "Failed to handle null arguments: %s", strerror(errno));
+
+  name = "foo";
+
+  c = add_config_set(NULL, name);
+  fail_unless(c == NULL, "Failed to handle null set argument");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  c = add_config_set(&set, name);
+  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+    strerror(errno));
+  fail_unless(c->config_type == 0, "Expected config_type 0, got %d",
+    c->config_type);
+
+  res = remove_config(set, name, FALSE);
+  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+    strerror(errno));
+
+  name = "bar";
+  res = remove_config(set, name, FALSE);
+  fail_unless(res == 0, "Removed config '%s' unexpectedly", name,
+    strerror(errno));
+}
+END_TEST
+
+START_TEST (add_config_param_set_test) {
+  xaset_t *set = NULL;
+  const char *name = NULL;
+  config_rec *c = NULL;
+
+  name = "foo";
+
+  c = add_config_param_set(NULL, name, 0);
+  fail_unless(c == NULL, "Failed to handle null set argument");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  c = add_config_param_set(&set, name, 0);
+  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+    strerror(errno));
+  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+    CONF_PARAM, c->config_type);
+  fail_unless(c->argc == 0, "Expected argc 0, got %d", c->argc);
+
+  c = add_config_param_set(&set, name, 2, "bar", "baz");
+  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+    strerror(errno));
+  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+    CONF_PARAM, c->config_type);
+  fail_unless(c->argc == 2, "Expected argc 2, got %d", c->argc);
+  fail_unless(strcmp("bar", (char *) c->argv[0]) == 0,
+    "Expected argv[0] to be 'bar', got '%s'", (char *) c->argv[0]);
+  fail_unless(strcmp("baz", (char *) c->argv[1]) == 0,
+    "Expected argv[1] to be 'baz', got '%s'", (char *) c->argv[1]);
+  fail_unless(c->argv[2] == NULL, "Expected argv[2] to be null");
+}
+END_TEST
+
+START_TEST (find_config_test) {
+  int res;
+  config_rec *c;
+  xaset_t *set = NULL;
+  const char *name;
+
+  c = find_config(NULL, -1, NULL, FALSE);
+  fail_unless(c == NULL, "Failed to handle null arguments");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  name = "foo";
+  c = add_config_param_set(&set, name, 0);
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  name = "bar";
+  c = find_config(set, -1, name, FALSE);
+  fail_unless(c == NULL, "Failed to handle null arguments");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  /* We expect to find "foo", but a 'next' should be empty. */
+  name = "foo";
+  c = find_config(set, -1, name, FALSE);
+  fail_unless(c != NULL, "Failed to find config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  c = find_config_next(c, c->next, -1, name, FALSE);
+  fail_unless(c == NULL, "Found next config unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  /* Now add another config, find "foo" again; this time, a 'next' should
+   * NOT be empty; it should find the 2nd config we added.
+   */
+
+  name = "foo2";
+  c = add_config_param_set(&set, name, 0);
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  name = NULL;
+  c = find_config(set, -1, name, FALSE);
+  fail_unless(c != NULL, "Failed to find any config: %s", strerror(errno));
+
+  mark_point();
+
+  c = find_config_next(c, c->next, -1, name, FALSE);
+  fail_unless(c != NULL, "Expected to find another config");
+
+  mark_point();
+
+  name = "foo";
+  res = remove_config(set, name, FALSE);
+  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  c = find_config(set, -1, name, FALSE);
+  fail_unless(c == NULL, "Found config '%s' unexpectedly", name);
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+}
+END_TEST
+
+START_TEST (find_config2_test) {
+  int res;
+  config_rec *c;
+  xaset_t *set = NULL;
+  const char *name;
+  unsigned long flags = 0;
+
+  c = find_config2(NULL, -1, NULL, FALSE, flags);
+  fail_unless(c == NULL, "Failed to handle null arguments");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  name = "foo";
+  c = add_config_param_set(&set, name, 0);
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  name = "bar";
+  c = find_config2(set, -1, name, FALSE, flags);
+  fail_unless(c == NULL, "Failed to handle null arguments");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  /* We expect to find "foo", but a 'next' should be empty. */
+  name = "foo";
+  c = find_config2(set, -1, name, FALSE, flags);
+  fail_unless(c != NULL, "Failed to find config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  c = find_config_next2(c, c->next, -1, name, FALSE, flags);
+  fail_unless(c == NULL, "Found next config unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  /* Now add another config, find "foo" again; this time, a 'next' should
+   * NOT be empty; it should find the 2nd config we added.
+   */
+
+  name = "foo2";
+  c = add_config_param_set(&set, name, 0);
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  name = NULL;
+  c = find_config2(set, -1, name, FALSE, flags);
+  fail_unless(c != NULL, "Failed to find any config: %s", strerror(errno));
+
+  mark_point();
+
+  c = find_config_next2(c, c->next, -1, name, FALSE, flags);
+  fail_unless(c != NULL, "Expected to find another config");
+
+  mark_point();
+
+  name = "foo";
+  res = remove_config(set, name, FALSE);
+  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  c = find_config2(set, -1, name, FALSE, flags);
+  fail_unless(c == NULL, "Found config '%s' unexpectedly", name);
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+}
+END_TEST
+
+START_TEST (get_param_ptr_test) {
+  void *res;
+  int count;
+  xaset_t *set = NULL;
+  config_rec *c;
+  const char *name = NULL;
+
+  res = get_param_ptr(NULL, NULL, FALSE);
+  fail_unless(res == NULL, "Failed to handle null arguments");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  name = "foo";
+  c = add_config_param_set(&set, name, 1, "bar");
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  name = "bar";
+  res = get_param_ptr(set, name, FALSE);
+  fail_unless(res == NULL, "Failed to handle null arguments");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  mark_point();
+
+  /* We expect to find "foo", but a 'next' should be empty. Note that we
+   * need to reset the get_param_ptr tree.
+   */
+  get_param_ptr(NULL, NULL, FALSE);
+
+  name = "foo";
+  res = get_param_ptr(set, name, FALSE);
+  fail_unless(res != NULL, "Failed to find config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  res = get_param_ptr_next(name, FALSE);
+  fail_unless(res == NULL, "Found next config unexpectedly");
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+
+  /* Now add another config, find "foo" again; this time, a 'next' should
+   * NOT be empty; it should find the 2nd config we added.
+   */
+
+  name = "foo2";
+  c = add_config_param_set(&set, name, 1, "baz");
+  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+    strerror(errno));
+
+  get_param_ptr(NULL, NULL, FALSE);
+
+  name = NULL;
+  res = get_param_ptr(set, name, FALSE);
+  fail_unless(res != NULL, "Failed to find any config: %s", strerror(errno));
+
+  mark_point();
+
+  res = get_param_ptr_next(name, FALSE);
+  fail_unless(res != NULL, "Expected to find another config");
+
+  mark_point();
+
+  name = "foo";
+  count = remove_config(set, name, FALSE);
+  fail_unless(count > 0, "Failed to remove config '%s': %s", name,
+    strerror(errno));
+
+  mark_point();
+
+  res = get_param_ptr(set, name, FALSE);
+  fail_unless(res == NULL, "Found config '%s' unexpectedly", name);
+  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+    errno, strerror(errno));
+}
+END_TEST
+
+START_TEST (config_set_get_id_test) {
+  unsigned int id, res;
+  const char *name;
+
+  res = pr_config_get_id(NULL);
+  fail_unless(res == 0, "Failed to handle null argument");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  res = pr_config_set_id(NULL);
+  fail_unless(res == 0, "Failed to handle null argument");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+    errno, strerror(errno));
+
+  name = "foo";
+
+  id = pr_config_set_id(name);
+  fail_unless(id > 0, "Failed to set ID for config '%s': %s", name,
+    strerror(errno));
+
+  res = pr_config_get_id(name);
+  fail_unless(res == id, "Expected ID %u for config '%s', found %u", id,
+    name, res);
+}
+END_TEST
+
+Suite *tests_get_config_suite(void) {
+  Suite *suite;
+  TCase *testcase;
+
+  suite = suite_create("config");
+
+  testcase = tcase_create("base");
+
+  tcase_add_checked_fixture(testcase, set_up, tear_down);
+
+  tcase_add_test(testcase, add_remove_config_test);
+  tcase_add_test(testcase, add_config_param_set_test);
+  tcase_add_test(testcase, find_config_test);
+  tcase_add_test(testcase, find_config2_test);
+  tcase_add_test(testcase, get_param_ptr_test);
+  tcase_add_test(testcase, config_set_get_id_test);
+
+  suite_add_tcase(suite, testcase);
+
+  return suite;
+}

--- a/tests/api/stubs.c
+++ b/tests/api/stubs.c
@@ -36,17 +36,12 @@ module *static_modules[] = { NULL };
 module *loaded_modules = NULL;
 xaset_t *server_list = NULL;
 
+int tests_stubs_set_main_server(server_rec *s) {
+  main_server = s;
+  return 0;
+}
+
 char *dir_realpath(pool *p, const char *path) {
-  return NULL;
-}
-
-void *get_param_ptr(xaset_t *set, const char *name, int recurse) {
-  errno = ENOENT;
-  return NULL;
-}
-
-struct passwd *pr_auth_getpwnam(pool *p, const char *name) {
-  errno = ENOENT;
   return NULL;
 }
 

--- a/tests/api/tests.c
+++ b/tests/api/tests.c
@@ -56,6 +56,8 @@ static struct testsuite_info suites[] = {
   { "trace",		tests_get_trace_suite },
   { "parser",		tests_get_parser_suite },
   { "pidfile",		tests_get_pidfile_suite },
+  { "config",		tests_get_config_suite },
+  { "auth",		tests_get_auth_suite },
 
   { NULL, NULL }
 };
@@ -138,6 +140,12 @@ static Suite *tests_get_suite(const char *suite) {
 
   } else if (strcmp(suite, "pidfile") == 0) {
     return tests_get_pidfile_suite();
+
+  } else if (strcmp(suite, "config") == 0) {
+    return tests_get_config_suite();
+
+  } else if (strcmp(suite, "auth") == 0) {
+    return tests_get_auth_suite();
   }
 
   return NULL;

--- a/tests/api/tests.h
+++ b/tests/api/tests.h
@@ -38,6 +38,8 @@
 # error "Missing Check installation; necessary for ProFTPD testsuite"
 #endif
 
+int tests_stubs_set_main_server(server_rec *);
+
 Suite *tests_get_pool_suite(void);
 Suite *tests_get_array_suite(void);
 Suite *tests_get_str_suite(void);
@@ -64,6 +66,8 @@ Suite *tests_get_netio_suite(void);
 Suite *tests_get_trace_suite(void);
 Suite *tests_get_parser_suite(void);
 Suite *tests_get_pidfile_suite(void);
+Suite *tests_get_config_suite(void);
+Suite *tests_get_auth_suite(void);
 
 /* Temporary hack/placement for this variable, until we get to testing
  * the Signals API.


### PR DESCRIPTION
..._*

API, and keeping the rest, for now.  This makes it possible to a) write unit
tests for that API, and b) write unit tests for other APIs (such as the Auth
API) by reducing complexity of the unit test build/link.
