### PR TITLE
Configure script refactoring of module handling

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -22,7 +22,6 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT(include/conf.h)
 
 ac_core_modules="mod_core.o mod_xfer.o mod_rlimit.o mod_auth_unix.o mod_auth_file.o mod_auth.o mod_ls.o mod_log.o mod_site.o mod_delay.o mod_facts.o"
-ac_build_core_modules="modules/mod_core.o modules/mod_xfer.o modules/mod_rlimit.o modules/mod_auth_unix.o modules/mod_auth_file.o modules/mod_auth.o modules/mod_ls.o modules/mod_log.o modules/mod_site.o modules/mod_delay.o modules/mod_facts.o"
 
 dnl Get the OS type
 AC_CONFIG_AUX_DIR(./)
@@ -564,7 +563,6 @@ AC_ARG_ENABLE(auth-file,
   [
     if test "$enableval" = "no"; then
       ac_core_modules=`echo "$ac_core_modules" | sed -e 's/mod_auth_file\.o//'`
-      ac_build_core_modules=`echo "$ac_build_core_modules" | sed -e 's/modules\/mod_auth_file\.o//'`
     fi
   ])
  
@@ -679,7 +677,6 @@ AC_ARG_ENABLE(dso,
   [
     if test x"$enableval" = x"yes"; then
       ac_core_modules="$ac_core_modules mod_dso.o"
-      ac_build_core_modules="$ac_build_core_modules modules/mod_dso.o"
 
       MAIN_LDFLAGS="-L\$(top_srcdir)/lib/libltdl -dlopen self -export-dynamic"
       MAIN_LIBS="\$(LIBLTDL)"
@@ -2259,7 +2256,6 @@ for amodule in $ac_shared_modules; do
   module=`echo "$amodule" | sed -e 's/\.la//g'`.o;
 
   ac_core_modules=`echo "$ac_core_modules" | sed -e "s/$module//g"`;
-  ac_build_core_modules=`echo "$ac_build_core_modules" | sed -e "s/modules\/$module//g"`;
 
   ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//g"`;
 done
@@ -2896,6 +2892,10 @@ done
 
 for module in $ac_static_modules; do
   ac_build_static_modules+=" /modules/$module.o"
+done
+
+for module in $core_modules; do
+  ac_build_core_modules+=" modules/$module"
 done
 
 dnl This is a nasty, cap-specific hack.  If we will be using the system

--- a/configure.in
+++ b/configure.in
@@ -334,9 +334,6 @@ AC_ARG_WITH(libraries,
     fi
   ])
 
-dnl This variable is used to impose a certain ordering between mod_ifsession
-dnl and mod_cap, per Bug#3576
-ifsession_requested="false"
 AC_ARG_WITH(modules,
   [AC_HELP_STRING(
     [--with-modules=LIST],
@@ -356,10 +353,6 @@ AC_ARG_WITH(modules,
             AC_MSG_ERROR([use --enable-dso instead of --with-modules=mod_dso for DSO support])
           fi
 
-          if test x"$amodule" = xmod_ifsession ; then
-            ifsession_requested="true"
-          fi
-
           if test x"$amodule" = xmod_lang ; then
             AC_MSG_ERROR([use --enable-nls instead of --with-modules=mod_lang for NLS/UTF8 support])
           fi
@@ -373,13 +366,6 @@ AC_ARG_WITH(modules,
         # into single colons; these are common typos.
         ac_static_modules=`echo "$withval" | sed 's/::/:/g' | sed 's/^://' | sed 's/:$//' | sed -e 's/:/.o /g'`.o ;
 
-
-        dnl Make sure that mod_ifsession, if present in the list, appears at
-        dnl the end.
-        if test x"$ifsession_requested" = xtrue; then
-          ac_static_modules=`echo "$ac_static_modules" | sed -e 's/mod_ifsession\.o//g'`
-          ac_static_modules="$ac_static_modules mod_ifsession.o"
-        fi
       fi
     fi
   ])
@@ -1386,16 +1372,7 @@ AC_MSG_CHECKING([whether to enable mod_cap])
 AC_MSG_RESULT($ac_add_mod_cap)
 
 if test x"$ac_add_mod_cap" = xyes; then
-
-  dnl Make sure that mod_ifsession, if present in the list, appears at
-  dnl the end.
-  if test x"$ifsession_requested" = xtrue; then
-    ac_static_modules=`echo "$ac_static_modules" | sed -e 's/mod_ifsession\.o//g'`
-    ac_static_modules="$ac_static_modules mod_cap.o mod_ifsession.o"
-
-  else
     ac_static_modules="$ac_static_modules mod_cap.o"
-  fi
 fi
 
 AC_CHECK_HEADERS(bstring.h crypt.h ctype.h execinfo.h iconv.h inttypes.h langinfo.h limits.h locale.h)
@@ -2884,6 +2861,18 @@ for module in $ac_static_modules; do
     AC_MSG_ERROR([source file '$srcdir/modules/$src' cannot be found -- aborting])
   fi
 done
+
+# Make sure that mod_ifsession, if present in the list, appears at the end.
+if [[ -z "{$static_modules##*mod_ifsession*}" ]]; then
+  ac_static_modules=${static_modules/mod_ifsession\.o/}
+  ac_static_modules+=" mod_ifsession.o"
+fi
+
+# Make sure that mod_ifsession, if present in the list, appears at the end, even after mod_ifsession.
+if [[ -z "{$static_modules##*mod_memcache*}" ]]; then
+  ac_static_modules=${static_modules/mod_memcache\.o/}
+  ac_static_modules+=" mod_memcache.o"
+fi
 
 # Generate object-file lists for makefiles
 for module in $shared_modules; do

--- a/configure.in
+++ b/configure.in
@@ -424,7 +424,6 @@ AC_ARG_WITH(shared,
 
         for amodule in $shared_modules; do
           ac_shared_modules+=" $amodule.la"
-          ac_build_shared_modules="modules/$amodule.la $ac_build_shared_modules"
         done
       fi
     fi
@@ -2888,6 +2887,11 @@ for module in $ac_static_modules; do
   else
     AC_MSG_ERROR([source file '$srcdir/modules/$src' cannot be found -- aborting])
   fi
+done
+
+# Generate object-file lists for makefiles
+for module in $shared_modules; do
+  ac_build_shared_modules+=" /modules/$module.la"
 done
 
 for module in $ac_static_modules; do

--- a/configure.in
+++ b/configure.in
@@ -406,10 +406,6 @@ AC_ARG_WITH(shared,
             fi
           done
         done
-
-        for amodule in $shared_modules; do
-          ac_shared_modules+=" $amodule.la"
-        done
       fi
     fi
   ])
@@ -585,7 +581,7 @@ AC_ARG_ENABLE(auth-pam,
         AC_MSG_ERROR([You cannot run configure with --disable-auth-pam and include mod_auth_pam in --with-modules at the same time])
       fi
 
-      if test `echo $ac_shared_modules | grep -c mod_auth_pam` != "0"; then
+      if test `echo $shared_modules | grep -c mod_auth_pam` != "0"; then
         AC_MSG_ERROR([You cannot run configure with --disable-auth-pam and include mod_auth_pam in --with-shared at the same time])
       fi
     fi
@@ -2228,17 +2224,13 @@ ac_shared_module_dirs=
 ac_static_module_dirs=
 
 # Remove any modules in the shared module list from the core and static module lists
-for amodule in $ac_shared_modules; do
-  module=`echo "$amodule" | sed -e 's/\.la//g'`;
-
-  core_modules=`echo "$core_modules" | sed -e "s/$module//g"`;
-
-  static_modules=`echo "$static_modules" | sed -e "s/$module//g"`;
+for module in $shared_modules; do
+  core_modules=${core_modules/$module/}
+  static_modules=${static_modules/$module/}
 done
 
 dnl Check for any duplicates
-my_shared_modules=`echo "$ac_shared_modules" | sed -e 's/\.la//g'`;
-all_modules="$core_modules $static_modules $my_shared_modules";
+all_modules="$core_modules $static_modules $shared_modules";
 
 pr_use_mysql="no"
 pr_use_openssl="no"
@@ -2664,8 +2656,9 @@ if test x"$pr_use_postgres" = xyes; then
   LIBS="$saved_libs"
 fi
 
-for module in $ac_shared_modules ; do
-  moduledir=`echo "$module" | sed -e 's/\.la$//'`;
+for modulename in $shared_modules ; do
+  module=$modulename".la"
+  moduledir=$modulename
 
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
     continue
@@ -2681,8 +2674,8 @@ for module in $ac_shared_modules ; do
 done
 
 for modulename in $static_modules ; do
-  module=$moduledir".o"
-  moduledir=modulename
+  module=$modulename".o"
+  moduledir=$modulename
 
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
     continue
@@ -2873,6 +2866,7 @@ fi
 
 # Generate object-file lists for makefiles
 for module in $shared_modules; do
+  ac_shared_modules+=" $module.la"
   ac_build_shared_modules+=" modules/$module.la"
 done
 

--- a/configure.in
+++ b/configure.in
@@ -2894,7 +2894,7 @@ for module in $ac_static_modules; do
   ac_build_static_modules+=" /modules/$module.o"
 done
 
-for module in $core_modules; do
+for module in $ac_core_modules; do
   ac_build_core_modules+=" modules/$module"
 done
 

--- a/configure.in
+++ b/configure.in
@@ -2829,12 +2829,13 @@ for module in $static_modules ; do
 done
 
 # Make sure that mod_ifsession, if present in the list, appears at the end.
+# This imposes a certain ordering between mod_ifsession and mod_cap, per Bug#3576
 if [[ -z "{$static_modules##*mod_ifsession*}" ]]; then
   static_modules=${static_modules/mod_ifsession/}
   static_modules+=" mod_ifsession"
 fi
 
-# Make sure that mod_ifsession, if present in the list, appears at the end, even after mod_ifsession.
+# Make sure that mod_memcache, if present in the list, appears at the end, even after mod_ifsession.
 if [[ -z "{$static_modules##*mod_memcache*}" ]]; then
   static_modules=${static_modules/mod_memcache/}
   static_modules+=" mod_memcache"

--- a/configure.in
+++ b/configure.in
@@ -2671,7 +2671,7 @@ for module in $shared_modules ; do
 
   # Create lists for the makefiles
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
-    ac_shared_module+=" $moduleobj"
+    ac_shared_modules+=" $moduleobj"
 
   elif test -d $srcdir/modules/$module; then
     ac_shared_module_dirs+=" modules/$module";
@@ -2842,7 +2842,6 @@ fi
 
 # Generate object-file lists for makefiles
 for module in $shared_modules; do
-  ac_shared_modules+=" $module.la"
   ac_build_shared_modules+=" modules/$module.la"
 done
 

--- a/configure.in
+++ b/configure.in
@@ -21,7 +21,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT(include/conf.h)
 
-ac_core_modules="mod_core.o mod_xfer.o mod_rlimit.o mod_auth_unix.o mod_auth_file.o mod_auth.o mod_ls.o mod_log.o mod_site.o mod_delay.o mod_facts.o"
+core_modules="mod_core mod_xfer mod_rlimit mod_auth_unix mod_auth_file mod_auth mod_ls mod_log mod_site mod_delay mod_facts"
 
 dnl Get the OS type
 AC_CONFIG_AUX_DIR(./)
@@ -548,7 +548,7 @@ AC_ARG_ENABLE(auth-file,
   ],
   [
     if test "$enableval" = "no"; then
-      ac_core_modules=`echo "$ac_core_modules" | sed -e 's/mod_auth_file\.o//'`
+      core_modules=${core_modules/mod_auth_file/}
     fi
   ])
  
@@ -662,7 +662,7 @@ AC_ARG_ENABLE(dso,
   ],
   [
     if test x"$enableval" = x"yes"; then
-      ac_core_modules="$ac_core_modules mod_dso.o"
+      core_modules+=" mod_dso"
 
       MAIN_LDFLAGS="-L\$(top_srcdir)/lib/libltdl -dlopen self -export-dynamic"
       MAIN_LIBS="\$(LIBLTDL)"
@@ -2227,23 +2227,19 @@ dnl Module handling.
 ac_shared_module_dirs=
 ac_static_module_dirs=
 
-dnl Remove any modules in the shared module list from the core and static
-dnl module lists
+# Remove any modules in the shared module list from the core and static module lists
 for amodule in $ac_shared_modules; do
-  module=`echo "$amodule" | sed -e 's/\.la//g'`.o;
+  module=`echo "$amodule" | sed -e 's/\.la//g'`;
 
-  ac_core_modules=`echo "$ac_core_modules" | sed -e "s/$module//g"`;
+  core_modules=`echo "$core_modules" | sed -e "s/$module//g"`;
 
-  ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//g"`;
+  ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module.o//g"`;
 done
 
-GLUE_MODULE_OBJS="$ac_core_modules $ac_static_modules"
-
 dnl Check for any duplicates
-my_core_modules=`echo "$ac_core_modules" | sed -e 's/\.o//g'`;
 my_static_modules=`echo "$ac_static_modules" | sed -e 's/\.o//g'`;
 my_shared_modules=`echo "$ac_shared_modules" | sed -e 's/\.la//g'`;
-all_modules="$my_core_modules $my_static_modules $my_shared_modules";
+all_modules="$core_modules $my_static_modules $my_shared_modules";
 
 pr_use_mysql="no"
 pr_use_openssl="no"
@@ -2876,16 +2872,19 @@ fi
 
 # Generate object-file lists for makefiles
 for module in $shared_modules; do
-  ac_build_shared_modules+=" /modules/$module.la"
+  ac_build_shared_modules+=" modules/$module.la"
 done
 
 for module in $ac_static_modules; do
-  ac_build_static_modules+=" /modules/$module"
+  ac_build_static_modules+=" modules/$module"
 done
 
-for module in $ac_core_modules; do
-  ac_build_core_modules+=" modules/$module"
+for module in $core_modules; do
+  ac_core_modules+=" $module.o"
+  ac_build_core_modules+=" modules/$module.o"
 done
+
+GLUE_MODULE_OBJS="$ac_core_modules $ac_static_modules"
 
 dnl This is a nasty, cap-specific hack.  If we will be using the system
 dnl libcap (i.e. ac_have_libcap is "yes"), then we want to remove the

--- a/configure.in
+++ b/configure.in
@@ -2656,120 +2656,31 @@ if test x"$pr_use_postgres" = xyes; then
   LIBS="$saved_libs"
 fi
 
-for modulename in $shared_modules ; do
-  module=$modulename".la"
-  moduledir=$modulename
+disp_shared_modules=""
+disp_static_modules=""
 
-  if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
-    continue
-
-  elif test -d $srcdir/modules/$moduledir; then
-    ac_shared_module_dirs="$ac_shared_module_dirs modules/$moduledir";
-    ac_shared_modules=`echo "$ac_shared_modules" | sed -e "s/$module//"`
-
-  elif test -d $srcdir/contrib/$moduledir; then
-    ac_shared_module_dirs="$ac_shared_module_dirs contrib/$moduledir";
-    ac_shared_modules=`echo "$ac_shared_modules" | sed -e "s/$module//"`
-  fi
-done
-
-for modulename in $static_modules ; do
-  module=$modulename".o"
-  moduledir=$modulename
-
-  if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
-    continue
-
-  elif test -d $srcdir/modules/$moduledir; then
-    ac_static_module_dirs="$ac_static_module_dirs modules/$moduledir";
-    static_modules=`echo "$static_modules" | sed -e "s/$modulename//"`
-
-  elif test -d $srcdir/contrib/$moduledir; then
-    ac_static_module_dirs="$ac_static_module_dirs contrib/$moduledir";
-    static_modules=`echo "$static_modules" | sed -e "s/$modulename//"`
-
-    addonlibs=""
-    src=`echo "$module" | sed -e 's/\.o$//'`.c;
-    srcinc=`echo "$module" | sed -e 's/\.o$//'`.h;
-
-    if test -f $srcdir/contrib/$moduledir/$src ; then
-      srcarch=`sed -n '/.*\$Archive: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$moduledir/$src"`
-      srclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$moduledir/$src"`
-    else
-      srcarch=
-      srclib=
-    fi
-
-    if test -f $srcdir/contrib/$moduledir/$srcinc ; then
-      if test -z $srcarch ; then
-        incarch=`sed -n '/.*\$Archive: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$moduledir/$srcinc"`
-      else
-        incarch=
-      fi
-
-      inclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$moduledir/$srcinc"`
-    else
-      incarch= 
-      inclib= 
-    fi
-
-    dnl If the module will be providing an archive (.a file), then remove it
-    dnl from the list of static module objects (.o files).
-    for thearch in $srcarch $incarch; do
-      archive=`echo "$thearch" | sed -e 's/\.a$//'`
-
-      if test x"$archive" != x"$moduledir" ; then
-        AC_MSG_ERROR([specified archive '$thearch' does not match expected module archive name '$moduledir.a' -- aborting])
-      fi
-
-      static_modules=`echo "$static_modules" | sed -e "s/$modulename//g"`
-      ac_build_static_module_archives="$ac_build_static_module_archives contrib/$moduledir/$thearch"
-    done
-
-    dnl Test for duplicate libraries, just in case.
-    for thelib in $srclib $inclib; do
-      dup="no"
-
-      for somelib in $ac_addl_libs $LIBS; do
-        if test "$thelib" = "$somelib"; then
-          dup="yes"
-          break
-        fi
-      done
-	
-      if test "$dup" = "no"; then
-        addonlibs="$addonlibs $thelib"
-      fi
-    done
-
-    test x"$addonlibs" = x || ac_addl_libs="$addonlibs $ac_addl_libs"
-  fi
-done
-
-dnl Yes, I know that this is not recommended Autoconf practice.  I doubt,
-dnl though, that many users will require the use of
-dnl `./configure --help=recursive' to see all of the options.
-if test ! -z "$ac_shared_module_dirs" ; then
-  AC_CONFIG_SUBDIRS($ac_shared_module_dirs)
-else
-  ac_shared_module_dirs="\"\""
-fi
-
-if test ! -z "$ac_static_module_dirs" ; then
-  AC_CONFIG_SUBDIRS($ac_static_module_dirs)
-else
-  ac_static_module_dirs="\"\""
-fi
-
-for module in $ac_shared_modules; do
+for module in $shared_modules ; do
   if test x"$enable_dso" != xyes ; then
     AC_MSG_ERROR([cannot build shared modules without DSO support -- aborting])
   fi
 
-  moduledir=`echo "$module" | sed -e 's/\.la$//'`;
-  src=`echo "$module" | sed -e 's/\.la$//'`.c;
-  srcinc=`echo "$module" | sed -e 's/\.la$//'`.h;
+  src=$module".c"
+  srcinc=$module".h"
+  moduleobj=$module".la"
+  disp_shared_modules+=" $module"
 
+  # Create lists for the makefiles
+  if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
+    ac_shared_module+=" $moduleobj"
+
+  elif test -d $srcdir/modules/$module; then
+    ac_shared_module_dirs+=" modules/$module";
+
+  elif test -d $srcdir/contrib/$module; then
+    ac_shared_module_dirs+=" contrib/$module";
+  fi
+
+  # Create symlinks
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
     if test ! -e $srcdir/modules/$src; then
       olddir=`pwd`
@@ -2785,7 +2696,7 @@ for module in $ac_shared_modules; do
       cd $olddir
     fi
 
-  elif test -d $srcdir/modules/$moduledir -o -d $srcdir/contrib/$moduledir; then
+  elif test -d $srcdir/modules/$module -o -d $srcdir/contrib/$module; then
     continue
 
   else
@@ -2793,37 +2704,64 @@ for module in $ac_shared_modules; do
   fi
 done
 
-for modulename in $static_modules; do
-  addonlibs=""
-  module=$modulename".o"
-  moduledir=$modulename
-  src=`echo "$module" | sed -e 's/\.o$//'`.c;
-  srcinc=`echo "$module" | sed -e 's/\.o$//'`.h;
+
+for module in $static_modules ; do
+  src=$module".c"
+  srcinc=$module".h"
+  moduleobj=$module".o"
+  disp_static_modules+=" $module"
 
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
+    ac_static_module+=" $moduleobj"
+
+  elif test -d $srcdir/modules/$module; then
+    ac_static_module_dirs+=" modules/$module"
+
+    # Create symlinks for source files
     if test ! -e $srcdir/modules/$src; then
-      olddir=`pwd`
-      cd $srcdir/modules
-      ln -s ../contrib/$src $src
-      cd $olddir
+      ln -s $srcdir/contrib/$src $srcdir/modules/$src
     fi
 
+  elif test -d $srcdir/contrib/$module; then
+    addonlibs=""
+    srcarch=
+    srclib=
+    incarch=
+    inclib= 
+
+    # Create symlinks for header files
     if test ! -f $srcdir/include/$srcinc -a -f $srcdir/contrib/$srcinc ; then
-      olddir=`pwd`
-      cd $srcdir/include
-      ln -s ../contrib/$srcinc $srcinc
-      cd $olddir
+      ln -s $srcdir/contrib/$srcinc $srcdir/include/$srcinc
     fi
 
-    srclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/modules/$src"`
-
-    if test -f $srcdir/include/$srcinc ; then
-      inclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/include/$srcinc"`
-    else
-      inclib= 
+    # Add required libraries and archives to appropriate lists
+    if test -f $srcdir/contrib/$module/$src ; then
+      srcarch=`sed -n '/.*\$Archive: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$module/$src"`
+      srclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$module/$src"`
     fi
 
-    dnl Test for duplicate libraries, just in case.
+    if test -f $srcdir/contrib/$module/$srcinc ; then
+      if test -z $srcarch ; then
+        incarch=`sed -n '/.*\$Archive: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$module/$srcinc"`
+      fi
+
+      inclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/contrib/$module/$srcinc"`
+    fi
+
+    # Does the module provide an archive (.a) or does it need to be added to static module list (.o)
+    addedarchives=0
+    for thearch in $srcarch $incarch; do
+      archive=${thearch/\.a/}
+
+      if test x"$archive" != x"$module" ; then
+        AC_MSG_ERROR([specified archive '$thearch' does not match expected module archive name '$module.a' -- aborting])
+      fi
+
+      ac_build_static_module_archives="$ac_build_static_module_archives contrib/$module/$thearch"
+      addedarchives+=1
+    done
+
+    # Test for duplicate libraries, just in case.
     for thelib in $srclib $inclib; do
       dup="no"
 
@@ -2841,10 +2779,48 @@ for modulename in $static_modules; do
 
     test x"$addonlibs" = x || ac_addl_libs="$addonlibs $ac_addl_libs"
 
+    # If there were no archives (.a) files for this module, add it to be compiled
+    if [ $addedarchives -eq 0 ]; then
+      ac_static_module_dirs+=" contrib/$module"
+    fi
+
+  fi
+
+  if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
+    addonlibs=""
+    inclib= 
+
+    # Add required libraries to list
+    srclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/modules/$src"`
+
+    if test -f $srcdir/include/$srcinc ; then
+      inclib=`sed -n '/.*\$Libraries: \(.*\)\$.*/s//\1/p' "$srcdir/include/$srcinc"`
+    fi
+
+    # Test for duplicate libraries, just in case.
+    for thelib in $srclib $inclib; do
+      dup="no"
+
+      for somelib in $ac_addl_libs $LIBS; do
+        if test "$thelib" = "$somelib"; then
+          dup="yes"
+          break
+        fi
+      done
+	
+      if test "$dup" = "no"; then
+        addonlibs="$addonlibs $thelib"
+      fi
+    done
+
+    test x"$addonlibs" = x || ac_addl_libs="$addonlibs $ac_addl_libs"
+  fi
+
+  if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
     adir=`cat $srcdir/modules/$src | grep "\\\$Directories:" | sed -e 's/^.*\$Directories: \(.*\)\\$/\1/'`
     test x"$adir" = x || ac_addl_dirs="$adir $ac_addl_dirs"
 
-  elif test -d $srcdir/modules/$moduledir -o -d $srcdir/contrib/$moduledir; then
+  elif test -d $srcdir/modules/$module -o -d $srcdir/contrib/$module; then
     continue
 
   else
@@ -2881,6 +2857,21 @@ for module in $core_modules; do
 done
 
 GLUE_MODULE_OBJS="$ac_core_modules $ac_static_modules"
+
+dnl Yes, I know that this is not recommended Autoconf practice.  I doubt,
+dnl though, that many users will require the use of
+dnl `./configure --help=recursive' to see all of the options.
+if test ! -z "$ac_shared_module_dirs" ; then
+  AC_CONFIG_SUBDIRS($ac_shared_module_dirs)
+else
+  ac_shared_module_dirs="\"\""
+fi
+
+if test ! -z "$ac_static_module_dirs" ; then
+  AC_CONFIG_SUBDIRS($ac_static_module_dirs)
+else
+  ac_static_module_dirs="\"\""
+fi
 
 dnl This is a nasty, cap-specific hack.  If we will be using the system
 dnl libcap (i.e. ac_have_libcap is "yes"), then we want to remove the
@@ -3091,23 +3082,27 @@ for moduledir in $ac_shared_module_dirs $ac_static_module_dirs; do
 done
 
 # Display a summary of what modules will be compiled
-disp_static=`echo "$ac_static_modules" | sed -e 's/\\.o//g'`;
-disp_shared=`echo "$ac_shared_modules" | sed -e 's/\\.la//g'`;
-
 echo
 echo "--------------"
 echo "Build Summary"
 echo "--------------"
+
+echo "Building the following core modules:"
+for amodule in $core_modules; do
+ echo "  $amodule"
+done
+echo
+
 echo "Building the following static modules:"
-for amodule in $disp_static; do
+for amodule in $disp_static_modules; do
  echo "  $amodule"
 done
-
 echo
+
 echo "Building the following shared modules:"
-for amodule in $disp_shared; do
+for amodule in $disp_shared_modules; do
  echo "  $amodule"
 done
-
 echo
+
 echo "--------------"

--- a/configure.in
+++ b/configure.in
@@ -2891,7 +2891,7 @@ for module in $shared_modules; do
 done
 
 for module in $ac_static_modules; do
-  ac_build_static_modules+=" /modules/$module.o"
+  ac_build_static_modules+=" /modules/$module"
 done
 
 for module in $ac_core_modules; do

--- a/configure.in
+++ b/configure.in
@@ -374,18 +374,12 @@ AC_ARG_WITH(modules,
         # into single colons; these are common typos.
         ac_static_modules=`echo "$withval" | sed 's/::/:/g' | sed 's/^://' | sed 's/:$//' | sed -e 's/:/.o /g'`.o ;
 
-        for amodule in $ac_static_modules; do
-          ac_build_static_modules="modules/$amodule $ac_build_static_modules"
-        done
 
         dnl Make sure that mod_ifsession, if present in the list, appears at
         dnl the end.
         if test x"$ifsession_requested" = xtrue; then
           ac_static_modules=`echo "$ac_static_modules" | sed -e 's/mod_ifsession\.o//g'`
           ac_static_modules="$ac_static_modules mod_ifsession.o"
-
-          ac_build_static_modules=`echo "$ac_build_static_modules" | sed -e 's/modules\/mod_ifsession\.o//g'`
-          ac_build_static_modules="$ac_build_static_modules modules/mod_ifsession.o";
         fi
       fi
     fi
@@ -397,7 +391,6 @@ if test x"$enable_memcache" = xyes; then
   # module list. Otherwise, the module load ordering will be such that
   # memcache support will not work as expected
   ac_static_modules="$ac_static_modules mod_memcache.o"
-  ac_build_static_modules="$ac_build_static_modules modules/mod_memcache.o"
 fi
 
 dnl List of modules which are not allowed to be built as DSOs
@@ -1335,7 +1328,6 @@ if test x"$enable_auth_pam" != xno ; then
     [
       if test `echo $ac_static_modules | grep -c mod_auth_pam` = "0"; then
         ac_static_modules="mod_auth_pam.o $ac_static_modules"
-        ac_build_static_modules="modules/mod_auth_pam.o $ac_build_static_modules"
       fi
     ], [],
     [
@@ -1405,12 +1397,8 @@ if test x"$ac_add_mod_cap" = xyes; then
     ac_static_modules=`echo "$ac_static_modules" | sed -e 's/mod_ifsession\.o//g'`
     ac_static_modules="$ac_static_modules mod_cap.o mod_ifsession.o"
 
-    ac_build_static_modules=`echo "$ac_build_static_modules" | sed -e 's/modules\/mod_ifsession\.o//g'`
-    ac_build_static_modules="$ac_build_static_modules modules/mod_cap.o modules/mod_ifsession.o";
-
   else
     ac_static_modules="$ac_static_modules mod_cap.o"
-    ac_build_static_modules="$ac_build_static_modules modules/mod_cap.o"
   fi
 fi
 
@@ -1790,13 +1778,11 @@ dnl Controls
 if test x"$enable_ctrls" = xyes; then
   AC_CHECK_FUNCS(getpeereid getpeerucred)
   ac_static_modules="$ac_static_modules mod_ctrls.o"
-  ac_build_static_modules="$ac_build_static_modules modules/mod_ctrls.o"
 fi
 
 dnl NLS/LANG support
 if test x"$enable_nls" = xyes; then
   ac_static_modules="$ac_static_modules mod_lang.o"
-  ac_build_static_modules="$ac_build_static_modules modules/mod_lang.o"
 fi
 
 dnl Controls-related checks
@@ -2181,7 +2167,6 @@ fi
 
 if test x"$enable_ident" != xno ; then
   ac_static_modules="mod_ident.o $ac_static_modules"
-  ac_build_static_modules="modules/mod_ident.o $ac_build_static_modules"
 fi
 
 dnl Check for various argv[] replacing functions on various OSs
@@ -2278,7 +2263,6 @@ for amodule in $ac_shared_modules; do
   ac_build_core_modules=`echo "$ac_build_core_modules" | sed -e "s/modules\/$module//g"`;
 
   ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//g"`;
-  ac_build_static_modules=`echo "$ac_build_static_modules" | sed -e "s/modules\/$module//g"`;
 done
 
 GLUE_MODULE_OBJS="$ac_core_modules $ac_static_modules"
@@ -2778,7 +2762,6 @@ for module in $ac_static_modules ; do
       fi
 
       ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//g"`
-      ac_build_static_modules=`echo "$ac_build_static_modules" | sed -e "s/modules\/$module//g"`
       ac_build_static_module_archives="$ac_build_static_module_archives contrib/$moduledir/$thearch"
     done
 
@@ -2905,6 +2888,10 @@ for module in $ac_static_modules; do
   else
     AC_MSG_ERROR([source file '$srcdir/modules/$src' cannot be found -- aborting])
   fi
+done
+
+for module in $ac_static_modules; do
+  ac_build_static_modules+=" /modules/$module.o"
 done
 
 dnl This is a nasty, cap-specific hack.  If we will be using the system

--- a/configure.in
+++ b/configure.in
@@ -364,7 +364,7 @@ AC_ARG_WITH(modules,
 
         # Trim off any leading/trailing colons, and collapse double-colons
         # into single colons; these are common typos.
-        ac_static_modules=`echo "$withval" | sed 's/::/:/g' | sed 's/^://' | sed 's/:$//' | sed -e 's/:/.o /g'`.o ;
+        static_modules=`echo "$withval" | sed 's/::/:/g'| sed 's/^://' | sed 's/:$//' | sed -e 's/:/ /g'`;
 
       fi
     fi
@@ -375,7 +375,7 @@ if test x"$enable_memcache" = xyes; then
   # Yes, we DO want mod_memcache AFTER the other modules in the static
   # module list. Otherwise, the module load ordering will be such that
   # memcache support will not work as expected
-  ac_static_modules="$ac_static_modules mod_memcache.o"
+  static_modules+=" mod_memcache"
 fi
 
 dnl List of modules which are not allowed to be built as DSOs
@@ -581,7 +581,7 @@ AC_ARG_ENABLE(auth-pam,
   ],
   [
     if test "$enableval" = "no"; then
-      if test `echo $ac_static_modules | grep -c mod_auth_pam` != "0"; then
+      if test `echo $static_modules | grep -c mod_auth_pam` != "0"; then
         AC_MSG_ERROR([You cannot run configure with --disable-auth-pam and include mod_auth_pam in --with-modules at the same time])
       fi
 
@@ -1308,8 +1308,8 @@ dnl really shouldn't have anything to do with force_shadow or use_shadow.
 if test x"$enable_auth_pam" != xno ; then
   AC_CHECK_HEADERS(security/pam_appl.h security/pam_modules.h pam/pam_appl.h,
     [
-      if test `echo $ac_static_modules | grep -c mod_auth_pam` = "0"; then
-        ac_static_modules="mod_auth_pam.o $ac_static_modules"
+      if test `echo $static_modules | grep -c mod_auth_pam` = "0"; then
+        static_modules+=" mod_auth_pam"
       fi
     ], [],
     [
@@ -1328,7 +1328,7 @@ if test x"$enable_auth_pam" != xno ; then
   dnl tag and is picked up at configure time.  The only thing we need is to
   dnl add -ldl in the event of broken PAM.
 
-  if test `echo $ac_static_modules | grep -c mod_auth_pam` = "1"; then
+  if test `echo $static_modules | grep -c mod_auth_pam` = "1"; then
 
 	AC_CHECK_LIB(pam, pam_start,
 		[AC_DEFINE(HAVE_PAM, 1, [Define if you have PAM support.])],
@@ -1372,7 +1372,7 @@ AC_MSG_CHECKING([whether to enable mod_cap])
 AC_MSG_RESULT($ac_add_mod_cap)
 
 if test x"$ac_add_mod_cap" = xyes; then
-    ac_static_modules="$ac_static_modules mod_cap.o"
+  static_modules+=" mod_cap"
 fi
 
 AC_CHECK_HEADERS(bstring.h crypt.h ctype.h execinfo.h iconv.h inttypes.h langinfo.h limits.h locale.h)
@@ -1750,12 +1750,12 @@ esac])
 dnl Controls
 if test x"$enable_ctrls" = xyes; then
   AC_CHECK_FUNCS(getpeereid getpeerucred)
-  ac_static_modules="$ac_static_modules mod_ctrls.o"
+  static_modules+=" mod_ctrls"
 fi
 
 dnl NLS/LANG support
 if test x"$enable_nls" = xyes; then
-  ac_static_modules="$ac_static_modules mod_lang.o"
+  static_modules+=" mod_lang"
 fi
 
 dnl Controls-related checks
@@ -2139,7 +2139,7 @@ if test x"$enable_nonblocking_log_open" != xno; then
 fi
 
 if test x"$enable_ident" != xno ; then
-  ac_static_modules="mod_ident.o $ac_static_modules"
+  static_modules+=" mod_ident"
 fi
 
 dnl Check for various argv[] replacing functions on various OSs
@@ -2233,13 +2233,12 @@ for amodule in $ac_shared_modules; do
 
   core_modules=`echo "$core_modules" | sed -e "s/$module//g"`;
 
-  ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module.o//g"`;
+  static_modules=`echo "$static_modules" | sed -e "s/$module//g"`;
 done
 
 dnl Check for any duplicates
-my_static_modules=`echo "$ac_static_modules" | sed -e 's/\.o//g'`;
 my_shared_modules=`echo "$ac_shared_modules" | sed -e 's/\.la//g'`;
-all_modules="$core_modules $my_static_modules $my_shared_modules";
+all_modules="$core_modules $static_modules $my_shared_modules";
 
 pr_use_mysql="no"
 pr_use_openssl="no"
@@ -2681,19 +2680,20 @@ for module in $ac_shared_modules ; do
   fi
 done
 
-for module in $ac_static_modules ; do
-  moduledir=`echo "$module" | sed -e 's/\.o$//'`;
+for modulename in $static_modules ; do
+  module=$moduledir".o"
+  moduledir=modulename
 
   if test -f $srcdir/modules/$src -o -f $srcdir/contrib/$src; then
     continue
 
   elif test -d $srcdir/modules/$moduledir; then
     ac_static_module_dirs="$ac_static_module_dirs modules/$moduledir";
-    ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//"`
+    static_modules=`echo "$static_modules" | sed -e "s/$modulename//"`
 
   elif test -d $srcdir/contrib/$moduledir; then
     ac_static_module_dirs="$ac_static_module_dirs contrib/$moduledir";
-    ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//"`
+    static_modules=`echo "$static_modules" | sed -e "s/$modulename//"`
 
     addonlibs=""
     src=`echo "$module" | sed -e 's/\.o$//'`.c;
@@ -2729,7 +2729,7 @@ for module in $ac_static_modules ; do
         AC_MSG_ERROR([specified archive '$thearch' does not match expected module archive name '$moduledir.a' -- aborting])
       fi
 
-      ac_static_modules=`echo "$ac_static_modules" | sed -e "s/$module//g"`
+      static_modules=`echo "$static_modules" | sed -e "s/$modulename//g"`
       ac_build_static_module_archives="$ac_build_static_module_archives contrib/$moduledir/$thearch"
     done
 
@@ -2800,9 +2800,10 @@ for module in $ac_shared_modules; do
   fi
 done
 
-for module in $ac_static_modules; do
+for modulename in $static_modules; do
   addonlibs=""
-  moduledir=`echo "$module" | sed -e 's/\.o$//'`;
+  module=$modulename".o"
+  moduledir=$modulename
   src=`echo "$module" | sed -e 's/\.o$//'`.c;
   srcinc=`echo "$module" | sed -e 's/\.o$//'`.h;
 
@@ -2860,14 +2861,14 @@ done
 
 # Make sure that mod_ifsession, if present in the list, appears at the end.
 if [[ -z "{$static_modules##*mod_ifsession*}" ]]; then
-  ac_static_modules=${static_modules/mod_ifsession\.o/}
-  ac_static_modules+=" mod_ifsession.o"
+  static_modules=${static_modules/mod_ifsession/}
+  static_modules+=" mod_ifsession"
 fi
 
 # Make sure that mod_ifsession, if present in the list, appears at the end, even after mod_ifsession.
 if [[ -z "{$static_modules##*mod_memcache*}" ]]; then
-  ac_static_modules=${static_modules/mod_memcache\.o/}
-  ac_static_modules+=" mod_memcache.o"
+  static_modules=${static_modules/mod_memcache/}
+  static_modules+=" mod_memcache"
 fi
 
 # Generate object-file lists for makefiles
@@ -2875,8 +2876,9 @@ for module in $shared_modules; do
   ac_build_shared_modules+=" modules/$module.la"
 done
 
-for module in $ac_static_modules; do
-  ac_build_static_modules+=" modules/$module"
+for module in $static_modules; do
+  ac_static_modules+=" $module.o"
+  ac_build_static_modules+=" modules/$module.o"
 done
 
 for module in $core_modules; do

--- a/configure.in
+++ b/configure.in
@@ -418,11 +418,10 @@ AC_ARG_WITH(shared,
         # Trim off any leading/trailing colons, and collapse double-colons
         # into single colons; these are common typos.
         shared_modules=`echo "$withval" | sed 's/::/:/g'| sed 's/^://' | sed 's/:$//' | sed -e 's/:/ /g'`;
-        ac_shared_modules=`echo "$withval" | sed 's/::/:/g'| sed 's/^://' | sed 's/:$//' | sed -e 's/:/.la /g'`.la;
 
         # First double-check that the given list does not contain any
         # unshareable modules
-        for amodule in $pr_shared_modules; do
+        for amodule in $shared_modules; do
           for smodule in $ac_unshareable_modules; do
             if test x"$amodule" = x"$smodule"; then
               AC_MSG_ERROR([cannot build $amodule as a shared module])
@@ -430,8 +429,9 @@ AC_ARG_WITH(shared,
           done
         done
 
-        for amodule in $ac_shared_modules; do
-          ac_build_shared_modules="modules/$amodule $ac_build_shared_modules"
+        for amodule in $shared_modules; do
+          ac_shared_modules+=" $amodule.la"
+          ac_build_shared_modules="modules/$amodule.la $ac_build_shared_modules"
         done
       fi
     fi


### PR DESCRIPTION
-Fixes a few errors in the code that might only trigger in corner cases
-Reorders some code to avoid having to duplicate code, and then forgetting to consider it when adding new code
-Reduces spawning of external processes
-Improves modules listing at the end of configure

The resulting makefiles are almost identical, except that BUILD_SHARED_MODULE_OBJS is reordered to match SHARED_MODULE_OBJS, this should not have any effect on the compile.

PS: This requires that autoconf is run to regenerate the configure script itself.