### PR TITLE
Issue #75: Add configure-time check for struct sockpeercred (as used on

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -82,6 +82,9 @@
 /* Define if you have struct sockcred.  */
 #undef HAVE_STRUCT_SOCKCRED
 
+/* Define if you have struct sockpeercred.  */
+#undef HAVE_STRUCT_SOCKPEERCRED
+
 /* Define if your spwd structure has member warn */
 #undef HAVE_SPWD_SP_WARN
 

--- a/configure
+++ b/configure
@@ -34003,6 +34003,132 @@ _ACEOF
 fi
 
 
+# See:
+#   https://github.com/proftpd/proftpd/issues/75
+{ echo "$as_me:$LINENO: checking for struct sockpeercred.uid" >&5
+echo $ECHO_N "checking for struct sockpeercred.uid... $ECHO_C" >&6; }
+if test "${ac_cv_member_struct_sockpeercred_uid+set}" = set; then
+  echo $ECHO_N "(cached) $ECHO_C" >&6
+else
+  cat >conftest.$ac_ext <<_ACEOF
+/* confdefs.h.  */
+_ACEOF
+cat confdefs.h >>conftest.$ac_ext
+cat >>conftest.$ac_ext <<_ACEOF
+/* end confdefs.h.  */
+
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    #if HAVE_SYS_UIO_H
+    # include <sys/uio.h>
+    #endif
+
+
+int
+main ()
+{
+static struct sockpeercred ac_aggr;
+if (ac_aggr.uid)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+rm -f conftest.$ac_objext
+if { (ac_try="$ac_compile"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
+  (eval "$ac_compile") 2>conftest.er1
+  ac_status=$?
+  grep -v '^ *+' conftest.er1 >conftest.err
+  rm -f conftest.er1
+  cat conftest.err >&5
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); } && {
+	 test -z "$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest.$ac_objext; then
+  ac_cv_member_struct_sockpeercred_uid=yes
+else
+  echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	cat >conftest.$ac_ext <<_ACEOF
+/* confdefs.h.  */
+_ACEOF
+cat confdefs.h >>conftest.$ac_ext
+cat >>conftest.$ac_ext <<_ACEOF
+/* end confdefs.h.  */
+
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    #if HAVE_SYS_UIO_H
+    # include <sys/uio.h>
+    #endif
+
+
+int
+main ()
+{
+static struct sockpeercred ac_aggr;
+if (sizeof ac_aggr.uid)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+rm -f conftest.$ac_objext
+if { (ac_try="$ac_compile"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
+  (eval "$ac_compile") 2>conftest.er1
+  ac_status=$?
+  grep -v '^ *+' conftest.er1 >conftest.err
+  rm -f conftest.er1
+  cat conftest.err >&5
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); } && {
+	 test -z "$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest.$ac_objext; then
+  ac_cv_member_struct_sockpeercred_uid=yes
+else
+  echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_cv_member_struct_sockpeercred_uid=no
+fi
+
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ echo "$as_me:$LINENO: result: $ac_cv_member_struct_sockpeercred_uid" >&5
+echo "${ECHO_T}$ac_cv_member_struct_sockpeercred_uid" >&6; }
+if test $ac_cv_member_struct_sockpeercred_uid = yes; then
+
+cat >>confdefs.h <<\_ACEOF
+#define HAVE_STRUCT_SOCKPEERCRED 1
+_ACEOF
+
+fi
+
+
 { echo "$as_me:$LINENO: checking for struct sockaddr_in.sin_len" >&5
 echo $ECHO_N "checking for struct sockaddr_in.sin_len... $ECHO_C" >&6; }
 if test "${ac_cv_member_struct_sockaddr_in_sin_len+set}" = set; then
@@ -38207,7 +38333,6 @@ LDFLAGS="$ac_orig_ldflags"
 
 INCLUDES="$ac_build_addl_includes"
 LIBDIRS="$ac_build_addl_libdirs"
-
 LIBRARIES="$ac_build_addl_libs"
 SHARED_MODULE_DIRS="$ac_shared_module_dirs"
 if test ! -z "$ac_shared_modules" ; then

--- a/configure.in
+++ b/configure.in
@@ -1828,6 +1828,22 @@ AC_CHECK_MEMBER(struct sockcred.sc_uid,
     #endif
   ])
 
+# See:
+#   https://github.com/proftpd/proftpd/issues/75
+AC_CHECK_MEMBER(struct sockpeercred.uid,
+  [AC_DEFINE(HAVE_STRUCT_SOCKPEERCRED, 1, [Define if you have struct sockpeercred])],,
+  [
+    #if HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #if HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    #if HAVE_SYS_UIO_H
+    # include <sys/uio.h>
+    #endif
+  ])
+
 dnl IPv4/IPv6-related checks
 AC_CHECK_MEMBER(struct sockaddr_in.sin_len,
   [AC_DEFINE(SIN_LEN, 1, [Define if you have sockaddr_in.sin_len])],,

--- a/src/ctrls.c
+++ b/src/ctrls.c
@@ -22,9 +22,7 @@
  * OpenSSL in the source distribution.
  */
 
-/* Controls API routines
- * $Id: ctrls.c,v 1.40 2013-05-28 21:02:02 castaglia Exp $
- */
+/* Controls API routines */
 
 #include "conf.h"
 #include "privs.h"
@@ -1216,10 +1214,15 @@ int pr_ctrls_issock_unix(mode_t sock_mode) {
 #if defined(SO_PEERCRED)
 static int ctrls_get_creds_peercred(int sockfd, uid_t *uid, gid_t *gid,
     pid_t *pid) {
+# if defined(HAVE_STRUCT_SOCKPEERCRED)
+  struct sockpeercred cred;
+# else
   struct ucred cred;
-  socklen_t credlen = sizeof(cred);
+# endif /* HAVE_STRUCT_SOCKPEERCRED */
+  socklen_t cred_len;
 
-  if (getsockopt(sockfd, SOL_SOCKET, SO_PEERCRED, &cred, &credlen) < 0) {
+  cred_len = sizeof(cred);
+  if (getsockopt(sockfd, SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) < 0) {
     int xerrno = errno;
 
     pr_trace_msg(trace_channel, 2,
@@ -1230,14 +1233,17 @@ static int ctrls_get_creds_peercred(int sockfd, uid_t *uid, gid_t *gid,
     return -1;
   }
 
-  if (uid)
+  if (uid) {
     *uid = cred.uid;
+  }
 
-  if (gid)
+  if (gid) {
     *gid = cred.gid;
+  }
 
-  if (pid)
+  if (pid) {
     *pid = cred.pid;
+  }
 
   return 0;
 }


### PR DESCRIPTION
OpenBSD systems), and update the Controls API to use this.
