### PR TITLE
Change the FSIO API's statcache from a single entry to one using tables.

### DIFF
--- a/contrib/mod_copy.c
+++ b/contrib/mod_copy.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_copy -- a module supporting copying of files on the server
  *                      without transferring the data to the client and back
  *
- * Copyright (c) 2009-2014 TJ Saunders
+ * Copyright (c) 2009-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ static int create_dir(const char *dir) {
   struct stat st;
   int res = -1;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(dir);
   res = pr_fsio_stat(dir, &st);
 
   if (res < 0 &&
@@ -84,10 +84,10 @@ static int create_path(pool *p, const char *path) {
   struct stat st;
   char *curr_path, *dup_path; 
  
-  pr_fs_clear_cache();
- 
-  if (pr_fsio_stat(path, &st) == 0)
+  pr_fs_clear_cache2(path);
+  if (pr_fsio_stat(path, &st) == 0) {
     return 0;
+  }
  
   dup_path = pstrdup(p, path);
 
@@ -280,7 +280,7 @@ static int copy_dir(pool *p, const char *src_dir, const char *dst_dir) {
 
           /* Write a TransferLog entry as well. */
 
-          pr_fs_clear_cache();
+          pr_fs_clear_cache2(dst_path);
           pr_fsio_stat(dst_path, &st);
 
           abs_path = dir_abs_path(p, dst_path, TRUE);
@@ -365,7 +365,7 @@ static int copy_paths(pool *p, const char *from, const char *to) {
   if (S_ISREG(st.st_mode)) { 
     char *abs_path;
 
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(to);
     res = pr_fsio_stat(to, &st);
     if (res == 0) {
       unsigned char *allow_overwrite;
@@ -391,7 +391,7 @@ static int copy_paths(pool *p, const char *from, const char *to) {
       return -1;
     }
 
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(to);
     if (pr_fsio_stat(to, &st) < 0) {
       pr_trace_msg(trace_channel, 3,
         "error stat'ing '%s': %s", to, strerror(errno));
@@ -436,7 +436,7 @@ static int copy_paths(pool *p, const char *from, const char *to) {
     }
 
   } else if (S_ISLNK(st.st_mode)) {
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(to);
     res = pr_fsio_stat(to, &st);
     if (res == 0) {
       unsigned char *allow_overwrite;

--- a/contrib/mod_quotatab.c
+++ b/contrib/mod_quotatab.c
@@ -1890,7 +1890,7 @@ MODRET quotatab_pre_appe(cmd_rec *cmd) {
   /* Briefly cache the size (in bytes) of the file being appended to, so that
    * if successful, the byte counts can be adjusted correctly.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) < 0) {
     quotatab_disk_nbytes = 0;
 
@@ -1923,7 +1923,7 @@ MODRET quotatab_post_appe(cmd_rec *cmd) {
    * in file size as the increment.  Make sure that no caching effects 
    * mess with the stat.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) >= 0) {
     append_bytes = st.st_size - quotatab_disk_nbytes;
 
@@ -2032,7 +2032,7 @@ MODRET quotatab_post_appe_err(cmd_rec *cmd) {
    * in file size as the increment.  Make sure that no caching effects 
    * mess with the stat.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) >= 0) {
     append_bytes = st.st_size - quotatab_disk_nbytes;
 
@@ -2188,7 +2188,7 @@ MODRET quotatab_pre_copy(cmd_rec *cmd) {
   /* Briefly cache the size (in bytes) of the file being overwritten, so that
    * if successful, the byte counts can be adjusted correctly.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->argv[2]);
   if (pr_fsio_stat(cmd->argv[2], &st) < 0) {
     quotatab_disk_nbytes = 0;
 
@@ -2263,7 +2263,7 @@ MODRET quotatab_post_copy(cmd_rec *cmd) {
     return PR_DECLINED(cmd);
   }
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->argv[2]);
   if (pr_fsio_stat(cmd->argv[2], &st) == 0) {
     if (quotatab_disk_nfiles == 0) {
 
@@ -2460,7 +2460,7 @@ MODRET quotatab_pre_dele(cmd_rec *cmd) {
     /* Briefly cache the size (in bytes) of the file to be deleted, so that
      * if successful, the byte counts can be adjusted correctly.
      */
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(path);
     if (pr_fsio_lstat(path, &quotatab_dele_st) < 0) {
       quotatab_disk_nbytes = 0;
 
@@ -3308,7 +3308,7 @@ MODRET quotatab_pre_rmd(cmd_rec *cmd) {
   /* Briefly cache the size (in bytes) of the directory to be deleted, so that
    * if successful, the byte counts can be adjusted correctly.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) < 0) {
     quotatab_disk_nbytes = 0;
 
@@ -3356,7 +3356,7 @@ MODRET quotatab_pre_rnto(cmd_rec *cmd) {
   /* Briefly cache the size (in bytes) of the file being overwritten, so that
    * if successful, the byte counts can be adjusted correctly.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) < 0) {
     quotatab_disk_nbytes = 0;
     quotatab_disk_nfiles = 0;
@@ -3487,7 +3487,7 @@ MODRET quotatab_pre_stor(cmd_rec *cmd) {
    * stat fails, it means that a new file is being uploaded, so set the
    * disk_nbytes to be zero. 
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) < 0) {
     quotatab_disk_nbytes = 0;
 
@@ -3537,7 +3537,7 @@ MODRET quotatab_post_stor(cmd_rec *cmd) {
    * in file size as the increment.  Make sure that no caching effects
    * mess with the stat.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(cmd->arg);
   if (pr_fsio_lstat(cmd->arg, &st) >= 0) {
     store_bytes = st.st_size - quotatab_disk_nbytes;
 
@@ -3707,7 +3707,7 @@ MODRET quotatab_post_stor_err(cmd_rec *cmd) {
      * in file size as the increment.  Make sure that no caching effects 
      * mess with the stat.
      */
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(cmd->arg);
     if (pr_fsio_lstat(cmd->arg, &st) >= 0) {
       store_bytes = st.st_size - quotatab_disk_nbytes;
 

--- a/contrib/mod_rewrite.c
+++ b/contrib/mod_rewrite.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_rewrite -- a module for rewriting FTP commands
  *
- * Copyright (c) 2001-2013 TJ Saunders
+ * Copyright (c) 2001-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -576,10 +576,11 @@ static unsigned char rewrite_match_cond(cmd_rec *cmd, config_rec *cond) {
       rewrite_log("rewrite_match_cond(): checking dir test cond against "
         "path '%s'", cond_str);
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(cond_str);
       if (pr_fsio_lstat(cond_str, &st) >= 0 &&
-          S_ISDIR(st.st_mode))
+          S_ISDIR(st.st_mode)) {
         res = TRUE;
+      }
 
       if (!negated)
         return res;
@@ -593,10 +594,11 @@ static unsigned char rewrite_match_cond(cmd_rec *cmd, config_rec *cond) {
       rewrite_log("rewrite_match_cond(): checking file test cond against "
         "path '%s'", cond_str);
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(cond_str);
       if (pr_fsio_lstat(cond_str, &st) >= 0 &&
-          S_ISREG(st.st_mode))
+          S_ISREG(st.st_mode)) {
         res = TRUE;
+      }
 
       if (!negated)
         return res;
@@ -610,10 +612,11 @@ static unsigned char rewrite_match_cond(cmd_rec *cmd, config_rec *cond) {
       rewrite_log("rewrite_match_cond(): checking symlink test cond against "
         "path '%s'", cond_str);
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(cond_str);
       if (pr_fsio_lstat(cond_str, &st) >= 0 &&
-          S_ISLNK(st.st_mode))
+          S_ISLNK(st.st_mode)) {
         res = TRUE;
+      }
 
       if (!negated)
         return res;
@@ -627,11 +630,12 @@ static unsigned char rewrite_match_cond(cmd_rec *cmd, config_rec *cond) {
       rewrite_log("rewrite_match_cond(): checking size test cond against "
         "path '%s'", cond_str);
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(cond_str);
       if (pr_fsio_lstat(cond_str, &st) >= 0 &&
           S_ISREG(st.st_mode) &&
-          st.st_size > 0)
+          st.st_size > 0) {
         res = TRUE;
+      }
 
       if (!negated)
         return res;

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -4277,7 +4277,7 @@ static int fxp_handle_ext_copy_file(struct fxp_packet *fxp, char *src,
   /* No errors. */
   xerrno = errno = 0;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(dst);
   pr_fsio_stat(dst, &st);
 
   pr_cmd_dispatch_phase(cmd, POST_CMD, 0);
@@ -6145,7 +6145,6 @@ static int fxp_handle_fstat(struct fxp_packet *fxp) {
   }
   pr_cmd_set_name(cmd, cmd_name);
 
-  pr_fs_clear_cache();
   if (pr_fsio_fstat(fxh->fh, &st) < 0) {
     uint32_t status_code;
     const char *reason;
@@ -6852,7 +6851,7 @@ static int fxp_handle_lstat(struct fxp_packet *fxp) {
   }
   pr_cmd_set_name(cmd, cmd_name);
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_lstat(path, &st) < 0) {
     uint32_t status_code;
     const char *reason;
@@ -10666,7 +10665,7 @@ static int fxp_handle_stat(struct fxp_packet *fxp) {
   }
   pr_cmd_set_name(cmd, cmd_name);
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) < 0) {
     uint32_t status_code;
     const char *reason;

--- a/contrib/mod_sftp/misc.c
+++ b/contrib/mod_sftp/misc.c
@@ -59,7 +59,6 @@ int sftp_misc_chown_file(pool *p, pr_fh_t *fh) {
           pr_uid2str(NULL, session.fsuid));
       }
 
-      pr_fs_clear_cache();
       if (pr_fsio_fstat(fh, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' fstat(2) error for root chmod: %s", fh->fh_path,
@@ -128,7 +127,6 @@ int sftp_misc_chown_file(pool *p, pr_fh_t *fh) {
         use_root_privs ? "root " : "", fh->fh_path,
         pr_gid2str(NULL, session.fsgid));
 
-      pr_fs_clear_cache();
       if (pr_fsio_fstat(fh, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' fstat(2) error for %sfchmod: %s", fh->fh_path,
@@ -192,7 +190,7 @@ int sftp_misc_chown_path(pool *p, const char *path) {
           pr_uid2str(NULL, session.fsuid));
       }
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(path);
       if (pr_fsio_stat(path, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' stat(2) error for root chmod: %s", path, strerror(errno));
@@ -260,7 +258,7 @@ int sftp_misc_chown_path(pool *p, const char *path) {
         use_root_privs ? "root " : "", path,
         pr_gid2str(NULL, session.fsgid));
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(path);
       if (pr_fsio_stat(path, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' stat(2) error for %schmod: %s", path,

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_site_misc -- a module implementing miscellaneous SITE commands
  *
- * Copyright (c) 2004-2014 The ProFTPD Project
+ * Copyright (c) 2004-2015 The ProFTPD Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,8 +57,7 @@ static int site_misc_create_dir(const char *dir) {
   struct stat st;
   int res;
 
-  pr_fs_clear_cache();
-
+  pr_fs_clear_cache2(dir);
   res = pr_fsio_stat(dir, &st);
   if (res < 0 &&
       errno != ENOENT) {
@@ -93,10 +92,10 @@ static int site_misc_create_path(pool *p, const char *path) {
   struct stat st;
   char *curr_path, *tmp_path;
 
-  pr_fs_clear_cache();
-
-  if (pr_fsio_stat(path, &st) == 0)
+  pr_fs_clear_cache2(path);
+  if (pr_fsio_stat(path, &st) == 0) {
     return 0;
+  }
 
   /* The given path should already be canonicalized; we do not need to worry
    * if it is relative to the current working directory or not.
@@ -312,10 +311,10 @@ static int site_misc_delete_dir(pool *p, const char *dir) {
 static int site_misc_delete_path(pool *p, const char *path) {
   struct stat st;
 
-  pr_fs_clear_cache();
-
-  if (pr_fsio_stat(path, &st) < 0)
+  pr_fs_clear_cache2(path);
+  if (pr_fsio_stat(path, &st) < 0) {
     return -1;
+  }
 
   if (!S_ISDIR(st.st_mode)) {
     errno = EINVAL;
@@ -867,7 +866,7 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
      * in the filesystem.
      */
        
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(src);
     res = pr_fsio_stat(src, &st);
     if (res < 0) {
       int xerrno = errno;

--- a/contrib/mod_snmp/mod_snmp.c
+++ b/contrib/mod_snmp/mod_snmp.c
@@ -423,7 +423,7 @@ static int snmp_mkdir(const char *dir, uid_t uid, gid_t gid, mode_t mode) {
   struct stat st;
   int res = -1;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(dir);
   res = pr_fsio_stat(dir, &st);
 
   if (res == -1 &&
@@ -461,7 +461,7 @@ static int snmp_mkpath(pool *p, const char *path, uid_t uid, gid_t gid,
   char *currpath = NULL, *tmppath = NULL;
   struct stat st;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) == 0) {
     /* Path already exists, nothing to be done. */
     errno = EEXIST;

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -2261,13 +2261,14 @@ MODRET sql_pre_dele(cmd_rec *cmd) {
     /* Briefly cache the size of the file being deleted, so that it can be
      * logged properly using %b.
      */
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(path);
     if (pr_fsio_stat(path, &st) < 0) {
       sql_log(DEBUG_INFO, "%s: unable to stat '%s': %s", cmd->argv[0],
         path, strerror(errno));
     
-    } else
+    } else {
       sql_dele_filesz = st.st_size;
+    }
   }
 
   return PR_DECLINED(cmd);

--- a/include/fsio.h
+++ b/include/fsio.h
@@ -312,7 +312,28 @@ int pr_insert_fs_match(pr_fs_match_t *);
 int pr_unregister_fs_match(const char *);
 #endif /* PR_USE_REGEX and PR_FS_MATCH */
 
+/* FS Statcache API */
 void pr_fs_clear_cache(void);
+int pr_fs_clear_cache2(const char *path);
+
+/* Dump the current contents of the statcache via trace logging, to the
+ * "fs.statcache" trace channel.
+ */
+void pr_fs_statcache_dump(void);
+
+/* Clears the entire statcache and re-creates the memory pool. */
+void pr_fs_statcache_reset(void);
+
+/* Tune the statcache defaults: max number of items in the cache at any
+ * one time, the max age (in seconds) for items in the cache, and the policy
+ * flags.
+ *
+ * Note that setting a size of zero, OR setting a max age of zero, effectively
+ * disables the statcache.
+ */
+int pr_fs_statcache_set(unsigned int size, unsigned int max_age,
+  unsigned int policy);
+
 int pr_fs_copy_file(const char *, const char *);
 int pr_fs_setcwd(const char *);
 const char *pr_fs_getcwd(void);

--- a/include/fsio.h
+++ b/include/fsio.h
@@ -324,15 +324,15 @@ void pr_fs_statcache_dump(void);
 /* Clears the entire statcache and re-creates the memory pool. */
 void pr_fs_statcache_reset(void);
 
-/* Tune the statcache defaults: max number of items in the cache at any
+/* Tune the statcache policy: max number of items in the cache at any
  * one time, the max age (in seconds) for items in the cache, and the policy
  * flags.
  *
  * Note that setting a size of zero, OR setting a max age of zero, effectively
  * disables the statcache.
  */
-int pr_fs_statcache_set(unsigned int size, unsigned int max_age,
-  unsigned int policy);
+int pr_fs_statcache_set_policy(unsigned int size, unsigned int max_age,
+  unsigned int flags);
 
 int pr_fs_copy_file(const char *, const char *);
 int pr_fs_setcwd(const char *);

--- a/include/options.h
+++ b/include/options.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2014 The ProFTPD Project team
+ * Copyright (c) 2001-2015 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,9 +24,7 @@
  * the source code for OpenSSL in the source distribution.
  */
 
-/* User configurable defaults and tunable parameters.
- * $Id: options.h,v 1.36 2014-01-25 16:34:09 castaglia Exp $
- */
+/* User configurable defaults and tunable parameters. */
 
 #ifndef PR_OPTIONS_H
 #define PR_OPTIONS_H
@@ -225,6 +223,15 @@
  * The default behavior is delay 0.2 secs between retries.
  */
 # define PR_TUNABLE_EINTR_RETRY_INTERVAL	0.2
+#endif
+
+/* FS Statcache tuning. */
+#ifndef PR_TUNABLE_FS_STATCACHE_SIZE
+# define PR_TUNABLE_FS_STATCACHE_SIZE		32
+#endif
+
+#ifndef PR_TUNABLE_FS_STATCACHE_MAX_AGE
+# define PR_TUNABLE_FS_STATCACHE_MAX_AGE	30
 #endif
 
 #endif /* PR_OPTIONS_H */

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -768,7 +768,7 @@ static int get_default_root(pool *p, int allow_symlinks, char **root) {
           path[pathlen-1] = '\0';
         }
 
-        pr_fs_clear_cache();
+        pr_fs_clear_cache2(path);
         res = pr_fsio_lstat(path, &st);
         if (res < 0) {
           xerrno = errno;
@@ -1262,7 +1262,7 @@ static int setup_env(pool *p, cmd_rec *cmd, char *user, char *pass) {
           chroot_path[chroot_pathlen-1] = '\0';
         }
 
-        pr_fs_clear_cache();
+        pr_fs_clear_cache2(chroot_path);
         res = pr_fsio_lstat(chroot_path, &st);
         if (res < 0) {
           int xerrno = errno;

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -3220,9 +3220,6 @@ MODRET core_pre_any(cmd_rec *cmd) {
   unsigned long cmd_delay = 0;
   char *rnfr_path = NULL;
 
-  /* Make sure any FS caches are clear before each command. */
-  pr_fs_clear_cache();
-
   /* Check for an exceeded MaxCommandRate. */
   cmd_delay = core_exceeded_cmd_rate(cmd);
   if (cmd_delay > 0) {
@@ -4659,18 +4656,17 @@ MODRET _chdir(cmd_rec *cmd, char *ndir) {
   unsigned char show_symlinks = TRUE, *tmp = NULL;
 
   odir = ndir;
-  pr_fs_clear_cache();
 
   tmp = get_param_ptr(TOPLEVEL_CONF, "ShowSymlinks", FALSE);
-  if (tmp != NULL)
+  if (tmp != NULL) {
     show_symlinks = *tmp;
+  }
 
   if (show_symlinks) {
     int use_cdpath = FALSE;
 
     dir = dir_realpath(cmd->tmp_pool, ndir);
-
-    if (!dir) {
+    if (dir == NULL) {
       use_cdpath = TRUE;
     }
 
@@ -4679,8 +4675,9 @@ MODRET _chdir(cmd_rec *cmd, char *ndir) {
 
       allowed_access = dir_check_full(cmd->tmp_pool, cmd, cmd->group, dir,
         NULL);
-      if (!allowed_access)
+      if (!allowed_access) {
         use_cdpath = TRUE;
+      }
     }
 
     if (!use_cdpath &&
@@ -5159,10 +5156,11 @@ MODRET core_size(cmd_rec *cmd) {
   }
 
   path = dir_realpath(cmd->tmp_pool, decoded_path);
+  if (path != NULL) {
+    pr_fs_clear_cache2(path);
+  }
 
-  pr_fs_clear_cache();
-
-  if (!path ||
+  if (path == NULL ||
       !dir_check(cmd->tmp_pool, cmd, cmd->group, path, NULL) ||
       pr_fsio_stat(path, &st) == -1) {
     int xerrno = errno;
@@ -5265,7 +5263,7 @@ MODRET core_dele(cmd_rec *cmd) {
    * so we need to use lstat(), not stat(), lest we log the wrong size.
    */
   memset(&st, 0, sizeof(st));
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_lstat(path, &st) < 0) {
     int xerrno = errno;
 
@@ -5400,7 +5398,7 @@ MODRET core_rnto(cmd_rec *cmd) {
   /* Deny the rename if AllowOverwrites are not allowed, and the destination
    * rename file already exists.
    */
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if ((!allow_overwrite || *allow_overwrite == FALSE) &&
       pr_fsio_stat(path, &st) == 0) {
     pr_log_debug(DEBUG6, "AllowOverwrite denied permission for %s", path);
@@ -5780,6 +5778,9 @@ MODRET core_post_pass(cmd_rec *cmd) {
     core_max_cmd_ts = 0;
   }
 
+  /* Reset the statcache, for the authenticated session. */
+  pr_fs_statcache_reset();
+
   /* Note: we MUST return HANDLED here, not DECLINED, to indicate that at
    * least one POST_CMD handler of the PASS command succeeded.  Since
    * mod_core is always the last module to which commands are dispatched,
@@ -5860,6 +5861,7 @@ static const char *core_get_xfer_bytes_str(void *data, size_t datasz) {
  */
 
 static void core_restart_ev(const void *event_data, void *user_data) {
+  pr_fs_statcache_reset();
   pr_scoreboard_scrub();
 
 #ifdef PR_USE_TRACE

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -5778,8 +5778,10 @@ MODRET core_post_pass(cmd_rec *cmd) {
     core_max_cmd_ts = 0;
   }
 
-  /* Reset the statcache, for the authenticated session. */
+  /* Configure the statcache to start caching for the authenticated session. */
   pr_fs_statcache_reset();
+  pr_fs_statcache_set_policy(PR_TUNABLE_FS_STATCACHE_SIZE,
+    PR_TUNABLE_FS_STATCACHE_MAX_AGE, 0);
 
   /* Note: we MUST return HANDLED here, not DECLINED, to indicate that at
    * least one POST_CMD handler of the PASS command succeeded.  Since

--- a/modules/mod_facl.c
+++ b/modules/mod_facl.c
@@ -70,13 +70,15 @@ static int sys_access(pr_fs_t *fs, const char *path, int mode, uid_t uid,
   mode_t mask;
   struct stat st;
 
-  pr_fs_clear_cache();
-  if (pr_fsio_stat(path, &st) < 0)
+  pr_fs_clear_cache2(path);
+  if (pr_fsio_stat(path, &st) < 0) {
     return -1;
+  }
 
   /* Root always succeeds. */
-  if (uid == PR_ROOT_UID)
+  if (uid == PR_ROOT_UID) {
     return 0;
+  }
 
   /* Initialize mask to reflect the permission bits that are applicable for
    * the given user. mask contains the user-bits if the user ID equals the
@@ -876,9 +878,10 @@ static int facl_fsio_access(pr_fs_t *fs, const char *path, int mode,
   struct stat st;
   void *acls;
 
-  pr_fs_clear_cache();
-  if (pr_fsio_stat(path, &st) < 0)
+  pr_fs_clear_cache2(path);
+  if (pr_fsio_stat(path, &st) < 0) {
     return -1;
+  }
 
   /* Look up the acl for this path. */
 # if defined(HAVE_BSD_POSIX_ACL) || defined(HAVE_LINUX_POSIX_ACL)
@@ -974,9 +977,9 @@ static int facl_fsio_faccess(pr_fh_t *fh, int mode, uid_t uid, gid_t gid,
   struct stat st;
   void *acls;
 
-  pr_fs_clear_cache();
-  if (pr_fsio_fstat(fh, &st) < 0)
+  if (pr_fsio_fstat(fh, &st) < 0) {
     return -1;
+  }
 
   /* Look up the acl for this fd. */
 # if defined(HAVE_BSD_POSIX_ACL) || defined(HAVE_LINUX_POSIX_ACL)

--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -386,7 +386,7 @@ static int facts_mlinfo_get(struct mlinfo *info, const char *path,
        * stat in order to ensure that the unique fact values are the same.
        */
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(path);
       res = pr_fsio_stat(path, &target_st);
       if (res < 0) {
         int xerrno = errno;
@@ -743,7 +743,7 @@ static int facts_modify_mtime(pool *p, const char *path, char *timestamp) {
        * enable the CAP_FOWNER capability for the session, or b) use root
        * privs.
        */
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(path);
       if (pr_fsio_stat(path, &st) < 0) {
         errno = xerrno;
         return -1;
@@ -1381,7 +1381,6 @@ MODRET facts_mlsd(cmd_rec *cmd) {
   }
   session.sf_flags |= SF_ASCII_OVERRIDE;
 
-  pr_fs_clear_cache();
   facts_mlinfobuf_init();
 
   while ((dent = pr_fsio_readdir(dirh)) != NULL) {
@@ -1579,7 +1578,7 @@ MODRET facts_mlst(cmd_rec *cmd) {
 
   info.pool = cmd->tmp_pool;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(decoded_path);
   if (facts_mlinfo_get(&info, decoded_path, decoded_path, flags, fake_uid,
       fake_gid, fake_mode) < 0) {
     pr_response_add_err(R_550, _("'%s' cannot be listed"), path);

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -2052,9 +2052,10 @@ MODRET log_pre_dele(cmd_rec *cmd) {
     /* Briefly cache the size of the file being deleted, so that it can be
      * logged properly using %b.
      */
-    pr_fs_clear_cache();
-    if (pr_fsio_stat(path, &st) == 0)
+    pr_fs_clear_cache2(path);
+    if (pr_fsio_stat(path, &st) == 0) {
       log_dele_filesz = st.st_size;
+    }
   }
 
   return PR_DECLINED(cmd);

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -512,7 +512,7 @@ static int listfile(cmd_rec *cmd, pool *p, const char *resp_code,
       /* Attempt to fully dereference symlink */
       struct stat l_st;
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(name);
       if (pr_fsio_stat(name, &l_st) != -1) {
         memcpy(&st, &l_st, sizeof(struct stat));
 
@@ -1720,8 +1720,9 @@ static int have_options(cmd_rec *cmd, const char *arg) {
    * options.
    */
 
-  if (cmd->argc > 2)
+  if (cmd->argc > 2) {
     return TRUE;
+  }
 
   /* Now we need to determine if the given string (arg) should be handled
    * as options (as when the target path is implied, e.g. "LIST -al") or
@@ -1729,11 +1730,12 @@ static int have_options(cmd_rec *cmd, const char *arg) {
    * then it's a path.
    */
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(arg);
   res = pr_fsio_stat(arg, &st);
 
-  if (res == 0)
+  if (res == 0) {
     return FALSE;
+  }
 
   return TRUE;
 }
@@ -1865,7 +1867,7 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
     if (pr_str_is_fnmatch(target) == FALSE) {
       struct stat st;
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(target);
       if (pr_fsio_stat(target, &st) < 0) {
         int xerrno = errno;
 
@@ -2698,7 +2700,7 @@ MODRET ls_stat(cmd_rec *cmd) {
   opt_C = opt_d = opt_F = opt_R = 0;
   opt_a = opt_l = opt_STAT = 1;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(arg && *arg ? arg : ".");
   res = pr_fsio_stat(arg && *arg ? arg : ".", &st);
   if (res < 0) {
     int xerrno = errno;
@@ -3138,7 +3140,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
     /* Make sure the target is a file or directory, and that we have access
      * to it.
      */
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(target);
     if (pr_fsio_stat(target, &st) < 0) {
       int xerrno = errno;
 

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -836,7 +836,7 @@ static void stor_chown(pool *p) {
           pr_uid2str(p, session.fsuid));
       }
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(xfer_path);
       if (pr_fsio_stat(xfer_path, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' stat(2) error during root chmod: %s", xfer_path,
@@ -903,7 +903,7 @@ static void stor_chown(pool *p) {
         use_root_privs ? "root " : "", xfer_path,
         pr_gid2str(p, session.fsgid));
 
-      pr_fs_clear_cache();
+      pr_fs_clear_cache2(xfer_path);
       if (pr_fsio_stat(xfer_path, &st) < 0) {
         pr_log_debug(DEBUG0,
           "'%s' stat(2) error during %schmod: %s", xfer_path,

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -1854,7 +1854,7 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
   int res = 1, isfile;
   int op_hidden = FALSE, regex_hidden = FALSE;
 
-  if (!path) {
+  if (path == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -1864,8 +1864,9 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
 
   fullpath = (char *) path;
 
-  if (session.chroot_path)
+  if (session.chroot_path) {
     fullpath = pdircat(p, session.chroot_path, fullpath, NULL);
+  }
 
   if (*path) {
     /* Only log this debug line if we are dealing with a real path. */
@@ -1874,10 +1875,10 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
   }
 
   /* Check and build all appropriate dynamic configuration entries */
-  pr_fs_clear_cache();
   isfile = pr_fsio_stat(path, &st);
-  if (isfile == -1)
+  if (isfile < 0) {
     memset(&st, '\0', sizeof(st));
+  }
 
   build_dyn_config(p, path, &st, TRUE);
 
@@ -2025,8 +2026,9 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
 
   fullpath = (char *) path;
 
-  if (session.chroot_path)
+  if (session.chroot_path) {
     fullpath = pdircat(p, session.chroot_path, fullpath, NULL);
+  }
 
   c = (session.dir_config ? session.dir_config :
         (session.anon_config ? session.anon_config : NULL));
@@ -2037,10 +2039,10 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
   }
 
   /* Check and build all appropriate dynamic configuration entries */
-  pr_fs_clear_cache();
   isfile = pr_fsio_stat(path, &st);
-  if (isfile == -1)
+  if (isfile < 0) {
     memset(&st, 0, sizeof(st));
+  }
 
   build_dyn_config(p, path, &st, FALSE);
 

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -1894,8 +1894,9 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
       session.dir_config->name, fullpath);
   }
 
-  if (!c && session.anon_config)
+  if (!c && session.anon_config) {
     c = session.anon_config;
+  }
 
   /* Make sure this cmd_rec has a cmd_id. */
   if (cmd->cmd_id == 0) {
@@ -1927,8 +1928,9 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     struct passwd *pw;
 
     pw = pr_auth_getpwnam(p, owner);
-    if (pw != NULL)
+    if (pw != NULL) {
       session.fsuid = pw->pw_uid;
+    }
   }
 
   owner = get_param_ptr(CURRENT_CONF, "GroupOwner", FALSE);
@@ -1967,8 +1969,9 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     /* If specifically allowed, res will be > 1 and we don't want to
      * check the command group limit.
      */
-    if (res == 1 && group)
+    if (res == 1 && group) {
       res = dir_check_limits(cmd, c, group, op_hidden || regex_hidden);
+    }
 
     /* If still == 1, no explicit allow so check lowest priority "ALL" group.
      * Note that certain commands are deliberately excluded from the
@@ -2016,7 +2019,7 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
   int res = 1, isfile;
   int op_hidden = FALSE, regex_hidden = FALSE;
 
-  if (!path) {
+  if (path == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -2058,8 +2061,9 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
       session.dir_config->name, fullpath);
   }
 
-  if (!c && session.anon_config)
+  if (!c && session.anon_config) {
     c = session.anon_config;
+  }
 
   /* Make sure this cmd_rec has a cmd_id. */
   if (cmd->cmd_id == 0) {
@@ -2091,8 +2095,9 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     struct passwd *pw;
 
     pw = pr_auth_getpwnam(p, owner);
-    if (pw != NULL)
+    if (pw != NULL) {
       session.fsuid = pw->pw_uid;
+    }
   }
 
   owner = get_param_ptr(CURRENT_CONF, "GroupOwner", FALSE);
@@ -2129,8 +2134,9 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     /* If specifically allowed, res will be > 1 and we don't want to
      * check the command group limit.
      */
-    if (res == 1 && group)
+    if (res == 1 && group) {
       res = dir_check_limits(cmd, c, group, op_hidden || regex_hidden);
+    }
 
     /* If still == 1, no explicit allow so check lowest priority "ALL" group.
      * Note that certain commands are deliberately excluded from the

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -369,7 +369,6 @@ static int sys_access(pr_fs_t *fs, const char *path, int mode, uid_t uid,
   mode_t mask;
   struct stat st;
 
-  pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) < 0) {
     return -1;
   }

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -785,6 +785,11 @@ static int cache_stat(pr_fs_t *fs, const char *path, struct stat *st,
 
   /* Update the cache */
   res = fs_statcache_add(pathbuf, path_len, st, errno, retval, now);
+  if (res < 0) {
+    pr_trace_msg(statcache_channel, 6,
+      "error adding cached stat for '%s': %s", pathbuf, strerror(errno));
+  }
+
   return retval;
 }
 

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -560,9 +560,9 @@ struct fs_statcache_evict_data {
 static const char *statcache_channel = "fs.statcache";
 static pool *statcache_pool = NULL;
 static pr_table_t *statcache_tab = NULL;
-static unsigned int statcache_size = PR_TUNABLE_FS_STATCACHE_SIZE;
-static unsigned int statcache_max_age = PR_TUNABLE_FS_STATCACHE_MAX_AGE;
-static unsigned int statcache_policy = 0;
+static unsigned int statcache_size = 0;
+static unsigned int statcache_max_age = 0;
+static unsigned int statcache_flags = 0;
 
 #define fs_cache_lstat(f, p, s) cache_stat((f), (p), (s), FSIO_FILE_LSTAT)
 #define fs_cache_stat(f, p, s) cache_stat((f), (p), (s), FSIO_FILE_STAT)
@@ -1035,12 +1035,12 @@ void pr_fs_statcache_reset(void) {
   statcache_tab = pr_table_alloc(statcache_pool, 0);
 }
 
-int pr_fs_statcache_set(unsigned int size, unsigned int max_age, 
-    unsigned int policy) {
+int pr_fs_statcache_set_policy(unsigned int size, unsigned int max_age, 
+    unsigned int flags) {
 
   statcache_size = size;
   statcache_max_age = max_age;
-  statcache_policy = policy;
+  statcache_flags = flags;
 
   return 0;
 }

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -24,9 +24,7 @@
  * the source code for OpenSSL in the source distribution.
  */
 
-/* ProFTPD virtual/modular file-system support
- * $Id: fsio.c,v 1.159 2014-02-11 15:17:54 castaglia Exp $
- */
+/* ProFTPD virtual/modular file-system support */
 
 #include "conf.h"
 #include "privs.h"
@@ -94,7 +92,9 @@ static unsigned char chk_fs_map = FALSE;
 
 /* Virtual working directory */
 static char vwd[PR_TUNABLE_PATH_MAX + 1] = "/";
+
 static char cwd[PR_TUNABLE_PATH_MAX + 1] = "/";
+static size_t cwd_len = 1;
 
 static int fsio_guard_chroot = FALSE;
 
@@ -369,7 +369,7 @@ static int sys_access(pr_fs_t *fs, const char *path, int mode, uid_t uid,
   mode_t mask;
   struct stat st;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) < 0) {
     return -1;
   }
@@ -544,29 +544,179 @@ static int fs_cmp(const void *a, const void *b) {
 }
 
 /* Statcache stuff */
-typedef struct {
-  char sc_path[PR_TUNABLE_PATH_MAX+1];
-  size_t sc_pathlen;
+struct fs_statcache {
+  pool *sc_pool;
   struct stat sc_stat;
   int sc_errno;
   int sc_retval;
+  time_t sc_cached_ts;
+};
 
-} fs_statcache_t;
+struct fs_statcache_evict_data {
+  time_t now;
+  time_t max_age;
+};
 
-static fs_statcache_t statcache;
+static const char *statcache_channel = "fs.statcache";
+static pool *statcache_pool = NULL;
+static pr_table_t *statcache_tab = NULL;
+static unsigned int statcache_size = PR_TUNABLE_FS_STATCACHE_SIZE;
+static unsigned int statcache_max_age = PR_TUNABLE_FS_STATCACHE_MAX_AGE;
+static unsigned int statcache_policy = 0;
 
 #define fs_cache_lstat(f, p, s) cache_stat((f), (p), (s), FSIO_FILE_LSTAT)
 #define fs_cache_stat(f, p, s) cache_stat((f), (p), (s), FSIO_FILE_STAT)
 
-static int cache_stat(pr_fs_t *fs, const char *path, struct stat *sbuf,
+static struct fs_statcache *fs_statcache_get(const char *path,
+    size_t path_len, time_t now) {
+  struct fs_statcache *sc = NULL;
+
+  if (pr_table_count(statcache_tab) == 0) {
+    errno = EPERM;
+    return NULL;
+  }
+
+  sc = pr_table_get(statcache_tab, path, NULL);
+  if (sc != NULL) {
+    time_t age;
+
+    /* If this item hasn't expired yet, return it, otherwise, remove it. */
+    age = now - sc->sc_cached_ts;
+    if (age <= statcache_max_age) {
+      pr_trace_msg(statcache_channel, 19,
+        "using cached entry for '%s' (age %lu %s)", path,
+        (unsigned long) age, age != 1 ? "secs" : "sec");
+      return sc;
+    }
+
+    pr_trace_msg(statcache_channel, 14,
+      "entry for '%s' expired (age %lu %s > max age %lu), removing", path,
+      (unsigned long) age, age != 1 ? "secs" : "sec",
+      (unsigned long) statcache_max_age);
+    (void) pr_table_remove(statcache_tab, path, NULL);
+  }
+
+  errno = ENOENT;
+  return NULL;
+}
+
+static int fs_statcache_evict_expired(const void *key_data, size_t key_datasz,
+    void *value_data, size_t value_datasz, void *user_data) {
+  struct fs_statcache *sc;
+  struct fs_statcache_evict_data *evict_data;
+  time_t age;
+
+  sc = value_data;
+  evict_data = user_data;
+
+  age = evict_data->now - sc->sc_cached_ts;
+  if (age > evict_data->max_age) {
+    pr_trace_msg(statcache_channel, 14,
+      "entry for '%s' expired (age %lu %s > max age %lu), evicting",
+      (char *) key_data, (unsigned long) age, age != 1 ? "secs" : "sec",
+      (unsigned long) evict_data->max_age);
+    (void) pr_table_kremove(statcache_tab, key_data, key_datasz, NULL);
+  }
+
+  return 0;
+}
+
+static int fs_statcache_evict(time_t now) {
+  int res;
+  struct fs_statcache_evict_data evict_data;
+
+  /* We try to make room in two passes.  First, evict any item that has
+   * exceeded the maximum age.  After that, if we are still not low enough,
+   * lower the maximum age, and try again.  If not enough room by then, then
+   * we'll try again on the next stat.
+   */
+ 
+  evict_data.now = now; 
+  evict_data.max_age = statcache_max_age;
+
+  res = pr_table_do(statcache_tab, fs_statcache_evict_expired, &evict_data,
+    PR_TABLE_DO_FL_ALL);
+  if (res < 0) {
+    pr_trace_msg(statcache_channel, 4,
+      "error evicting expired items: %s", strerror(errno));
+  }
+
+  if (pr_table_count(statcache_tab) < statcache_size) {
+    return 0;
+  }
+
+  /* Try for a shorter max age. */
+  if (statcache_max_age > 10) {
+    evict_data.max_age = (statcache_max_age - 10);
+    res = pr_table_do(statcache_tab, fs_statcache_evict_expired, &evict_data,
+      PR_TABLE_DO_FL_ALL);
+    if (res < 0) {
+      pr_trace_msg(statcache_channel, 4,
+        "error evicting expired items: %s", strerror(errno));
+    }
+  }
+
+  if (pr_table_count(statcache_tab) < statcache_size) {
+    return 0;
+  }
+
+  pr_trace_msg(statcache_channel, 14,
+    "still not enough room in cache (size %d >= max %d)",
+    pr_table_count(statcache_tab), statcache_size);
+  errno = EPERM;
+  return -1;
+}
+
+static int fs_statcache_add(const char *path, size_t path_len, struct stat *st,
+    int xerrno, int retval, time_t now) {
+  int res;
+  pool *sc_pool;
+  struct fs_statcache *sc;
+
+  if (statcache_size == 0 ||
+      statcache_max_age == 0) {
+    /* Caching disabled; nothing to do here. */
+    return 0;
+  }
+
+  if (pr_table_count(statcache_tab) >= statcache_size) {
+    /* We've reached capacity, and need to evict some items to make room. */
+    if (fs_statcache_evict(now) < 0) {
+      pr_trace_msg(statcache_channel, 8,
+        "unable to evict enough items from the cache: %s", strerror(errno));
+    }
+  }
+
+  sc_pool = pr_pool_create_sz(statcache_pool, 10 * 1024);
+  pr_pool_tag(sc_pool, "FS statcache entry pool");
+  sc = pcalloc(sc_pool, sizeof(struct fs_statcache));
+  sc->sc_pool = sc_pool;
+  sc->sc_errno = xerrno;
+  sc->sc_retval = retval;
+  sc->sc_cached_ts = now;
+
+  res = pr_table_add(statcache_tab, pstrndup(sc_pool, path, path_len), sc,
+    sizeof(struct fs_statcache *));
+  if (res < 0 &&
+      errno == EEXIST) {
+    res = 0;
+  }
+
+  return res;
+}
+
+static int cache_stat(pr_fs_t *fs, const char *path, struct stat *st,
     unsigned int op) {
-  int res = -1;
+  int res = -1, retval;
   char pathbuf[PR_TUNABLE_PATH_MAX + 1];
   int (*mystat)(pr_fs_t *, const char *, struct stat *) = NULL;
-  size_t pathlen;
+  size_t path_len;
+  struct fs_statcache *sc = NULL;
+  time_t now;
 
   /* Sanity checks */
-  if (fs == NULL) {
+  if (fs == NULL ||
+      st == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -576,24 +726,29 @@ static int cache_stat(pr_fs_t *fs, const char *path, struct stat *sbuf,
     return -1;
   }
 
+  now = time(NULL);
   memset(pathbuf, '\0', sizeof(pathbuf));
 
   /* Use only absolute path names.  Construct them, if given a relative
    * path, based on cwd.  This obviates the need for something like
-   * realpath(3), which only introduces more stat system calls.
+   * realpath(3), which only introduces more stat(2) system calls.
    */
   if (*path != '/') {
+    size_t pathbuf_len;
+
     sstrcat(pathbuf, cwd, sizeof(pathbuf)-1);
+    pathbuf_len = cwd_len;
 
     /* If the cwd is "/", we don't need to duplicate the path separator. 
      * On some systems (e.g. Cygwin), this duplication can cause problems,
      * as the path may then have different semantics.
      */
     if (strncmp(cwd, "/", 2) != 0) {
-      sstrcat(pathbuf, "/", sizeof(pathbuf)-1);
+      sstrcat(pathbuf + pathbuf_len, "/", sizeof(pathbuf) - pathbuf_len - 1);
+      pathbuf_len++;
     }
 
-    sstrcat(pathbuf, path, sizeof(pathbuf)-1);
+    sstrcat(pathbuf + pathbuf_len, path, sizeof(pathbuf)- pathbuf_len - 1);
 
   } else {
     sstrncpy(pathbuf, path, sizeof(pathbuf)-1);
@@ -607,38 +762,31 @@ static int cache_stat(pr_fs_t *fs, const char *path, struct stat *sbuf,
     mystat = fs->lstat ? fs->lstat : sys_lstat;
   }
 
-  pathlen = strlen(pathbuf);
+  path_len = strlen(pathbuf);
 
-  /* Can the last cached stat be used? */
-  if (pathlen == statcache.sc_pathlen &&
-      strncmp(pathbuf, statcache.sc_path, pathlen + 1) == 0) {
+  sc = fs_statcache_get(pathbuf, path_len, now);
+  if (sc != NULL) {
 
     /* Update the given struct stat pointer with the cached info */
-    memcpy(sbuf, &statcache.sc_stat, sizeof(struct stat));
+    memcpy(st, &(sc->sc_stat), sizeof(struct stat));
 
     pr_trace_msg(trace_channel, 8, "using cached stat for %s for path '%s'",
       op == FSIO_FILE_STAT ? "stat()" : "lstat()", path);
 
     /* Use the cached errno as well */
-    errno = statcache.sc_errno;
+    errno = sc->sc_errno;
 
-    return statcache.sc_retval;
+    return sc->sc_retval;
   }
 
   pr_trace_msg(trace_channel, 8, "using %s %s for path '%s'",
     fs ? fs->fs_name : "system",
     op == FSIO_FILE_STAT ? "stat()" : "lstat()", path);
-  res = mystat(fs, pathbuf, sbuf);
+  retval = mystat(fs, pathbuf, st);
 
   /* Update the cache */
-  memset(statcache.sc_path, '\0', sizeof(statcache.sc_path));
-  sstrncpy(statcache.sc_path, pathbuf, sizeof(statcache.sc_path));
-  memcpy(&statcache.sc_stat, sbuf, sizeof(struct stat));
-  statcache.sc_pathlen = pathlen;
-  statcache.sc_errno = errno;
-  statcache.sc_retval = res;
-
-  return res;
+  res = fs_statcache_add(pathbuf, path_len, st, errno, retval, now);
+  return retval;
 }
 
 /* Lookup routines */
@@ -845,11 +993,87 @@ static pr_fs_t *lookup_file_canon_fs(const char *path, char **deref, int op) {
   return lookup_file_fs(workpath, deref, op);
 }
 
-/* FS functions proper */
+/* FS Statcache API */
+
+static void statcache_dumpf(const char *fmt, ...) {
+  char buf[PR_TUNABLE_BUFFER_SIZE];
+  va_list msg;
+
+  memset(buf, '\0', sizeof(buf));
+
+  va_start(msg, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, msg);
+  va_end(msg);
+
+  buf[sizeof(buf)-1] = '\0';
+  (void) pr_trace_msg(statcache_channel, 9, "%s", buf);
+}
+
+void pr_fs_statcache_dump(void) {
+  pr_table_dump(statcache_dumpf, statcache_tab);
+}
+
+void pr_fs_statcache_reset(void) {
+  if (statcache_tab != NULL) {
+    int size;
+
+    size = pr_table_count(statcache_tab);
+    pr_trace_msg(statcache_channel, 11,
+      "resetting statcache (clearing %d %s)", size,
+      size != 1 ? "entries" : "entry");
+    pr_table_empty(statcache_tab);
+    pr_table_free(statcache_tab);
+    statcache_tab = NULL;
+  }
+
+  if (statcache_pool != NULL) {
+    destroy_pool(statcache_pool);
+    statcache_pool = make_sub_pool(permanent_pool);
+    pr_pool_tag(statcache_pool, "FS Statcache Pool");
+  }
+
+  statcache_tab = pr_table_alloc(statcache_pool, 0);
+}
+
+int pr_fs_statcache_set(unsigned int size, unsigned int max_age, 
+    unsigned int policy) {
+
+  statcache_size = size;
+  statcache_max_age = max_age;
+  statcache_policy = policy;
+
+  return 0;
+}
+
+int pr_fs_clear_cache2(const char *path) {
+  int res;
+
+  if (path != NULL) {
+    int count;
+
+    count = pr_table_exists(statcache_tab, path);
+    if (count == 0) {
+      return 0;
+    }
+
+    pr_table_remove(statcache_tab, path, NULL);
+    res = count;
+
+  } else {
+    /* Caller is requesting that we empty the entire cache. */
+
+    (void) pr_table_empty(statcache_tab);
+    res = 0;
+  }
+
+  return res;
+}
 
 void pr_fs_clear_cache(void) {
-  memset(&statcache, '\0', sizeof(statcache));
+  (void) pr_fs_clear_cache2(NULL);
 }
+
+/* FS functions proper */
 
 int pr_fs_copy_file(const char *src, const char *dst) {
   pr_fh_t *src_fh, *dst_fh;
@@ -912,7 +1136,7 @@ int pr_fs_copy_file(const char *src, const char *dst) {
    */
   if (pr_fsio_stat(dst, &dst_st) == 0) {
     dst_existed = TRUE;
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(dst);
   }
 
   /* Use a nonblocking open() for the path; it could be a FIFO, and we don't
@@ -1707,6 +1931,7 @@ int pr_fs_setcwd(const char *dir) {
 
   fs_cwd = lookup_dir_fs(cwd, FSIO_DIR_CHDIR);
   cwd[sizeof(cwd) - 1] = '\0';
+  cwd_len = strlen(cwd);
 
   return 0;
 }
@@ -3440,22 +3665,37 @@ int pr_fsio_rmdir(const char *path) {
   return res;
 }
 
-int pr_fsio_stat_canon(const char *path, struct stat *sbuf) {
-  pr_fs_t *fs = lookup_file_canon_fs(path, NULL, FSIO_FILE_STAT);
+int pr_fsio_stat_canon(const char *path, struct stat *st) {
+  pr_fs_t *fs;
+
+  if (path == NULL ||
+      st == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fs = lookup_file_canon_fs(path, NULL, FSIO_FILE_STAT);
 
   /* Find the first non-NULL custom stat handler.  If there are none,
    * use the system stat.
    */
-  while (fs && fs->fs_next && !fs->stat)
+  while (fs && fs->fs_next && !fs->stat) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s stat() for path '%s'",
     fs ? fs->fs_name : "system", path);
-  return fs_cache_stat(fs ? fs : root_fs, path, sbuf);
+  return fs_cache_stat(fs ? fs : root_fs, path, st);
 }
 
-int pr_fsio_stat(const char *path, struct stat *sbuf) {
-  pr_fs_t *fs;
+int pr_fsio_stat(const char *path, struct stat *st) {
+  pr_fs_t *fs = NULL;
+
+  if (path == NULL ||
+      st == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_fs(path, NULL, FSIO_FILE_STAT);
   if (fs == NULL) {
@@ -3465,19 +3705,21 @@ int pr_fsio_stat(const char *path, struct stat *sbuf) {
   /* Find the first non-NULL custom stat handler.  If there are none,
    * use the system stat.
    */
-  while (fs && fs->fs_next && !fs->stat)
+  while (fs && fs->fs_next && !fs->stat) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s stat() for path '%s'", fs->fs_name,
     path);
-  return fs_cache_stat(fs ? fs : root_fs, path, sbuf);
+  return fs_cache_stat(fs ? fs : root_fs, path, st);
 }
 
-int pr_fsio_fstat(pr_fh_t *fh, struct stat *sbuf) {
+int pr_fsio_fstat(pr_fh_t *fh, struct stat *st) {
   int res;
   pr_fs_t *fs;
 
-  if (!fh) {
+  if (fh == NULL ||
+      st == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -3486,32 +3728,48 @@ int pr_fsio_fstat(pr_fh_t *fh, struct stat *sbuf) {
    * use the system fstat.
    */
   fs = fh->fh_fs;
-  while (fs && fs->fs_next && !fs->fstat)
+  while (fs && fs->fs_next && !fs->fstat) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s fstat() for path '%s'", fs->fs_name,
     fh->fh_path);
-  res = (fs->fstat)(fh, fh->fh_fd, sbuf);
+  res = (fs->fstat)(fh, fh->fh_fd, st);
 
   return res;
 }
 
-int pr_fsio_lstat_canon(const char *path, struct stat *sbuf) {
-  pr_fs_t *fs = lookup_file_canon_fs(path, NULL, FSIO_FILE_LSTAT);
+int pr_fsio_lstat_canon(const char *path, struct stat *st) {
+  pr_fs_t *fs;
+
+  if (path == NULL ||
+      st == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fs = lookup_file_canon_fs(path, NULL, FSIO_FILE_LSTAT);
 
   /* Find the first non-NULL custom lstat handler.  If there are none,
    * use the system lstat.
    */
-  while (fs && fs->fs_next && !fs->lstat)
+  while (fs && fs->fs_next && !fs->lstat) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s lstat() for path '%s'",
     fs ? fs->fs_name : "system", path);
-  return fs_cache_lstat(fs ? fs : root_fs, path, sbuf);
+  return fs_cache_lstat(fs ? fs : root_fs, path, st);
 }
 
-int pr_fsio_lstat(const char *path, struct stat *sbuf) {
+int pr_fsio_lstat(const char *path, struct stat *st) {
   pr_fs_t *fs;
+
+  if (path == NULL ||
+      st == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_fs(path, NULL, FSIO_FILE_LSTAT);
   if (fs == NULL) {
@@ -3521,12 +3779,13 @@ int pr_fsio_lstat(const char *path, struct stat *sbuf) {
   /* Find the first non-NULL custom lstat handler.  If there are none,
    * use the system lstat.
    */
-  while (fs && fs->fs_next && !fs->lstat)
+  while (fs && fs->fs_next && !fs->lstat) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s lstat() for path '%s'", fs->fs_name,
     path);
-  return fs_cache_lstat(fs ? fs : root_fs, path, sbuf);
+  return fs_cache_lstat(fs ? fs : root_fs, path, st);
 }
 
 int pr_fsio_readlink_canon(const char *path, char *buf, size_t buflen) {
@@ -4204,6 +4463,11 @@ int pr_fsio_chmod_canon(const char *name, mode_t mode) {
   char *deref = NULL;
   pr_fs_t *fs;
 
+  if (name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
   fs = lookup_file_canon_fs(name, &deref, FSIO_FILE_CHMOD);
   if (fs == NULL) {
     return -1;
@@ -4212,15 +4476,17 @@ int pr_fsio_chmod_canon(const char *name, mode_t mode) {
   /* Find the first non-NULL custom chmod handler.  If there are none,
    * use the system chmod.
    */
-  while (fs && fs->fs_next && !fs->chmod)
+  while (fs && fs->fs_next && !fs->chmod) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s chmod() for path '%s'",
     fs->fs_name, name);
   res = (fs->chmod)(fs, deref, mode);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(name);
+  }
 
   return res;
 }
@@ -4228,6 +4494,11 @@ int pr_fsio_chmod_canon(const char *name, mode_t mode) {
 int pr_fsio_chmod(const char *name, mode_t mode) {
   int res;
   pr_fs_t *fs;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_fs(name, NULL, FSIO_FILE_CHMOD);
   if (fs == NULL) {
@@ -4237,15 +4508,17 @@ int pr_fsio_chmod(const char *name, mode_t mode) {
   /* Find the first non-NULL custom chmod handler.  If there are none,
    * use the system chmod.
    */
-  while (fs && fs->fs_next && !fs->chmod)
+  while (fs && fs->fs_next && !fs->chmod) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s chmod() for path '%s'",
     fs->fs_name, name);
   res = (fs->chmod)(fs, name, mode);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(name);
+  }
 
   return res;
 }
@@ -4263,15 +4536,17 @@ int pr_fsio_fchmod(pr_fh_t *fh, mode_t mode) {
    * the system fchmod.
    */
   fs = fh->fh_fs;
-  while (fs && fs->fs_next && !fs->fchmod)
+  while (fs && fs->fs_next && !fs->fchmod) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s fchmod() for path '%s'",
     fs->fs_name, fh->fh_path);
   res = (fs->fchmod)(fh, fh->fh_fd, mode);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(fh->fh_path);
+  }
 
   return res;
 }
@@ -4279,6 +4554,11 @@ int pr_fsio_fchmod(pr_fh_t *fh, mode_t mode) {
 int pr_fsio_chown_canon(const char *name, uid_t uid, gid_t gid) {
   int res;
   pr_fs_t *fs;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_canon_fs(name, NULL, FSIO_FILE_CHOWN);
   if (fs == NULL) {
@@ -4288,15 +4568,17 @@ int pr_fsio_chown_canon(const char *name, uid_t uid, gid_t gid) {
   /* Find the first non-NULL custom chown handler.  If there are none,
    * use the system chown.
    */
-  while (fs && fs->fs_next && !fs->chown)
+  while (fs && fs->fs_next && !fs->chown) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s chown() for path '%s'",
     fs->fs_name, name);
   res = (fs->chown)(fs, name, uid, gid);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(name);
+  }
 
   return res;
 }
@@ -4304,6 +4586,11 @@ int pr_fsio_chown_canon(const char *name, uid_t uid, gid_t gid) {
 int pr_fsio_chown(const char *name, uid_t uid, gid_t gid) {
   int res;
   pr_fs_t *fs;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_fs(name, NULL, FSIO_FILE_CHOWN);
   if (fs == NULL) {
@@ -4313,15 +4600,17 @@ int pr_fsio_chown(const char *name, uid_t uid, gid_t gid) {
   /* Find the first non-NULL custom chown handler.  If there are none,
    * use the system chown.
    */
-  while (fs && fs->fs_next && !fs->chown)
+  while (fs && fs->fs_next && !fs->chown) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s chown() for path '%s'",
     fs->fs_name, name);
   res = (fs->chown)(fs, name, uid, gid);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(name);
+  }
 
   return res;
 }
@@ -4330,7 +4619,7 @@ int pr_fsio_fchown(pr_fh_t *fh, uid_t uid, gid_t gid) {
   int res;
   pr_fs_t *fs;
 
-  if (!fh) {
+  if (fh == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -4339,15 +4628,17 @@ int pr_fsio_fchown(pr_fh_t *fh, uid_t uid, gid_t gid) {
    * the system fchown.
    */
   fs = fh->fh_fs;
-  while (fs && fs->fs_next && !fs->fchown)
+  while (fs && fs->fs_next && !fs->fchown) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s fchown() for path '%s'",
     fs->fs_name, fh->fh_path);
   res = (fs->fchown)(fh, fh->fh_fd, uid, gid);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(fh->fh_path);
+  }
 
   return res;
 }
@@ -4355,6 +4646,11 @@ int pr_fsio_fchown(pr_fh_t *fh, uid_t uid, gid_t gid) {
 int pr_fsio_lchown(const char *name, uid_t uid, gid_t gid) {
   int res;
   pr_fs_t *fs;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
   fs = lookup_file_fs(name, NULL, FSIO_FILE_CHOWN);
   if (fs == NULL) {
@@ -4373,7 +4669,7 @@ int pr_fsio_lchown(const char *name, uid_t uid, gid_t gid) {
   res = (fs->lchown)(fs, name, uid, gid);
 
   if (res == 0) {
-    pr_fs_clear_cache();
+    pr_fs_clear_cache2(name);
   }
 
   return res;
@@ -4443,15 +4739,17 @@ int pr_fsio_utimes(const char *path, struct timeval *tvs) {
   /* Find the first non-NULL custom utimes handler.  If there are none,
    * use the system utimes.
    */
-  while (fs && fs->fs_next && !fs->utimes)
+  while (fs && fs->fs_next && !fs->utimes) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s utimes() for path '%s'",
     fs->fs_name, path);
   res = (fs->utimes)(fs, path, tvs);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(path);
+  }
 
   return res;
 }
@@ -4470,15 +4768,17 @@ int pr_fsio_futimes(pr_fh_t *fh, struct timeval *tvs) {
    * use the system futimes.
    */
   fs = fh->fh_fs;
-  while (fs && fs->fs_next && !fs->futimes)
+  while (fs && fs->fs_next && !fs->futimes) {
     fs = fs->fs_next;
+  }
 
   pr_trace_msg(trace_channel, 8, "using %s futimes() for path '%s'",
     fs->fs_name, fh->fh_path);
   res = (fs->futimes)(fh, fh->fh_fd, tvs);
 
-  if (res == 0)
-    pr_fs_clear_cache();
+  if (res == 0) {
+    pr_fs_clear_cache2(fh->fh_path);
+  }
 
   return res;
 }
@@ -5262,7 +5562,9 @@ int init_fs(void) {
   }
 
   /* Prepare the stat cache as well. */
-  memset(&statcache, '\0', sizeof(statcache));
+  statcache_pool = make_sub_pool(permanent_pool);
+  pr_pool_tag(statcache_pool, "FS Statcache Pool");
+  statcache_tab = pr_table_alloc(statcache_pool, 0);
 
   return 0;
 }

--- a/src/mkhome.c
+++ b/src/mkhome.c
@@ -36,7 +36,7 @@ static int create_dir(const char *dir, uid_t uid, gid_t gid,
   struct stat st;
   int res = -1;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(dir);
   res = pr_fsio_stat(dir, &st);
 
   if (res == -1 &&
@@ -97,7 +97,7 @@ static int create_path(pool *p, const char *path, const char *user,
   char *currpath = NULL, *tmppath = NULL;
   struct stat st;
 
-  pr_fs_clear_cache();
+  pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) == 0) {
     /* Path already exists, nothing to be done. */
     errno = EEXIST;

--- a/src/support.c
+++ b/src/support.c
@@ -443,14 +443,22 @@ static mode_t _symlink(const char *path, ino_t last_inode, int rcount) {
 }
 
 mode_t symlink_mode(const char *path) {
-  _symlink(path, (ino_t) 0, 0);
+  if (path == NULL) {
+    return 0;
+  }
+
+  return _symlink(path, (ino_t) 0, 0);
 }
 
 mode_t file_mode(const char *path) {
   struct stat sbuf;
   mode_t res = 0;
 
-  pr_fs_clear_cache();
+  if (path == NULL) {
+    return res;
+  }
+
+  pr_fs_clear_cache2(path);
   if (pr_fsio_lstat(path, &sbuf) != -1) {
     if (S_ISLNK(sbuf.st_mode)) {
       res = _symlink(path, (ino_t) 0, 0);

--- a/src/table.c
+++ b/src/table.c
@@ -680,16 +680,18 @@ void *pr_table_kremove(pr_table_t *tab, const void *key_data,
 
   for (ent = head; ent; ent = ent->next) {
     if (ent->key == NULL ||
-        ent->key->hash != h)
+        ent->key->hash != h) {
       continue;
+    }
 
     /* Matching hashes.  Now to see if the keys themselves match. */
     if (tab->keycmp(ent->key->key_data, ent->key->key_datasz,
         key_data, key_datasz) == 0) {
       void *value_data = ent->value_data;
 
-      if (value_datasz)
+      if (value_datasz) {
         *value_datasz = ent->value_datasz;
+      }
 
       tab_entry_remove(tab, ent);
       tab_entry_free(tab, ent);
@@ -878,19 +880,25 @@ int pr_table_do(pr_table_t *tab, int (*cb)(const void *key_data,
     void *user_data, int flags) {
   register unsigned int i;
 
-  if (!tab || !cb) {
+  if (tab == NULL ||
+      cb == NULL) {
     errno = EINVAL;
     return -1;
   }
 
-  if (tab->nents == 0)
+  if (tab->nents == 0) {
     return 0;
+  }
 
   for (i = 0; i < tab->nchains; i++) {
-    pr_table_entry_t *ent = tab->chains[i];
+    pr_table_entry_t *ent;
 
+    ent = tab->chains[i];
     while (ent) {
+      pr_table_entry_t *next_ent;
       int res;
+
+      next_ent = ent->next;
 
       if (!handling_signal) { 
         pr_signals_handle();
@@ -904,7 +912,7 @@ int pr_table_do(pr_table_t *tab, int (*cb)(const void *key_data,
         return -1;
       }
 
-      ent = ent->next;
+      ent = next_ent;
     }
   }
 
@@ -1018,7 +1026,8 @@ void *pr_table_next(pr_table_t *tab) {
 void *pr_table_remove(pr_table_t *tab, const char *key_data,
     size_t *value_datasz) {
 
-  if (!tab || !key_data) {
+  if (tab == NULL ||
+      key_data == NULL) {
     errno = EINVAL;
     return NULL;
   }

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -314,30 +314,36 @@ START_TEST (fsio_access_dir_test) {
 
   /* First, check that we ourselves can access our own directory. */
 
+  pr_fs_clear_cache2(fsio_access_dir_path);
   res = pr_fsio_access(fsio_access_dir_path, F_OK, uid, gid, NULL);
   fail_unless(res == 0, "Failed to check for file access on directory: %s",
     strerror(errno));
 
+  pr_fs_clear_cache2(fsio_access_dir_path);
   res = pr_fsio_access(fsio_access_dir_path, R_OK, uid, gid, NULL);
   fail_unless(res == 0, "Failed to check for read access on directory: %s",
     strerror(errno));
 
+  pr_fs_clear_cache2(fsio_access_dir_path);
   res = pr_fsio_access(fsio_access_dir_path, W_OK, uid, gid, NULL);
   fail_unless(res == 0, "Failed to check for read access on directory: %s",
     strerror(errno));
 
+  pr_fs_clear_cache2(fsio_access_dir_path);
   res = pr_fsio_access(fsio_access_dir_path, X_OK, uid, gid, NULL);
   fail_unless(res == 0, "Failed to check for execute access on directory: %s",
     strerror(errno));
 
   if (getenv("TRAVIS_CI") == NULL) {
     /* Next, check that others can access the directory. */
+    pr_fs_clear_cache2(fsio_access_dir_path);
     res = pr_fsio_access(fsio_access_dir_path, F_OK, other_uid, other_gid,
       NULL);
     fail_unless(res == 0,
       "Failed to check for other file access on directory: %s",
       strerror(errno));
 
+    pr_fs_clear_cache2(fsio_access_dir_path);
     res = pr_fsio_access(fsio_access_dir_path, R_OK, other_uid, other_gid,
       NULL);
     fail_unless(res < 0,
@@ -345,6 +351,7 @@ START_TEST (fsio_access_dir_test) {
     fail_unless(errno == EACCES, "Expected EACCES, got %s (%d)",
       strerror(errno), errno);
 
+    pr_fs_clear_cache2(fsio_access_dir_path);
     res = pr_fsio_access(fsio_access_dir_path, W_OK, other_uid, other_gid,
       NULL);
     fail_unless(res < 0,
@@ -352,6 +359,7 @@ START_TEST (fsio_access_dir_test) {
     fail_unless(errno == EACCES, "Expected EACCES, got %s (%d)",
       strerror(errno), errno);
 
+    pr_fs_clear_cache2(fsio_access_dir_path);
     res = pr_fsio_access(fsio_access_dir_path, X_OK, other_uid, other_gid,
       NULL);
     fail_unless(res == 0, "Failed to check for execute access on directory: %s",

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -39,7 +39,7 @@ static void set_up(void) {
   }
 
   init_fs();
-  pr_fs_statcache_set(PR_TUNABLE_FS_STATCACHE_SIZE,
+  pr_fs_statcache_set_policy(PR_TUNABLE_FS_STATCACHE_SIZE,
     PR_TUNABLE_FS_STATCACHE_MAX_AGE, 0);
 
   if (getenv("TEST_VERBOSE") != NULL) {
@@ -54,7 +54,7 @@ static void tear_down(void) {
     permanent_pool = NULL;
   }
 
-  pr_fs_statcache_set(PR_TUNABLE_FS_STATCACHE_SIZE,
+  pr_fs_statcache_set_policy(PR_TUNABLE_FS_STATCACHE_SIZE,
     PR_TUNABLE_FS_STATCACHE_MAX_AGE, 0);
   if (getenv("TEST_VERBOSE") != NULL) {
     pr_trace_set_levels("fs.statcache", 0, 0);
@@ -365,7 +365,7 @@ END_TEST
 START_TEST (fsio_stat_test) {
   int res;
   struct stat st;
-  unsigned int item_count = 3, max_age = 1, policy = 0;
+  unsigned int cache_size = 3, max_age = 1, policy_flags = 0;
 
   res = pr_fsio_stat(NULL, &st);
   fail_unless(res < 0, "Failed to handle null path");
@@ -377,7 +377,7 @@ START_TEST (fsio_stat_test) {
   fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
-  res = pr_fs_statcache_set(item_count, max_age, policy);
+  res = pr_fs_statcache_set_policy(cache_size, max_age, policy_flags);
   fail_unless(res == 0, "Failed to set statcache policy: %s", strerror(errno));
 
   res = pr_fsio_stat("/foo/bar/baz/quxx", &st);
@@ -403,7 +403,7 @@ END_TEST
 START_TEST (fsio_lstat_test) {
   int res;
   struct stat st;
-  unsigned int item_count = 3, max_age = 1, policy = 0;
+  unsigned int cache_size = 3, max_age = 1, policy_flags = 0;
 
   res = pr_fsio_lstat(NULL, &st);
   fail_unless(res < 0, "Failed to handle null path");
@@ -415,7 +415,7 @@ START_TEST (fsio_lstat_test) {
   fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
-  res = pr_fs_statcache_set(item_count, max_age, policy);
+  res = pr_fs_statcache_set_policy(cache_size, max_age, policy_flags);
   fail_unless(res == 0, "Failed to set statcache policy: %s", strerror(errno));
 
   res = pr_fsio_lstat("/foo/bar/baz/quxx", &st);


### PR DESCRIPTION
This cache now holds up to a configurable size, with expiration, and allows
clearing of single entries (or the entire cache if needed).