### PR TITLE
Fix the setting of FTP response codes for the internal commands that

### DIFF
--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -7183,6 +7183,8 @@ static int fxp_handle_mkdir(struct fxp_packet *fxp) {
   fxp_status_write(&buf, &buflen, fxp->request_id, status_code,
     fxp_strerror(status_code), NULL);
 
+  pr_response_add(R_257, "\"%s\" - Directory successfully created",
+    quote_dir(cmd->tmp_pool, path));
   pr_cmd_dispatch_phase(cmd, POST_CMD, 0);
   pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
 

--- a/include/support.h
+++ b/include/support.h
@@ -66,6 +66,12 @@ char *dir_canonical_path(pool *, const char *);
 char *dir_canonical_vpath(pool *, const char *);
 char *dir_best_path(pool *, const char *);
 
+/* Per RFC959, directory responses for MKD and PWD should be
+ * "dir_name" (w/ quote).  For directories that CONTAIN quotes,
+ * the add'l quotes must be duplicated.
+ */
+const char *quote_dir(pool *p, char *dir);
+
 /* Schedulables. */
 void schedule(void (*f)(void *, void *, void *, void *), int, void *, void *,
   void *, void *);

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -3403,14 +3403,6 @@ MODRET core_log_quit(cmd_rec *cmd) {
   return PR_HANDLED(cmd);
 }
 
-/* Per RFC959, directory responses for MKD and PWD should be
- * "dir_name" (w/ quote).  For directories that CONTAIN quotes,
- * the add'l quotes must be duplicated.
- */
-static const char *quote_dir(cmd_rec *cmd, char *dir) {
-  return sreplace(cmd->tmp_pool, dir, "\"", "\"\"", NULL);
-}
-
 MODRET core_pwd(cmd_rec *cmd) {
   CHECK_CMD_ARGS(cmd, 1);
 
@@ -3425,7 +3417,7 @@ MODRET core_pwd(cmd_rec *cmd) {
   }
 
   pr_response_add(R_257, _("\"%s\" is the current directory"),
-    quote_dir(cmd, pr_fs_encode_path(cmd->tmp_pool, session.vwd)));
+    quote_dir(cmd->tmp_pool, pr_fs_encode_path(cmd->tmp_pool, session.vwd)));
 
   return PR_HANDLED(cmd);
 }
@@ -5090,7 +5082,7 @@ MODRET core_mkd(cmd_rec *cmd) {
   }
 
   pr_response_add(R_257, _("\"%s\" - Directory successfully created"),
-    quote_dir(cmd, dir));
+    quote_dir(cmd->tmp_pool, dir));
 
   return PR_HANDLED(cmd);
 }

--- a/src/support.c
+++ b/src/support.c
@@ -116,6 +116,16 @@ void pr_signals_unblock(void) {
   sigs_nblocked--;
 }
 
+const char *quote_dir(pool *p, char *path) {
+  if (p == NULL ||
+      path == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  return sreplace(p, path, "\"", "\"\"", NULL);
+}
+
 void schedule(void (*f)(void*,void*,void*,void*),int nloops, void *a1,
     void *a2, void *a3, void *a4) {
   pool *p, *sub_pool;

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
@@ -124,7 +124,12 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
-  site_misc_extlog_rmdir_resp_code => {
+  site_misc_extlog_rmdir_resp_code_empty_dir => {
+    order => ++$order,
+    test_class => [qw(forking)],
+  },
+
+  site_misc_extlog_rmdir_resp_code_nonempty_dir => {
     order => ++$order,
     test_class => [qw(forking)],
   },
@@ -3037,7 +3042,7 @@ sub site_misc_utime_atime_mtime_ctime_with_spaces_bug4130 {
   unlink($log_file);
 }
 
-sub site_misc_extlog_rmdir_resp_code {
+sub site_misc_extlog_rmdir_resp_code_empty_dir {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -3103,7 +3108,7 @@ sub site_misc_extlog_rmdir_resp_code {
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
 
-    LogFormat => 'custom "%m: %s"',
+    LogFormat => 'custom "%r: %s"',
     ExtendedLog => "$extlog_file MISC custom",
 
     IfModules => {
@@ -3187,7 +3192,11 @@ sub site_misc_extlog_rmdir_resp_code {
       while (my $line = <$fh>) {
         chomp($line);
 
-        if ($line eq 'SITE RMDIR: 200') {
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# line: $line\n"
+        }
+
+        if ($line =~ /SITE RMDIR (\S+): 200/) {
           $ok = 1;
           last;
         }
@@ -3196,6 +3205,199 @@ sub site_misc_extlog_rmdir_resp_code {
       close($fh);
 
       $self->assert($ok, "ExtendedLog did not contain expected log line");
+    } else {
+      die("Can't read $extlog_file: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  if ($ex) {
+    die($ex);
+  }
+
+  unlink($log_file);
+}
+
+sub site_misc_extlog_rmdir_resp_code_nonempty_dir {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  my $config_file = "$tmpdir/site.conf";
+  my $pid_file = File::Spec->rel2abs("$tmpdir/site.pid");
+  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/site.scoreboard");
+  my $extlog_file = File::Spec->rel2abs("$tmpdir/ext.log");
+
+  my $log_file = File::Spec->rel2abs('tests.log');
+
+  my $auth_user_file = File::Spec->rel2abs("$tmpdir/site.passwd");
+  my $auth_group_file = File::Spec->rel2abs("$tmpdir/site.group");
+
+  my $user = 'proftpd';
+  my $passwd = 'test';
+  my $group = 'ftpd';
+  my $home_dir = File::Spec->rel2abs($tmpdir);
+  my $uid = 500;
+  my $gid = 500;
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/foo/bar/baz");
+  mkpath($sub_dir);
+
+  my $test_dirs = [
+    File::Spec->rel2abs("$tmpdir/foo"),
+    File::Spec->rel2abs("$tmpdir/foo/bar"),
+    $sub_dir,
+  ];
+
+  my $test_file = File::Spec->rel2abs("$tmpdir/foo/bar/quxx.txt");
+  if (open(my $fh, "> $test_file")) {
+    print $fh "Quzz\n";
+
+    unless (close($fh)) {
+      die("Can't write $test_file: $!");
+    }
+
+  } else {
+    die("Can't open $test_file: $!");
+  }
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $home_dir)) {
+      die("Can't set perms on $home_dir to 0755: $!");
+    }
+
+    unless (chown($uid, $gid, $home_dir)) {
+      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    }
+  }
+
+  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
+    '/bin/bash');
+  auth_group_write($auth_group_file, $group, $gid, $user);
+
+  my $config = {
+    PidFile => $pid_file,
+    ScoreboardFile => $scoreboard_file,
+    SystemLog => $log_file,
+
+    AuthUserFile => $auth_user_file,
+    AuthGroupFile => $auth_group_file,
+
+    LogFormat => 'custom "%r: %s"',
+    ExtendedLog => "$extlog_file ALL custom",
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($user, $passwd);
+
+      my ($resp_code, $resp_msg) = $client->site('RMDIR', 'foo');
+
+      my $expected;
+
+      $expected = 200;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "SITE RMDIR command successful";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      # Make sure that the test file is gone, along with all of the
+      # test dirs.
+      if (-f $test_file) {
+        die("File $test_file exists, should be deleted");
+      }
+
+      foreach my $test_dir (@$test_dirs) {
+        if (-d $test_dir) {
+          die("Directory $test_dir exists, should be deleted");
+        }
+      }
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($config_file, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($pid_file);
+
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $extlog_file")) {
+      my $dele_ok = 0;
+      my $rmd_ok = 0;
+      my $site_ok = 0;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# line: $line\n"
+        }
+
+        if ($line =~ /DELE .*?250$/) {
+          $dele_ok = 1;
+          next;
+        }
+
+        if ($line =~ /RMD .*?257$/) {
+          $rmd_ok = 1;
+          next;
+        }
+
+        if ($line =~ /SITE RMDIR (\S+): 200$/) {
+          $site_ok = 1;
+          last;
+        }
+      }
+
+      close($fh);
+
+      $self->assert($dele_ok, "ExtendedLog did not contain expected log line for DELE");
+      $self->assert($rmd_ok, "ExtendedLog did not contain expected log line for RMD");
+      $self->assert($site_ok, "ExtendedLog did not contain expected log line for SITE RMDIR");
+
     } else {
       die("Can't read $extlog_file: $!");
     }


### PR DESCRIPTION
mod_site_misc dispatches, when e.g. handling a SITE RMDIR command.  Also
make similar fixes in mod_sftp's handling of the MKDIR request.