### PR TITLE
Changed the version string to reflect 1.3.6rc1

### DIFF
--- a/contrib/dist/rpm/proftpd.spec
+++ b/contrib/dist/rpm/proftpd.spec
@@ -43,18 +43,18 @@
 # RHEL5 and clones don't have suitably recent versions of pcre/libmemcached
 # so use --with rhel5 to inhibit those features when using --with everything
 
-%global proftpd_version           1.3.5
+%global proftpd_version           1.3.6
 
 # When doing a stable or maint release, this line is to be commented out.
 # When doing an RC, define it to be e.g. 'rc2'.
 #
 # NOTE: rpmbuild is really bloody stupid, and CANNOT handle a leading '#'
 # character followed by a '%' character.  
-#global release_cand_version      rc4
+%global release_cand_version      rc1
 
 %global usecvsversion             0%{?_with_cvs:1}
 
-%global proftpd_cvs_version_main  1.3.5
+%global proftpd_cvs_version_main  1.3.6
 %global proftpd_cvs_version_date  20140515
 
 # Spec default assumes that a gzipped tarball is used, since nightly CVS builds,


### PR DESCRIPTION
I've just changed the version and uncommented the rc global. RPMs have been created on CentOS 5 i386 successfully.