### PR TITLE
Address some pointer cast alignment issues by defining the cmd_rec.ar…

### DIFF
--- a/contrib/mod_copy.c
+++ b/contrib/mod_copy.c
@@ -537,10 +537,10 @@ MODRET copy_copy(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[2],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[2], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("%s: Illegal character sequence in filename"), cmd->argv[2]);
+        _("%s: Illegal character sequence in filename"), (char *) cmd->argv[2]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -554,10 +554,10 @@ MODRET copy_copy(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[3],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[3], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("%s: Illegal character sequence in filename"), cmd->argv[3]);
+        _("%s: Illegal character sequence in filename"), (char *) cmd->argv[3]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -572,7 +572,8 @@ MODRET copy_copy(cmd_rec *cmd) {
       int xerrno = EPERM;
 
       pr_cmd_set_name(cmd, cmd_name);
-      pr_response_add_err(R_550, "%s: %s", cmd->argv[3], strerror(xerrno));
+      pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[3],
+        strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -583,14 +584,16 @@ MODRET copy_copy(cmd_rec *cmd) {
     if (copy_paths(cmd->tmp_pool, from, to) < 0) {
       int xerrno = errno;
 
-      pr_response_add_err(R_550, "%s: %s", cmd->argv[1], strerror(xerrno));
+      pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[1],
+        strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
       return PR_ERROR(cmd);
     }
 
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+    pr_response_add(R_200, _("SITE %s command successful"),
+      (char *) cmd->argv[1]);
     return PR_HANDLED(cmd);
   }
 
@@ -640,8 +643,8 @@ MODRET copy_cpfr(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[i],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[i], strerror(xerrno));
       pr_response_add_err(R_550,
         _("%s: Illegal character sequence in filename"), cmd->arg);
 
@@ -749,8 +752,8 @@ MODRET copy_cpto(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[i],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[i], strerror(xerrno));
       pr_response_add_err(R_550,
         _("%s: Illegal character sequence in filename"), cmd->arg);
 
@@ -767,7 +770,8 @@ MODRET copy_cpto(cmd_rec *cmd) {
   if (copy_paths(cmd->tmp_pool, from, to) < 0) {
     int xerrno = errno;
 
-    pr_response_add_err(R_550, "%s: %s", cmd->argv[1], strerror(xerrno));
+    pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[1],
+      strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
     errno = xerrno;

--- a/contrib/mod_ifsession.c
+++ b/contrib/mod_ifsession.c
@@ -434,7 +434,7 @@ MODRET start_ifctxt(cmd_rec *cmd) {
   int config_type = 0, eval_type = 0;
   int argc = 0;
   char *name = NULL;
-  char **argv = NULL;
+  void **argv = NULL;
   array_header *acl = NULL;
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
@@ -545,7 +545,7 @@ MODRET start_ifctxt(cmd_rec *cmd) {
     argv = cmd->argv;
   }
 
-  acl = pr_expr_create(cmd->tmp_pool, &argc, argv);
+  acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) argv);
   if (acl == NULL) {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error creating regex expression: ",
       strerror(errno), NULL));
@@ -555,12 +555,12 @@ MODRET start_ifctxt(cmd_rec *cmd) {
 
   c->config_type = config_type;
   c->argc = acl->nelts + 2;
-  c->argv = pcalloc(c->pool, (c->argc + 2) * sizeof(char *));
+  c->argv = pcalloc(c->pool, (c->argc + 2) * sizeof(void *));
   c->argv[0] = pstrdup(c->pool, cmd->arg);
   c->argv[1] = pcalloc(c->pool, sizeof(unsigned char));
   *((unsigned char *) c->argv[1]) = eval_type;
 
-  argv = (char **) c->argv + 2;
+  argv = c->argv + 2;
 
   if (acl) {
     while (acl->nelts--) {

--- a/contrib/mod_ifversion.c
+++ b/contrib/mod_ifversion.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_ifversion -- a module supporting conditional configuration
  *                           depending on the proftpd server version
  *
- * Copyright (c) 2009-2013 TJ Saunders
+ * Copyright (c) 2009-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,6 @@
  *
  * This is mod_ifversion, contrib software for proftpd 1.3.x and above.
  * For more information contact TJ Saunders <tj@castaglia.org>.
- *
- * $Id: mod_ifversion.c,v 1.5 2013-02-15 22:46:42 castaglia Exp $
  */
 
 #include "conf.h"
@@ -34,8 +32,8 @@
 #define MOD_IFVERSION_VERSION	"mod_ifversion/0.1"
 
 /* Make sure the version of proftpd is as necessary. */
-#if PROFTPD_VERSION_NUMBER < 0x0001030101
-# error "ProFTPD 1.3.1rc1 or later required"
+#if PROFTPD_VERSION_NUMBER < 0x0001030602
+# error "ProFTPD 1.3.6rc2 or later required"
 #endif
 
 /* Support routines
@@ -443,12 +441,13 @@ MODRET start_ifversion(cmd_rec *cmd) {
   if ((matched && !negated) ||
       (!matched && negated)) {
     pr_log_debug(DEBUG3, "%s: using '%s %s' section at line %u",
-      cmd->argv[0], cmd->argv[1], cmd->argv[2], pr_parser_get_lineno());
-      return PR_HANDLED(cmd);
+      (char *) cmd->argv[0], (char *) cmd->argv[1], (char *) cmd->argv[2],
+      pr_parser_get_lineno()); return PR_HANDLED(cmd);
   }
 
   pr_log_debug(DEBUG3, "%s: skipping '%s %s' section at line %u",
-    cmd->argv[0], cmd->argv[1], cmd->argv[2], pr_parser_get_lineno());
+    (char *) cmd->argv[0], (char *) cmd->argv[1], (char *) cmd->argv[2],
+    pr_parser_get_lineno());
 
   while (ifversion_ctx_count > 0 &&
          (config_line = pr_parser_read_line(buf, sizeof(buf))) != NULL) {

--- a/contrib/mod_ldap.c
+++ b/contrib/mod_ldap.c
@@ -1129,7 +1129,7 @@ MODRET handle_ldap_quota_lookup(cmd_rec *cmd) {
 
   } else {
     (void) pr_log_writefile(ldap_logfd, MOD_LDAP_VERSION,
-      "returning cached quota for user %s", cmd->argv[0]);
+      "returning cached quota for user %s", (char *) cmd->argv[0]);
   }
 
   return mod_create_data(cmd, cached_quota);
@@ -1144,7 +1144,7 @@ MODRET handle_ldap_ssh_pubkey_lookup(cmd_rec *cmd) {
       strcasecmp(((char **) cached_ssh_pubkeys->elts)[0], cmd->argv[0]) == 0) {
 
     (void) pr_log_writefile(ldap_logfd, MOD_LDAP_VERSION,
-      "returning cached SSH public keys for user %s", cmd->argv[0]);
+      "returning cached SSH public keys for user %s", (char *) cmd->argv[0]);
     return mod_create_data(cmd, cached_ssh_pubkeys);
   }
 
@@ -1323,7 +1323,7 @@ MODRET ldap_auth_getgroups(cmd_rec *cmd) {
 
       (void) pr_log_writefile(ldap_logfd, MOD_LDAP_VERSION,
         "added user %s secondary group %s/%s",
-        (pw && pw->pw_name) ? pw->pw_name : cmd->argv[0],
+        (pw && pw->pw_name) ? pw->pw_name : (char *) cmd->argv[0],
         LDAP_VALUE(cn, 0), LDAP_VALUE(gidNumber, 0));
     }
 
@@ -1607,12 +1607,14 @@ MODRET set_ldaplog(cmd_rec *cmd) {
 MODRET set_ldapprotoversion(cmd_rec *cmd) {
   int i = 0;
   config_rec *c;
+  char *version;
 
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-  while (cmd->argv[1][i]) {
-    if (!PR_ISDIGIT((int) cmd->argv[1][i])) {
+  version = cmd->argv[1];
+  while (version[i]) {
+    if (!PR_ISDIGIT((int) version[i])) {
       CONF_ERROR(cmd, "LDAPProtocolVersion: argument must be numeric!");
     }
 
@@ -1621,7 +1623,7 @@ MODRET set_ldapprotoversion(cmd_rec *cmd) {
 
   c = add_config_param(cmd->argv[0], 1, NULL);
   c->argv[0] = pcalloc(c->pool, sizeof(int));
-  *((int *) c->argv[0]) = atoi(cmd->argv[1]);
+  *((int *) c->argv[0]) = atoi(version);
 
   return PR_HANDLED(cmd);
 }

--- a/contrib/mod_log_forensic.c
+++ b/contrib/mod_log_forensic.c
@@ -2,7 +2,7 @@
  * mod_log_forensic - a buffering log module for aiding in server behavior
  *                    forensic analysis
  *
- * Copyright (c) 2011-2014 TJ Saunders
+ * Copyright (c) 2011-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,6 @@ module log_forensic_module;
 static pool *forensic_pool = NULL;
 static int forensic_engine = FALSE;
 static int forensic_logfd = -1;
-static uint64_t forensic_ms = 0L;
 
 /* Criteria for flushing out the "forensic" logs. */
 #define FORENSIC_CRIT_FAILED_LOGIN		0x00001

--- a/contrib/mod_quotatab_sql.c
+++ b/contrib/mod_quotatab_sql.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_quotatab_sql -- a mod_quotatab sub-module for managing quota
  *                              data via SQL-based tables
  *
- * Copyright (c) 2002-2014 TJ Saunders
+ * Copyright (c) 2002-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,8 +21,6 @@
  * As a special exemption, TJ Saunders gives permission to link this program
  * with OpenSSL, and distribute the resulting executable, without including
  * the source code for OpenSSL in the source distribution.
- *
- * $Id: mod_quotatab_sql.c,v 1.17 2013-01-21 19:59:59 castaglia Exp $
  */
 
 #include "mod_quotatab.h"
@@ -43,14 +41,15 @@ static cmd_rec *sqltab_cmd_create(pool *parent_pool, int argc, ...) {
   cmd->pool = cmd_pool;
 
   cmd->argc = argc;
-  cmd->argv = (char **) pcalloc(cmd->pool, argc * sizeof(char *));
+  cmd->argv = pcalloc(cmd->pool, argc * sizeof(void *));
 
   /* Hmmm... */
   cmd->tmp_pool = cmd->pool;
 
   va_start(argp, argc);
-  for (i = 0; i < argc; i++)
+  for (i = 0; i < argc; i++) {
     cmd->argv[i] = va_arg(argp, char *);
+  }
   va_end(argp);
 
   return cmd;
@@ -68,8 +67,9 @@ static char *sqltab_get_name(pool *p, char *name) {
     return name;
   }
 
-  if (strlen(name) == 0)
+  if (strlen(name) == 0) {
     return name;
+  }
 
   cmd = sqltab_cmd_create(p, 1, pr_str_strip(p, name));
 

--- a/contrib/mod_radius.c
+++ b/contrib/mod_radius.c
@@ -4137,15 +4137,21 @@ MODRET set_radiususerinfo(cmd_rec *cmd) {
   } 
 
   if (!radius_have_var(cmd->argv[3])) {
+    char *path;
+
+    path = cmd->argv[3];
     /* Make sure the path is absolute, at least. */
-    if (*(cmd->argv[3]) != '/') {
+    if (*path != '/') {
       CONF_ERROR(cmd, "home relative path not allowed");
     }
   }
 
   if (!radius_have_var(cmd->argv[4])) {
+    char *path;
+
+    path = cmd->argv[4];
     /* Make sure the path is absolute, at least. */
-    if (*(cmd->argv[4]) != '/') {
+    if (*path != '/') {
       CONF_ERROR(cmd, "shell relative path not allowed");
     }
   }
@@ -4167,12 +4173,14 @@ MODRET set_radiusvendor(cmd_rec *cmd) {
   /* Make sure that the given vendor ID number is valid. */
   id = strtol(cmd->argv[2], &tmp, 10);
 
-  if (tmp && *tmp)
+  if (tmp && *tmp) {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": vendor id '", cmd->argv[2],
       "' is not a valid number", NULL));
+  }
 
-  if (id < 0)
+  if (id < 0) {
     CONF_ERROR(cmd, "vendor id must be a positive number");
+  }
 
   c = add_config_param(cmd->argv[0], 2, NULL, NULL);
   c->argv[0] = pstrdup(c->pool, cmd->argv[1]);

--- a/contrib/mod_readme.c
+++ b/contrib/mod_readme.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2011 The ProFTPD Project team
+ * Copyright (c) 2001-2015 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -147,7 +147,8 @@ MODRET set_displayreadme(cmd_rec *cmd) {
   c = add_config_param_str(cmd->argv[0], 1, cmd->argv[1]);
   c->flags |= CF_MERGEDOWN;
   
-  pr_log_debug(DEBUG5, "Added pattern %s to readme list", cmd->argv[1]);
+  pr_log_debug(DEBUG5, "Added pattern %s to readme list",
+    (char *) cmd->argv[1]);
   return PR_HANDLED(cmd);
 }
 

--- a/contrib/mod_sftp/auth-hostbased.c
+++ b/contrib/mod_sftp/auth-hostbased.c
@@ -51,7 +51,7 @@ int sftp_auth_hostbased(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
   if (pr_cmd_dispatch_phase(pass_cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
-      orig_user, pass_cmd->argv[0]);
+      orig_user, (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp/auth-kbdint.c
+++ b/contrib/mod_sftp/auth-kbdint.c
@@ -64,7 +64,7 @@ int sftp_auth_kbdint(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
   if (pr_cmd_dispatch_phase(pass_cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
-      orig_user, pass_cmd->argv[0]);
+      orig_user, (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp/auth-password.c
+++ b/contrib/mod_sftp/auth-password.c
@@ -77,7 +77,7 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
   if (pr_cmd_dispatch_phase(pass_cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
-      orig_user, pass_cmd->argv[0]);
+      orig_user, (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp/auth-publickey.c
+++ b/contrib/mod_sftp/auth-publickey.c
@@ -94,7 +94,7 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
   if (pr_cmd_dispatch_phase(pass_cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
-      orig_user, pass_cmd->argv[0]);
+      orig_user, (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -1067,7 +1067,7 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
   if (pr_cmd_dispatch_phase(user_cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
-      orig_user, user_cmd->argv[0]);
+      orig_user, (char *) user_cmd->argv[0]);
 
     pr_response_add_err(R_530, "Login incorrect.");
     pr_cmd_dispatch_phase(user_cmd, POST_CMD_ERR, 0);

--- a/contrib/mod_sftp/cipher.c
+++ b/contrib/mod_sftp/cipher.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp ciphers
- * Copyright (c) 2008-2014 TJ Saunders
+ * Copyright (c) 2008-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,8 +20,6 @@
  * give permission to link this program with OpenSSL, and distribute the
  * resulting executable, without including the source code for OpenSSL in the
  * source distribution.
- *
- * $Id: cipher.c,v 1.18 2014-03-02 06:07:43 castaglia Exp $
  */
 
 #include "mod_sftp.h"
@@ -228,7 +226,6 @@ static int set_cipher_iv(struct sftp_cipher *cipher, const EVP_MD *hash,
 static int set_cipher_key(struct sftp_cipher *cipher, const EVP_MD *hash,
     const unsigned char *k, uint32_t klen, const char *h, uint32_t hlen,
     char *letter, const unsigned char *id, uint32_t id_len) {
-
   EVP_MD_CTX ctx;
   unsigned char *key = NULL;
   size_t key_sz = 0;
@@ -351,20 +348,22 @@ const char *sftp_cipher_get_read_algo(void) {
 
 int sftp_cipher_set_read_algo(const char *algo) {
   unsigned int idx = read_cipher_idx;
+  size_t key_len, discard_len;
 
   if (read_ciphers[idx].key) {
     /* If we have an existing key, it means that we are currently rekeying. */
     idx = get_next_read_index();
   }
 
-  read_ciphers[idx].cipher = sftp_crypto_get_cipher(algo,
-    (size_t *) &(read_ciphers[idx].key_len),
-    &(read_ciphers[idx].discard_len));
-
-  if (read_ciphers[idx].cipher == NULL)
+  read_ciphers[idx].cipher = sftp_crypto_get_cipher(algo, &key_len,
+    &discard_len);
+  if (read_ciphers[idx].cipher == NULL) {
     return -1;
+  }
 
   read_ciphers[idx].algo = algo;
+  read_ciphers[idx].key_len = (uint32_t) key_len;
+  read_ciphers[idx].discard_len = discard_len;
   return 0;
 }
 
@@ -514,20 +513,22 @@ const char *sftp_cipher_get_write_algo(void) {
 
 int sftp_cipher_set_write_algo(const char *algo) {
   unsigned int idx = write_cipher_idx;
+  size_t key_len, discard_len;
 
   if (write_ciphers[idx].key) {
     /* If we have an existing key, it means that we are currently rekeying. */
     idx = get_next_write_index();
   }
 
-  write_ciphers[idx].cipher = sftp_crypto_get_cipher(algo,
-    (size_t *) &(write_ciphers[idx].key_len),
-    &(write_ciphers[idx].discard_len));
-
-  if (write_ciphers[idx].cipher == NULL)
+  write_ciphers[idx].cipher = sftp_crypto_get_cipher(algo, &key_len,
+    &discard_len);
+  if (write_ciphers[idx].cipher == NULL) {
     return -1;
+  }
 
   write_ciphers[idx].algo = algo;
+  write_ciphers[idx].key_len = (uint32_t) key_len;
+  write_ciphers[idx].discard_len = discard_len;
   return 0;
 }
 

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -4120,7 +4120,8 @@ static int fxp_handle_ext_copy_file(struct fxp_packet *fxp, char *src,
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "COPY of '%s' to '%s' blocked by '%s' handler", src, dst, cmd->argv[0]);
+      "COPY of '%s' to '%s' blocked by '%s' handler", src, dst,
+      (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -4630,7 +4631,7 @@ static int fxp_handle_ext_posix_rename(struct fxp_packet *fxp, char *src,
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RENAME from '%s' blocked by '%s' handler", src, cmd2->argv[0]);
+      "RENAME from '%s' blocked by '%s' handler", src, (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -4696,7 +4697,7 @@ static int fxp_handle_ext_posix_rename(struct fxp_packet *fxp, char *src,
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RENAME to '%s' blocked by '%s' handler", dst, cmd3->argv[0]);
+      "RENAME to '%s' blocked by '%s' handler", dst, (char *) cmd3->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -5431,8 +5432,8 @@ static int fxp_handle_close(struct fxp_packet *fxp) {
   fxh = fxp_handle_get(name);
   if (fxh == NULL) {
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -5891,8 +5892,8 @@ static int fxp_handle_extended(struct fxp_packet *fxp) {
     fxh = fxp_handle_get(handle);
     if (fxh == NULL) {
       pr_trace_msg(trace_channel, 17,
-        "%s: unable to find handle for name '%s': %s", cmd->argv[0], handle,
-        strerror(errno));
+        "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+        handle, strerror(errno));
 
       status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -5915,7 +5916,7 @@ static int fxp_handle_extended(struct fxp_packet *fxp) {
       errno = EISDIR;
 
       pr_trace_msg(trace_channel, 17,
-        "%s: handle '%s': %s", cmd->argv[0], handle, strerror(errno));
+        "%s: handle '%s': %s", (char *) cmd->argv[0], handle, strerror(errno));
 
       status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -6011,8 +6012,8 @@ static int fxp_handle_extended(struct fxp_packet *fxp) {
     fxh = fxp_handle_get(handle);
     if (fxh == NULL) {
       pr_trace_msg(trace_channel, 17,
-        "%s: unable to find handle for name '%s': %s", cmd->argv[0], handle,
-        strerror(errno));
+        "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+        handle, strerror(errno));
 
       status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -6100,8 +6101,8 @@ static int fxp_handle_fsetstat(struct fxp_packet *fxp) {
   fxh = fxp_handle_get(name);
   if (fxh == NULL) {
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -6130,7 +6131,8 @@ static int fxp_handle_fsetstat(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "FSETSTAT of '%s' blocked by '%s' handler", cmd->arg, cmd->argv[0]);
+      "FSETSTAT of '%s' blocked by '%s' handler", cmd->arg,
+      (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -6192,7 +6194,7 @@ static int fxp_handle_fsetstat(struct fxp_packet *fxp) {
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "FSETSTAT of '%s' blocked by <Limit %s> configuration", path,
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
 
     pr_cmd_set_name(cmd, cmd_name);
 
@@ -6341,8 +6343,8 @@ static int fxp_handle_fstat(struct fxp_packet *fxp) {
     uint32_t status_code;
 
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -6673,7 +6675,7 @@ static int fxp_handle_link(struct fxp_packet *fxp) {
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "LINK of '%s' to '%s' blocked by <Limit %s> configuration",
-      target_path, link_path, cmd->argv[0]);
+      target_path, link_path, (char *) cmd->argv[0]);
 
     pr_cmd_set_name(cmd, cmd_name);
 
@@ -6774,8 +6776,8 @@ static int fxp_handle_lock(struct fxp_packet *fxp) {
   fxh = fxp_handle_get(name);
   if (fxh == NULL) {
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -7045,7 +7047,7 @@ static int fxp_handle_lstat(struct fxp_packet *fxp) {
     uint32_t status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "LSTAT of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "LSTAT of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -7242,7 +7244,7 @@ static int fxp_handle_mkdir(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "MKDIR of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "MKDIR of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -7267,7 +7269,7 @@ static int fxp_handle_mkdir(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "MKDIR of '%s' blocked by '%s' handler", path, cmd2->argv[0]);
+      "MKDIR of '%s' blocked by '%s' handler", path, (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -7329,7 +7331,8 @@ static int fxp_handle_mkdir(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "MKDIR of '%s' blocked by <Limit %s> configuration", path, cmd->argv[0]);
+      "MKDIR of '%s' blocked by <Limit %s> configuration", path,
+      (char *) cmd->argv[0]);
 
     pr_cmd_set_name(cmd, cmd_name);
 
@@ -7767,7 +7770,8 @@ static int fxp_handle_open(struct fxp_packet *fxp) {
       /* One of the PRE_CMD phase handlers rejected the command. */
 
       (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-        "OPEN command for '%s' blocked by '%s' handler", path, cmd2->argv[0]);
+        "OPEN command for '%s' blocked by '%s' handler", path,
+        (char *) cmd2->argv[0]);
 
       /* Hopefully the command handlers set an appropriate errno value.  If
        * they didn't, however, we need to be prepared with a fallback.
@@ -8178,7 +8182,7 @@ static int fxp_handle_opendir(struct fxp_packet *fxp) {
     uint32_t status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "OPENDIR of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "OPENDIR of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -8257,7 +8261,8 @@ static int fxp_handle_opendir(struct fxp_packet *fxp) {
 
     /* One of the PRE_CMD phase handlers rejected the command. */
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "OPENDIR command for '%s' blocked by '%s' handler", path, cmd2->argv[0]);
+      "OPENDIR command for '%s' blocked by '%s' handler", path,
+      (char *) cmd2->argv[0]);
 
     /* Hopefully the command handlers set an appropriate errno value.  If
      * they didn't, however, we need to be prepared with a fallback.
@@ -8534,8 +8539,8 @@ static int fxp_handle_read(struct fxp_packet *fxp) {
     uint32_t status_code;
 
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -8866,8 +8871,8 @@ static int fxp_handle_readdir(struct fxp_packet *fxp) {
     uint32_t status_code;
 
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -8943,7 +8948,7 @@ static int fxp_handle_readdir(struct fxp_packet *fxp) {
  
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "READDIR of '%s' blocked by <Limit %s> configuration", fxh->dir,
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
 
     pr_cmd_set_name(cmd, cmd_name);
 
@@ -9205,7 +9210,7 @@ static int fxp_handle_readlink(struct fxp_packet *fxp) {
     uint32_t status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "READLINK of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "READLINK of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -9259,7 +9264,7 @@ static int fxp_handle_readlink(struct fxp_packet *fxp) {
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "READLINK of '%s' (resolved to '%s') blocked by <Limit %s> configuration",
-      path, resolved_path, cmd->argv[0]);
+      path, resolved_path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -9453,7 +9458,7 @@ static int fxp_handle_realpath(struct fxp_packet *fxp) {
     uint32_t status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "REALPATH of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "REALPATH of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     if (fxp_session->client_version <= 5 ||
         (fxp_session->client_version >= 6 &&
@@ -9760,7 +9765,7 @@ static int fxp_handle_remove(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "REMOVE of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "REMOVE of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -9785,7 +9790,7 @@ static int fxp_handle_remove(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "DELE of '%s' blocked by '%s' handler", path, cmd2->argv[0]);
+      "DELE of '%s' blocked by '%s' handler", path, (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -9994,7 +9999,7 @@ static int fxp_handle_remove(struct fxp_packet *fxp) {
     xferlog_write(0, session.c->remote_name, st.st_size, abs_path,
       'b', 'd', 'r', session.user, 'c', "_");
 
-    pr_response_add(R_250, "%s command successful", cmd2->argv[0]);
+    pr_response_add(R_250, "%s command successful", (char *) cmd2->argv[0]);
     pr_cmd_dispatch_phase(cmd2, POST_CMD, 0);
     pr_cmd_dispatch_phase(cmd2, LOG_CMD, 0);
     pr_response_clear(&resp_list);
@@ -10101,7 +10106,8 @@ static int fxp_handle_rename(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RENAME from '%s' blocked by '%s' handler", old_path, cmd2->argv[0]);
+      "RENAME from '%s' blocked by '%s' handler", old_path,
+      (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -10165,7 +10171,8 @@ static int fxp_handle_rename(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RENAME to '%s' blocked by '%s' handler", new_path, cmd3->argv[0]);
+      "RENAME to '%s' blocked by '%s' handler", new_path,
+      (char *) cmd3->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -10503,7 +10510,7 @@ static int fxp_handle_rmdir(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RMDIR of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "RMDIR of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -10550,7 +10557,7 @@ static int fxp_handle_rmdir(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "RMDIR of '%s' blocked by '%s' handler", path, cmd2->argv[0]);
+      "RMDIR of '%s' blocked by '%s' handler", path, (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -10768,7 +10775,7 @@ static int fxp_handle_setstat(struct fxp_packet *fxp) {
     status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "SETSTAT of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "SETSTAT of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -10957,7 +10964,7 @@ static int fxp_handle_stat(struct fxp_packet *fxp) {
     uint32_t status_code = SSH2_FX_PERMISSION_DENIED;
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
-      "STAT of '%s' blocked by '%s' handler", path, cmd->argv[0]);
+      "STAT of '%s' blocked by '%s' handler", path, (char *) cmd->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -11232,7 +11239,7 @@ static int fxp_handle_symlink(struct fxp_packet *fxp) {
 
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "SYMLINK of '%s' to '%s' blocked by '%s' handler", target_path, link_path,
-      cmd2->argv[0]);
+      (char *) cmd2->argv[0]);
 
     pr_trace_msg(trace_channel, 8, "sending response: STATUS %lu '%s'",
       (unsigned long) status_code, fxp_strerror(status_code));
@@ -11386,8 +11393,8 @@ static int fxp_handle_write(struct fxp_packet *fxp) {
   fxh = fxp_handle_get(name);
   if (fxh == NULL) {
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 
@@ -11739,8 +11746,8 @@ static int fxp_handle_unlock(struct fxp_packet *fxp) {
   fxh = fxp_handle_get(name);
   if (fxh == NULL) {
     pr_trace_msg(trace_channel, 17,
-      "%s: unable to find handle for name '%s': %s", cmd->argv[0], name,
-      strerror(errno));
+      "%s: unable to find handle for name '%s': %s", (char *) cmd->argv[0],
+      name, strerror(errno));
 
     status_code = SSH2_FX_INVALID_HANDLE;
 

--- a/contrib/mod_sftp/mod_sftp.c
+++ b/contrib/mod_sftp/mod_sftp.c
@@ -363,7 +363,7 @@ MODRET set_sftpauthmeths(cmd_rec *cmd) {
       cmd->argv[i]);
     if (method_names == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-        "invalid authentication parameter: ", cmd->argv[i], NULL));
+        "invalid authentication parameter: ", (char *) cmd->argv[i], NULL));
     }
 
     auth_chain = sftp_auth_chain_alloc(c->pool);
@@ -397,8 +397,8 @@ MODRET set_sftpauthmeths(cmd_rec *cmd) {
 
     if (sftp_auth_chain_isvalid(auth_chain) < 0) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-        "unsupportable chain of authentication methods '", cmd->argv[i], "': ",
-        strerror(errno), NULL));
+        "unsupportable chain of authentication methods '",
+        (char *) cmd->argv[i], "': ", strerror(errno), NULL));
     }
 
     *((struct sftp_auth_chain **) push_array(auth_chains)) = auth_chain;
@@ -434,7 +434,7 @@ MODRET set_sftpauthorizedkeys(cmd_rec *cmd) {
     ptr = strchr(cmd->argv[i], ':');
     if (ptr == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "badly formatted parameter: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
     }
     *ptr = '\0';
 
@@ -443,7 +443,7 @@ MODRET set_sftpauthorizedkeys(cmd_rec *cmd) {
      */
     if (sftp_keystore_supports_store(cmd->argv[i], requested_key_type) < 0) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unsupported key store: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
     }
 
     *ptr = ':';
@@ -473,7 +473,7 @@ MODRET set_sftpciphers(cmd_rec *cmd) {
   for (i = 1; i < cmd->argc; i++) {
     if (sftp_crypto_get_cipher(cmd->argv[i], NULL, NULL) == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-        "unsupported cipher algorithm: ", cmd->argv[i], NULL));
+        "unsupported cipher algorithm: ", (char *) cmd->argv[i], NULL));
     }
   }
 
@@ -495,13 +495,13 @@ MODRET set_sftpclientalive(cmd_rec *cmd) {
 
   count = atoi(cmd->argv[1]);
   if (count < 0) {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "max count '", cmd->argv[1],
-      "' must be equal to or greater than zero", NULL));
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "max count '",
+      (char *) cmd->argv[1], "' must be equal to or greater than zero", NULL));
   }
 
   interval = atoi(cmd->argv[2]);
   if (interval < 0) {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "interval '", cmd->argv[2],
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "interval '", (char *) cmd->argv[2],
       "' must be equal to or greater than zero", NULL));
   }
 
@@ -549,8 +549,8 @@ MODRET set_sftpclientmatch(cmd_rec *cmd) {
     pr_regexp_error(res, pre, errstr, sizeof(errstr));
     pr_regexp_free(NULL, pre);
 
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "'", cmd->argv[1], "' failed regex "
-      "compilation: ", errstr, NULL));
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "'", (char *) cmd->argv[1],
+      "' failed regex compilation: ", errstr, NULL));
   }
 
   c = add_config_param(cmd->argv[0], 3, NULL, NULL, NULL);
@@ -1390,26 +1390,29 @@ MODRET set_sftpoptions(cmd_rec *cmd) {
 /* usage: SFTPPassPhraseProvider path */
 MODRET set_sftppassphraseprovider(cmd_rec *cmd) {
   struct stat st;
+  char *path;
  
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT);
+
+  path = cmd->argv[1];
  
-  if (*cmd->argv[1] != '/') {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "must be a full path: '",
-      cmd->argv[1], "'", NULL));
+  if (*path != '/') {
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "must be a full path: '", path, "'",
+      NULL));
   }
  
-  if (stat(cmd->argv[1], &st) < 0) {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error checking '", 
-      cmd->argv[1], "': ", strerror(errno), NULL));
+  if (stat(path, &st) < 0) {
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error checking '", path, "': ",
+      strerror(errno), NULL));
   }
 
   if (!S_ISREG(st.st_mode)) {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unable to use '",
-      cmd->argv[1], ": Not a regular file", NULL));
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unable to use '", path,
+      ": Not a regular file", NULL));
   }
 
-  add_config_param_str(cmd->argv[0], 1, cmd->argv[1]);
+  add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
 }
 

--- a/contrib/mod_sftp/scp.c
+++ b/contrib/mod_sftp/scp.c
@@ -932,7 +932,7 @@ static int recv_finfo(pool *p, uint32_t channel_id, struct scp_path *sp,
   if (pr_cmd_dispatch_phase(cmd, PRE_CMD, 0) < 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "scp upload to '%s' blocked by '%s' handler", sp->path,
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
 
     (void) pr_cmd_dispatch_phase(cmd, POST_CMD_ERR, 0);
     (void) pr_cmd_dispatch_phase(cmd, LOG_CMD_ERR, 0);
@@ -1909,7 +1909,7 @@ static int send_path(pool *p, uint32_t channel_id, struct scp_path *sp) {
       if (xerrno != EISDIR) {
         (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
           "scp download of '%s' blocked by '%s' handler", sp->path,
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         (void) pr_cmd_dispatch_phase(cmd, POST_CMD_ERR, 0);
         (void) pr_cmd_dispatch_phase(cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp_sql.c
+++ b/contrib/mod_sftp_sql.c
@@ -62,14 +62,15 @@ static cmd_rec *sqlstore_cmd_create(pool *parent_pool, int argc, ...) {
   cmd->pool = cmd_pool;
 
   cmd->argc = argc;
-  cmd->argv = (char **) pcalloc(cmd->pool, argc * sizeof(char *));
+  cmd->argv = pcalloc(cmd->pool, argc * sizeof(void *));
 
   /* Hmmm... */
   cmd->tmp_pool = cmd->pool;
 
   va_start(argp, argc);
-  for (i = 0; i < argc; i++)
+  for (i = 0; i < argc; i++) {
     cmd->argv[i] = va_arg(argp, char *);
+  }
   va_end(argp);
 
   return cmd;

--- a/contrib/mod_shaper.c
+++ b/contrib/mod_shaper.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_shaper -- a module implementing daemon-wide rate throttling
  *                        via IPC
  *
- * Copyright (c) 2004-2014 TJ Saunders
+ * Copyright (c) 2004-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,6 @@
  *
  * This is mod_shaper, contrib software for proftpd 1.2 and above.
  * For more information contact TJ Saunders <tj@castaglia.org>.
- *
- * $Id: mod_shaper.c,v 1.18 2013-10-13 22:51:36 castaglia Exp $
  */
 
 #include "conf.h"
@@ -1953,48 +1951,63 @@ MODRET set_shapersession(cmd_rec *cmd) {
 
   register unsigned int i;
 
-  if (cmd->argc-1 < 2 || cmd->argc-1 > 8 || (cmd->argc-1) % 2 != 0)
+  if (cmd->argc-1 < 2 ||
+      cmd->argc-1 > 8 ||
+      (cmd->argc-1) % 2 != 0) {
     CONF_ERROR(cmd, "wrong number of parameters");
+  }
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON);
 
   for (i = 1; i < cmd->argc;) {
     if (strcmp(cmd->argv[i], "downshares") == 0) {
-      if (*cmd->argv[i+1] != '+' &&
-          *cmd->argv[i+1] != '-')
-        CONF_ERROR(cmd, "downshares parameter must start with '+' or '-'");
+      char *shareno;
 
-      downshares = atoi(cmd->argv[i+1]);
+      shareno = cmd->argv[i+1];
+      if (*shareno != '+' &&
+          *shareno != '-') {
+        CONF_ERROR(cmd, "downshares parameter must start with '+' or '-'");
+      }
+
+      downshares = atoi(shareno);
       i += 2;
 
     } else if (strcmp(cmd->argv[i], "priority") == 0) {
       prio = atoi(cmd->argv[i+1]);
-
-      if (prio < 0)
+      if (prio < 0) {
         CONF_ERROR(cmd, "priority must be greater than 0");
+      }
 
       i += 2;
 
     } else if (strcmp(cmd->argv[i], "shares") == 0) {
-      if (*cmd->argv[i+1] != '+' &&
-          *cmd->argv[i+1] != '-')
+      char *shareno;
+
+      shareno = cmd->argv[i+1];
+      if (*shareno != '+' &&
+          *shareno != '-') {
         CONF_ERROR(cmd, "shares parameter must start with '+' or '-'");
+      }
 
-      downshares = upshares = atoi(cmd->argv[i+1]);
-
+      downshares = upshares = atoi(shareno);
       i += 2;
 
     } else if (strcmp(cmd->argv[i], "upshares") == 0) {
-      if (*cmd->argv[i+1] != '+' &&
-          *cmd->argv[i+1] != '-')
-        CONF_ERROR(cmd, "upshares parameter must start with '+' or '-'");
+      char *shareno;
 
-      upshares = atoi(cmd->argv[i+1]);
+      shareno = cmd->argv[i+1];
+      if (*shareno != '+' &&
+          *shareno != '-') {
+        CONF_ERROR(cmd, "upshares parameter must start with '+' or '-'");
+      }
+
+      upshares = atoi(shareno);
       i += 2;
 
-    } else
+    } else {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unknown option: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
+    }
   }
 
   c = add_config_param(cmd->argv[0], 3, NULL, NULL);
@@ -2014,8 +2027,9 @@ MODRET set_shapertable(cmd_rec *cmd) {
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT);
 
-  if (pr_fs_valid_path(cmd->argv[1]) < 0)
+  if (pr_fs_valid_path(cmd->argv[1]) < 0) {
     CONF_ERROR(cmd, "must be an absolute path");
+  }
 
   shaper_tab_path = pstrdup(shaper_pool, cmd->argv[1]);
   return PR_HANDLED(cmd);

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -261,7 +261,7 @@ static int site_misc_delete_dir(pool *p, const char *dir) {
         return -1;
       }
 
-      pr_response_add(R_250, "%s command successful", cmd->argv[0]);
+      pr_response_add(R_250, "%s command successful", (char *) cmd->argv[0]);
       pr_cmd_dispatch_phase(cmd, POST_CMD, 0);
       pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
       pr_response_clear(&resp_list);
@@ -558,7 +558,7 @@ MODRET site_misc_mkdir(cmd_rec *cmd) {
 
   if (cmd->argc < 2) {
     pr_log_debug(DEBUG5, MOD_SITE_MISC_VERSION
-      "%s : wrong number of arguments (%d)", cmd->argv[0], cmd->argc);
+      "%s : wrong number of arguments (%d)", (char *) cmd->argv[0], cmd->argc);
     return PR_DECLINED(cmd);
   }
 
@@ -631,7 +631,7 @@ MODRET site_misc_mkdir(cmd_rec *cmd) {
       cmd->argv[0] = cmd_name;
 
       pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-        ": %s command denied by <Limit>", cmd->argv[0]);
+        ": %s command denied by <Limit>", (char *) cmd->argv[0]);
       pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
@@ -650,7 +650,8 @@ MODRET site_misc_mkdir(cmd_rec *cmd) {
       return PR_ERROR(cmd);
     }
 
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+    pr_response_add(R_200, _("SITE %s command successful"),
+      (char *) cmd->argv[1]);
     return PR_HANDLED(cmd);
   }
 
@@ -668,7 +669,7 @@ MODRET site_misc_rmdir(cmd_rec *cmd) {
 
   if (cmd->argc < 2) {
     pr_log_debug(DEBUG5, MOD_SITE_MISC_VERSION
-      "%s : wrong number of arguments (%d)", cmd->argv[0], cmd->argc);
+      "%s : wrong number of arguments (%d)", (char *) cmd->argv[0], cmd->argc);
     return PR_DECLINED(cmd);
   }
 
@@ -729,7 +730,7 @@ MODRET site_misc_rmdir(cmd_rec *cmd) {
       cmd->argv[0] = cmd_name;
 
       pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-        ": %s command denied by <Limit>", cmd->argv[0]);
+        ": %s command denied by <Limit>", (char *) cmd->argv[0]);
       pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
@@ -748,7 +749,8 @@ MODRET site_misc_rmdir(cmd_rec *cmd) {
       return PR_ERROR(cmd);
     }
 
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+    pr_response_add(R_200, _("SITE %s command successful"),
+      (char *) cmd->argv[1]);
     return PR_HANDLED(cmd);
   } 
 
@@ -766,7 +768,7 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
 
   if (cmd->argc < 2) {
     pr_log_debug(DEBUG5, MOD_SITE_MISC_VERSION
-      "%s : wrong number of arguments (%d)", cmd->argv[0], cmd->argc);
+      "%s : wrong number of arguments (%d)", (char *) cmd->argv[0], cmd->argc);
     return PR_DECLINED(cmd);
   }
 
@@ -795,10 +797,10 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[2],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[2], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("%s: Illegal character sequence in filename"), cmd->argv[2]);
+        _("%s: Illegal character sequence in filename"), (char *) cmd->argv[2]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -823,8 +825,9 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
       cmd->argv[0] = cmd_name;
 
       pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-        ": %s command denied by <Limit>", cmd->argv[0]);
-      pr_response_add_err(R_550, "%s: %s", cmd->argv[2], strerror(xerrno));
+        ": %s command denied by <Limit>", (char *) cmd->argv[0]);
+      pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[2],
+        strerror(xerrno));
 
       errno = xerrno;
       return PR_ERROR(cmd);
@@ -835,10 +838,10 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[3],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[3], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("%s: Illegal character sequence in filename"), cmd->argv[3]);
+        _("%s: Illegal character sequence in filename"), (char *) cmd->argv[3]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -861,8 +864,9 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
       cmd->argv[0] = cmd_name;
 
       pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-        ": %s command denied by <Limit>", cmd->argv[0]);
-      pr_response_add_err(R_550, "%s: %s", cmd->argv[3], strerror(xerrno));
+        ": %s command denied by <Limit>", (char *) cmd->argv[0]);
+      pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[3],
+        strerror(xerrno));
 
       errno = xerrno;
       return PR_ERROR(cmd);
@@ -904,7 +908,8 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
       return PR_ERROR(cmd);
     }
 
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+    pr_response_add(R_200, _("SITE %s command successful"),
+      (char *) cmd->argv[1]);
     return PR_HANDLED(cmd);
   } 
 
@@ -931,7 +936,7 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
 
     pr_log_debug(DEBUG7, MOD_SITE_MISC_VERSION
       ": wrong number of digits in timestamp argument '%s' (%lu)",
-      cmd->argv[2], (unsigned long) timestamp_len);
+      (char *) cmd->argv[2], (unsigned long) timestamp_len);
     pr_response_add_err(R_500, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;
@@ -975,7 +980,7 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
     cmd->argv[0] = cmd_name;
 
     pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-      ": %s command denied by <Limit>", cmd->argv[0]);
+      ": %s command denied by <Limit>", (char *) cmd->argv[0]);
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;
@@ -1015,7 +1020,8 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
  
-  pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+  pr_response_add(R_200, _("SITE %s command successful"),
+    (char *) cmd->argv[1]);
   return PR_HANDLED(cmd);
 }
 
@@ -1065,7 +1071,7 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
     cmd->argv[0] = cmd_name;
 
     pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-      ": %s command denied by <Limit>", cmd->argv[0]);
+      ": %s command denied by <Limit>", (char *) cmd->argv[0]);
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;
@@ -1196,7 +1202,8 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
  
-  pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[1]);
+  pr_response_add(R_200, _("SITE %s command successful"),
+    (char *) cmd->argv[1]);
   return PR_HANDLED(cmd);
 }
 
@@ -1207,7 +1214,7 @@ MODRET site_misc_utime(cmd_rec *cmd) {
 
   if (cmd->argc < 2) {
     pr_log_debug(DEBUG5, MOD_SITE_MISC_VERSION
-      "%s : wrong number of arguments (%d)", cmd->argv[0], cmd->argc);
+      "%s : wrong number of arguments (%d)", (char *) cmd->argv[0], cmd->argc);
     return PR_DECLINED(cmd);
   }
 

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -4003,7 +4003,7 @@ MODRET errinfo_master(cmd_rec *cmd) {
     outsp = outs;
 
     pr_trace_msg(trace_channel, 15, "processing SQLShowInfo ERR_%s '%s'",
-      cmd->argv[0], cmd->argv[1]);
+      (char *) cmd->argv[0], (char *) cmd->argv[1]);
 
     for (tmp = c->argv[1]; *tmp; ) {
       pr_signals_handle();
@@ -4041,7 +4041,7 @@ MODRET errinfo_master(cmd_rec *cmd) {
 
               pr_trace_msg(trace_channel, 13,
                 "SQLShowInfo ERR_%s query '%s' returned row count %lu",
-                cmd->argv[0], query, sd->rnum);
+                (char *) cmd->argv[0], query, sd->rnum);
 
               if (sd->rnum == 0 ||
                   sd->data[0] == NULL) {
@@ -4132,14 +4132,14 @@ MODRET errinfo_master(cmd_rec *cmd) {
           *resp_code == '5') {
         pr_trace_msg(trace_channel, 15,
           "adding error response code %s, msg '%s' for SQLShowInfo ERR_%s",
-          resp_code, outs, cmd->argv[0]);
+          resp_code, outs, (char *) cmd->argv[0]);
 
         pr_response_add_err(resp_code, "%s", outs);
 
       } else {
         pr_trace_msg(trace_channel, 15,
           "adding response code %s, msg '%s' for SQLShowInfo ERR_%s", resp_code,
-          outs, cmd->argv[0]);
+          outs, (char *) cmd->argv[0]);
 
         pr_response_add(resp_code, "%s", outs);
       }
@@ -5562,21 +5562,22 @@ MODRET set_sqluserinfo(cmd_rec *cmd) {
 
   if (cmd->argc-1 == 1) {
     char *user = NULL, *userbyid = NULL, *userset = NULL, *usersetfast = NULL;
-    char *ptr = NULL;
+    char *param, *ptr = NULL;
 
     /* If only one paramter is used, it must be of the "custom:/" form. */
-    if (strncmp("custom:/", cmd->argv[1], 8) != 0) {
+    param = cmd->argv[1];
+    if (strncmp("custom:/", param, 8) != 0) {
       CONF_ERROR(cmd, "badly formatted parameter");
     }
 
-    ptr = strchr(cmd->argv[1] + 8, '/');
+    ptr = strchr(param + 8, '/');
     if (ptr == NULL) {
-      add_config_param_str("SQLCustomUserInfoByName", 1, cmd->argv[1] + 8);
+      add_config_param_str("SQLCustomUserInfoByName", 1, param + 8);
       return PR_HANDLED(cmd);
     }
 
     *ptr = '\0';
-    user = cmd->argv[1] + 8;
+    user = param + 8;
     userbyid = ptr + 1;
 
     add_config_param_str("SQLCustomUserInfoByName", 1, user);
@@ -5652,20 +5653,21 @@ MODRET set_sqlgroupinfo(cmd_rec *cmd) {
   if (cmd->argc-1 == 1) {
     char *groupbyname = NULL, *groupbyid = NULL, *groupmembers = NULL,
       *groupset = NULL, *groupsetfast = NULL;
-    char *ptr = NULL;
+    char *param, *ptr = NULL;
 
     /* If only one paramter is used, it must be of the "custom:/" form. */
-    if (strncmp("custom:/", cmd->argv[1], 8) != 0) {
+    param = cmd->argv[1];
+    if (strncmp("custom:/", param, 8) != 0) {
       CONF_ERROR(cmd, "badly formatted parameter");
     }
 
-    ptr = strchr(cmd->argv[1] + 8, '/');
+    ptr = strchr(param + 8, '/');
     if (ptr == NULL) {
       CONF_ERROR(cmd, "badly formatted parameter");
     }
 
     *ptr = '\0';
-    groupbyname = cmd->argv[1] + 8;
+    groupbyname = param + 8;
     groupbyid = ptr + 1;
 
     add_config_param_str("SQLCustomGroupInfoByName", 1, groupbyname);
@@ -6101,11 +6103,15 @@ MODRET set_sqlauthenticate(cmd_rec *cmd) {
         userset_flag = 1;
 
       } else if (strncasecmp("groups", arg, 6) == 0) {
-        if (groups_flag)
+        if (groups_flag) {
           CONF_ERROR(cmd, "groups already set");
-	
+        }
+
         if (strcasecmp("groups*", arg) == 0) {
-          pr_log_debug(DEBUG1, "%s: use of '*' in SQLAuthenticate has been deprecated.  Use AuthOrder for setting authoritativeness", cmd->argv[0]);
+          pr_log_debug(DEBUG1,
+            "%s: use of '*' in SQLAuthenticate has been deprecated. "
+            "Use AuthOrder for setting authoritativeness",
+            (char *) cmd->argv[0]);
 
         } else if (strlen(arg) > 6) {
           CONF_ERROR(cmd, "unknown argument");
@@ -6115,11 +6121,15 @@ MODRET set_sqlauthenticate(cmd_rec *cmd) {
         groups_flag = 1;
 
       } else if (strncasecmp("users", arg, 5) == 0) {
-        if (users_flag)
+        if (users_flag) {
           CONF_ERROR(cmd, "users already set");
+        }
 
         if (strcasecmp("users*", arg) == 0) {
-          pr_log_debug(DEBUG1, "%s: use of '*' in SQLAuthenticate has been deprecated.  Use AuthOrder for setting authoritativeness", cmd->argv[0]);
+          pr_log_debug(DEBUG1,
+            "%s: use of '*' in SQLAuthenticate has been deprecated. "
+            "Use AuthOrder for setting authoritativeness",
+            (char *) cmd->argv[0]);
 
         } else if (strlen(arg) > 5) {
           CONF_ERROR(cmd, "unknown argument");

--- a/contrib/mod_sql_passwd.c
+++ b/contrib/mod_sql_passwd.c
@@ -93,14 +93,15 @@ static cmd_rec *sql_passwd_cmd_create(pool *parent_pool, int argc, ...) {
   cmd->pool = cmd_pool;
  
   cmd->argc = argc;
-  cmd->argv = (char **) pcalloc(cmd->pool, argc * sizeof(char *));
+  cmd->argv = pcalloc(cmd->pool, argc * sizeof(void *));
 
   /* Hmmm... */
   cmd->tmp_pool = cmd->pool;
 
   va_start(argp, argc);
-  for (i = 0; i < argc; i++)
+  for (i = 0; i < argc; i++) {
     cmd->argv[i] = va_arg(argp, char *);
+  } 
   va_end(argp);
 
   return cmd;

--- a/contrib/mod_wrap2/mod_wrap2.c
+++ b/contrib/mod_wrap2/mod_wrap2.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_wrap2 -- tcpwrappers-like access control
  *
- * Copyright (c) 2000-2014 TJ Saunders
+ * Copyright (c) 2000-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1428,9 +1428,8 @@ MODRET set_wrapgrouptables(cmd_rec *cmd) {
   register unsigned int i = 0;
   unsigned char have_registration = FALSE;
   config_rec *c = NULL;
-
   int argc = 1;
-  char **argv = NULL;
+  void **argv = NULL;
   array_header *acl = NULL;
 
   CHECK_ARGS(cmd, 3);
@@ -1443,7 +1442,7 @@ MODRET set_wrapgrouptables(cmd_rec *cmd) {
     tmp = strchr(cmd->argv[i], ':');
     if (tmp == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "badly table parameter: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
     }
 
     *tmp = '\0';
@@ -1457,7 +1456,7 @@ MODRET set_wrapgrouptables(cmd_rec *cmd) {
 
     if (!have_registration) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unsupported table source type: '",
-        cmd->argv[1], "'", NULL));
+        (char *) cmd->argv[1], "'", NULL));
     }
 
     *tmp = ':';
@@ -1465,12 +1464,12 @@ MODRET set_wrapgrouptables(cmd_rec *cmd) {
 
   c = add_config_param(cmd->argv[0], 0);
 
-  acl = pr_expr_create(cmd->tmp_pool, &argc, &cmd->argv[0]);
+  acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) &cmd->argv[0]);
 
   /* Build the desired config_rec manually. */
   c->argc = argc + 2;
-  c->argv = pcalloc(c->pool, (argc + 3) * sizeof(char *));
-  argv = (char **) c->argv;
+  c->argv = pcalloc(c->pool, (argc + 3) * sizeof(void *));
+  argv = c->argv;
 
   /* The tables are the first two parameters */
   *argv++ = pstrdup(c->pool, cmd->argv[2]);
@@ -1497,7 +1496,6 @@ MODRET set_wraplog(cmd_rec *cmd) {
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
   add_config_param_str(cmd->argv[0], 1, cmd->argv[1]);
-
   return PR_HANDLED(cmd);
 }
 
@@ -1507,8 +1505,9 @@ MODRET set_wrapoptions(cmd_rec *cmd) {
   register unsigned int i = 0;
   unsigned long opts = 0UL;
 
-  if (cmd->argc-1 == 0)
+  if (cmd->argc-1 == 0) {
     CONF_ERROR(cmd, "wrong number of parameters");
+  }
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
@@ -1591,9 +1590,8 @@ MODRET set_wrapusertables(cmd_rec *cmd) {
   register unsigned int i = 0;
   unsigned char have_registration = FALSE;
   config_rec *c = NULL;
-
   int argc = 1;
-  char **argv = NULL;
+  void **argv = NULL;
   array_header *acl = NULL;
 
   CHECK_ARGS(cmd, 3);
@@ -1606,7 +1604,7 @@ MODRET set_wrapusertables(cmd_rec *cmd) {
     tmp = strchr(cmd->argv[i], ':');
     if (tmp == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "badly table parameter: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
     }
 
     *tmp = '\0';
@@ -1620,7 +1618,7 @@ MODRET set_wrapusertables(cmd_rec *cmd) {
 
     if (!have_registration) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unsupported table source type: '",
-        cmd->argv[1], "'", NULL));
+        (char *) cmd->argv[1], "'", NULL));
     }
 
     *tmp = ':';
@@ -1628,29 +1626,29 @@ MODRET set_wrapusertables(cmd_rec *cmd) {
 
   c = add_config_param(cmd->argv[0], 0);
 
-  acl = pr_expr_create(cmd->tmp_pool, &argc, &cmd->argv[0]);
+  acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) &cmd->argv[0]);
 
   /* Build the desired config_rec manually. */
   c->argc = argc + 2;
-  c->argv = pcalloc(c->pool, (argc + 3) * sizeof(char *));
-  argv = (char **) c->argv;
+  c->argv = pcalloc(c->pool, (argc + 3) * sizeof(void *));
+  argv = c->argv;
 
   /* The tables are the first two parameters */
   *argv++ = pstrdup(c->pool, cmd->argv[2]);
   *argv++ = pstrdup(c->pool, cmd->argv[3]); 
 
   /* Now populate the user-expression names */
-  if (argc && acl)
+  if (argc && acl) {
     while (argc--) {
       *argv++ = pstrdup(c->pool, *((char **) acl->elts));
       acl->elts = ((char **) acl->elts) + 1;
     }
+  }
 
   /* Do not forget the terminating NULL */
   *argv = NULL;
 
   c->flags |= CF_MERGEDOWN;
-
   return PR_HANDLED(cmd);
 }
 

--- a/contrib/mod_wrap2_sql.c
+++ b/contrib/mod_wrap2_sql.c
@@ -45,14 +45,15 @@ static cmd_rec *sql_cmd_create(pool *parent_pool, int argc, ...) {
   cmd->pool = cmd_pool;
 
   cmd->argc = argc;
-  cmd->argv = (char **) pcalloc(cmd->pool, argc * sizeof(char *));
+  cmd->argv = pcalloc(cmd->pool, argc * sizeof(void *));
 
   /* Hmmm... */
   cmd->tmp_pool = cmd->pool;
 
   va_start(argp, argc);
-  for (i = 0; i < argc; i++)
+  for (i = 0; i < argc; i++) {
     cmd->argv[i] = va_arg(argp, char *);
+  }
   va_end(argp);
 
   return cmd;

--- a/include/dirtree.h
+++ b/include/dirtree.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2014 The ProFTPD Project team
+ * Copyright (c) 2001-2015 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,9 +24,7 @@
  * the source code for OpenSSL in the source distribution.
  */
 
-/* Server, command and associated prototypes.
- * $Id: dirtree.h,v 1.88 2013-07-16 19:06:13 castaglia Exp $
- */
+/* Server, command and associated prototypes. */
 
 #ifndef PR_DIRTREE_H
 #define PR_DIRTREE_H
@@ -117,7 +115,8 @@ typedef struct cmd_struc {
   int argc;
 
   char *arg;			/* entire argument (excluding command) */
-  char **argv;
+  void **argv;
+
   char *group;			/* Command grouping */
 
   int cmd_class;		/* The command class */

--- a/include/proftpd.h
+++ b/include/proftpd.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2014 The ProFTPD Project team
+ * Copyright (c) 2001-2015 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,9 +24,7 @@
  * the source code for OpenSSL in the source distribution.
  */
 
-/* General options
- * $Id: proftpd.h,v 1.75 2012-04-15 18:04:14 castaglia Exp $
- */
+/* General options */
 
 #ifndef PR_PROFTPD_H
 #define PR_PROFTPD_H

--- a/lib/json.c
+++ b/lib/json.c
@@ -445,7 +445,7 @@ bool json_validate(const char *json)
 	return true;
 }
 
-JsonNode *json_find_element(JsonNode *array, int index)
+JsonNode *json_find_element(JsonNode *array, int idx)
 {
 	JsonNode *element;
 	int i = 0;
@@ -454,7 +454,7 @@ JsonNode *json_find_element(JsonNode *array, int index)
 		return NULL;
 	
 	json_foreach(element, array) {
-		if (i == index)
+		if (i == idx)
 			return element;
 		i++;
 	}

--- a/lib/tpl.c
+++ b/lib/tpl.c
@@ -23,9 +23,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define TPL_VERSION 1.5
 
-static const char id[]="$Id: tpl.c,v 1.4 2012-06-18 16:48:30 castaglia Exp $";
-
-
 #include <stdlib.h>  /* malloc */
 #include <stdarg.h>  /* va_list */
 #include <string.h>  /* memcpy, memset, strchr */
@@ -228,7 +225,6 @@ tpl_hook_t tpl_hook = {
 };
 
 static const char tpl_fmt_chars[] = "AS($)BiucsfIUjv#"; /* valid format chars */
-static const char tpl_S_fmt_chars[] = "iucsfIUjv#$()"; /* valid within S(...) */
 static const char tpl_datapeek_ok_chars[] = "iucsfIUjv"; /* valid in datapeek */
 static const struct tpl_type_t tpl_types[] = {
     /* [TPL_TYPE_ROOT] =   */  {'r', 0},

--- a/modules/mod_auth_file.c
+++ b/modules/mod_auth_file.c
@@ -1326,6 +1326,7 @@ MODRET set_authgroupfile(cmd_rec *cmd) {
   config_rec *c = NULL;
   authfile_file_t *file = NULL;
   int flags = 0;
+  char *path;
 
 #ifdef PR_USE_REGEX
   if (cmd->argc-1 < 1 ||
@@ -1339,10 +1340,11 @@ MODRET set_authgroupfile(cmd_rec *cmd) {
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-  if (*(cmd->argv[1]) != '/') {
+  path = cmd->argv[1];
+  if (*path != '/') {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-      "unable to use relative path for ", cmd->argv[0], " '",
-      cmd->argv[1], "'.", NULL));
+      "unable to use relative path for ", (char *) cmd->argv[0], " '",
+      path, "'.", NULL));
   }
 
   /* Make sure the configured file has the correct permissions.  Note that
@@ -1352,13 +1354,13 @@ MODRET set_authgroupfile(cmd_rec *cmd) {
   flags = PR_AUTH_FILE_FL_ALLOW_WORLD_READABLE;
   if (af_check_file(cmd->tmp_pool, cmd->argv[0], cmd->argv[1], flags) < 0) {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-      "unable to use ", cmd->argv[1], ": ", strerror(errno), NULL));
+      "unable to use ", path, ": ", strerror(errno), NULL));
   }
 
   c = add_config_param(cmd->argv[0], 1, NULL);
 
   file = pcalloc(c->pool, sizeof(authfile_file_t));
-  file->af_path = pstrdup(c->pool, cmd->argv[1]);
+  file->af_path = pstrdup(c->pool, path);
   c->argv[0] = (void *) file;
 
   /* Check for restrictions */
@@ -1446,6 +1448,7 @@ MODRET set_authuserfile(cmd_rec *cmd) {
   config_rec *c = NULL;
   authfile_file_t *file = NULL;
   int flags = 0;
+  char *path;
 
 #ifdef PR_USE_REGEX
   if (cmd->argc-1 < 1 ||
@@ -1459,10 +1462,11 @@ MODRET set_authuserfile(cmd_rec *cmd) {
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
-  if (*(cmd->argv[1]) != '/') {
+  path = cmd->argv[1];
+  if (*path != '/') {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-      "unable to use relative path for ", cmd->argv[0], " '",
-      cmd->argv[1], "'.", NULL));
+      "unable to use relative path for ", (char *) cmd->argv[0], " '",
+      path, "'.", NULL));
   }
 
   /* Make sure the configured file has the correct permissions.  Note that
@@ -1472,13 +1476,13 @@ MODRET set_authuserfile(cmd_rec *cmd) {
   flags = 0;
   if (af_check_file(cmd->tmp_pool, cmd->argv[0], cmd->argv[1], flags) < 0) {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-      "unable to use ", cmd->argv[1], ": ", strerror(errno), NULL));
+      "unable to use ", path, ": ", strerror(errno), NULL));
   }
 
   c = add_config_param(cmd->argv[0], 1, NULL);
 
   file = pcalloc(c->pool, sizeof(authfile_file_t));
-  file->af_path = pstrdup(c->pool, cmd->argv[1]);
+  file->af_path = pstrdup(c->pool, path);
   c->argv[0] = (void *) file;
 
   /* Check for restrictions */

--- a/modules/mod_auth_pam.c
+++ b/modules/mod_auth_pam.c
@@ -277,11 +277,11 @@ MODRET pam_auth(cmd_rec *cmd) {
    */
   if (pam_user_len > MAXLOGNAME) {
     pr_log_pri(PR_LOG_NOTICE,
-      "PAM(%s): Name exceeds maximum login length (%u)", cmd->argv[0],
+      "PAM(%s): Name exceeds maximum login length (%u)", (char *) cmd->argv[0],
       MAXLOGNAME);
     pr_trace_msg(trace_channel, 1,
       "user name '%s' exceeds maximum login length %u, declining",
-      cmd->argv[0], MAXLOGNAME);
+      (char *) cmd->argv[0], MAXLOGNAME);
     return PR_DECLINED(cmd);
   }
 #endif
@@ -408,7 +408,7 @@ MODRET pam_auth(cmd_rec *cmd) {
     }
 
     pr_trace_msg(trace_channel, 1,
-      "authentication error (%d) for user '%s': %s", res, cmd->argv[0],
+      "authentication error (%d) for user '%s': %s", res, (char *) cmd->argv[0],
       pam_strerror(pamh, res));
     goto done;
   }
@@ -462,7 +462,7 @@ MODRET pam_auth(cmd_rec *cmd) {
     }
 
     pr_log_pri(PR_LOG_NOTICE, MOD_AUTH_PAM_VERSION
-      ": PAM(%s): %s", cmd->argv[0], pam_strerror(pamh, res));
+      ": PAM(%s): %s", (char *) cmd->argv[0], pam_strerror(pamh, res));
     goto done;
   }
 
@@ -480,7 +480,7 @@ MODRET pam_auth(cmd_rec *cmd) {
     }
 
     pr_log_pri(PR_LOG_NOTICE, MOD_AUTH_PAM_VERSION
-      ": PAM(%s): %s", cmd->argv[0], pam_strerror(pamh, res));
+      ": PAM(%s): %s", (char *) cmd->argv[0], pam_strerror(pamh, res));
     goto done;
   }
 
@@ -525,7 +525,7 @@ MODRET pam_auth(cmd_rec *cmd) {
     }
 
     pr_log_pri(PR_LOG_NOTICE, MOD_AUTH_PAM_VERSION
-      ": PAM(%s): %s", cmd->argv[0], pam_strerror(pamh, res));
+      ": PAM(%s): %s", (char *) cmd->argv[0], pam_strerror(pamh, res));
     goto done;
   }
 
@@ -621,7 +621,7 @@ MODRET set_authpamoptions(cmd_rec *cmd) {
 
     } else {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown AuthPAMOption: '",
-        cmd->argv[i], "'", NULL));
+        (char *) cmd->argv[i], "'", NULL));
     }
   }
 

--- a/modules/mod_cap.c
+++ b/modules/mod_cap.c
@@ -29,7 +29,7 @@
  * recommended for security-consious admins. See README.capabilities for more
  * information.
  *
- * -- DO NOT MODIFY THE TWO LINES BELOW --
+ * ----- DO NOT MODIFY THE TWO LINES BELOW -----
  * $Libraries: -L$(top_srcdir)/lib/libcap -lcap$
  * $Directories: $(top_srcdir)/lib/libcap$
  */
@@ -190,8 +190,9 @@ MODRET set_caps(cmd_rec *cmd) {
   config_rec *c = NULL;
   register unsigned int i = 0;
 
-  if (cmd->argc - 1 < 1)
+  if (cmd->argc - 1 < 1) {
     CONF_ERROR(cmd, "need at least one parameter");
+  }
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
 
@@ -199,40 +200,50 @@ MODRET set_caps(cmd_rec *cmd) {
   flags |= (CAP_USE_CHOWN|CAP_USE_SETUID);
 
   for (i = 1; i < cmd->argc; i++) {
-    char *cp = cmd->argv[i];
-    cp++;
+    char *cap, *ptr;
 
-    if (*cmd->argv[i] != '+' && *cmd->argv[i] != '-')
+    cap = ptr = cmd->argv[i];
+    ptr++;
+
+    if (*param != '+' &&
+        *param != '-') {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": bad option: '",
-        cmd->argv[i], "'", NULL));
+        param, "'", NULL));
+    }
 
-    if (strcasecmp(cp, "CAP_CHOWN") == 0) {
-      if (*cmd->argv[i] == '-')
+    if (strcasecmp(ptr, "CAP_CHOWN") == 0) {
+      if (*param == '-') {
         flags &= ~CAP_USE_CHOWN;
+      }
 
-    } else if (strcasecmp(cp, "CAP_DAC_OVERRIDE") == 0) {
-      if (*cmd->argv[i] == '+')
+    } else if (strcasecmp(ptr, "CAP_DAC_OVERRIDE") == 0) {
+      if (*param == '+') {
         flags |= CAP_USE_DAC_OVERRIDE;
+      }
 
-    } else if (strcasecmp(cp, "CAP_DAC_READ_SEARCH") == 0) {
-      if (*cmd->argv[i] == '+')
+    } else if (strcasecmp(ptr, "CAP_DAC_READ_SEARCH") == 0) {
+      if (*param == '+') {
         flags |= CAP_USE_DAC_READ_SEARCH;
+      }
 
-    } else if (strcasecmp(cp, "CAP_FOWNER") == 0) {
-      if (*cmd->argv[i] == '+')
+    } else if (strcasecmp(ptr, "CAP_FOWNER") == 0) {
+      if (*param == '+') {
         flags |= CAP_USE_FOWNER;
+      }
 
-    } else if (strcasecmp(cp, "CAP_FSETID") == 0) {
-      if (*cmd->argv[i] == '+')
+    } else if (strcasecmp(ptr, "CAP_FSETID") == 0) {
+      if (*param == '+') {
         flags |= CAP_USE_FSETID;
+      }
 
-    } else if (strcasecmp(cp, "CAP_SETUID") == 0) {
-      if (*cmd->argv[i] == '-')
+    } else if (strcasecmp(ptr, "CAP_SETUID") == 0) {
+      if (*param == '-') {
         flags &= ~CAP_USE_SETUID;
+      }
 
     } else {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unknown capability: '",
-        cp, "'", NULL));
+        ptr, "'", NULL));
     }
   }
 

--- a/modules/mod_cap.c
+++ b/modules/mod_cap.c
@@ -205,39 +205,39 @@ MODRET set_caps(cmd_rec *cmd) {
     cap = ptr = cmd->argv[i];
     ptr++;
 
-    if (*param != '+' &&
-        *param != '-') {
-      CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": bad option: '",
-        param, "'", NULL));
+    if (*cap != '+' &&
+        *cap != '-') {
+      CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": bad option: '", cap, "'",
+        NULL));
     }
 
     if (strcasecmp(ptr, "CAP_CHOWN") == 0) {
-      if (*param == '-') {
+      if (*cap == '-') {
         flags &= ~CAP_USE_CHOWN;
       }
 
     } else if (strcasecmp(ptr, "CAP_DAC_OVERRIDE") == 0) {
-      if (*param == '+') {
+      if (*cap == '+') {
         flags |= CAP_USE_DAC_OVERRIDE;
       }
 
     } else if (strcasecmp(ptr, "CAP_DAC_READ_SEARCH") == 0) {
-      if (*param == '+') {
+      if (*cap == '+') {
         flags |= CAP_USE_DAC_READ_SEARCH;
       }
 
     } else if (strcasecmp(ptr, "CAP_FOWNER") == 0) {
-      if (*param == '+') {
+      if (*cap == '+') {
         flags |= CAP_USE_FOWNER;
       }
 
     } else if (strcasecmp(ptr, "CAP_FSETID") == 0) {
-      if (*param == '+') {
+      if (*cap == '+') {
         flags |= CAP_USE_FSETID;
       }
 
     } else if (strcasecmp(ptr, "CAP_SETUID") == 0) {
-      if (*param == '-') {
+      if (*cap == '-') {
         flags &= ~CAP_USE_SETUID;
       }
 

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -2307,9 +2307,11 @@ MODRET set_hidefiles(cmd_rec *cmd) {
   } else if (cmd->argc-1 == 3) {
     array_header *acl = NULL;
     int argc = cmd->argc - 3;
-    char **argv = ((char **) cmd->argv) + 2;
+    void **argv;
 
-    acl = pr_expr_create(cmd->tmp_pool, &argc, argv);
+    argv = &(cmd->argv[2]);
+
+    acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) argv);
     if (acl == NULL) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error creating expression: ",
         strerror(errno), NULL));
@@ -2327,7 +2329,7 @@ MODRET set_hidefiles(cmd_rec *cmd) {
     /* Capture the config_rec's argv pointer for doing the by-hand
      * population.
      */
-    argv = (char **) c->argv;
+    argv = c->argv;
 
     /* Copy in the regexp. */
     *argv = pcalloc(c->pool, sizeof(pr_regex_t *));

--- a/modules/mod_ctrls.c
+++ b/modules/mod_ctrls.c
@@ -3,7 +3,7 @@
  *          server, as well as several utility functions for other Controls
  *          modules
  *
- * Copyright (c) 2000-2014 TJ Saunders
+ * Copyright (c) 2000-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@
  *
  * This is mod_ctrls, contrib software for proftpd 1.2 and above.
  * For more information contact TJ Saunders <tj@castaglia.org>.
- *
- * $Id: mod_ctrls.c,v 1.59 2013-12-05 00:11:01 castaglia Exp $
  */
 
 #include "conf.h"
@@ -991,11 +989,11 @@ MODRET set_ctrlsauthfreshness(cmd_rec *cmd) {
   CHECK_CONF(cmd, CONF_ROOT);
 
   freshness = atoi(cmd->argv[1]);
-  if (freshness <= 0)
+  if (freshness <= 0) {
     CONF_ERROR(cmd, "must be a positive number");
+  }
 
   ctrls_cl_freshness = freshness;
-
   return PR_HANDLED(cmd);
 }
 
@@ -1006,8 +1004,9 @@ MODRET set_ctrlsengine(cmd_rec *cmd) {
   CHECK_CONF(cmd, CONF_ROOT);
 
   bool = get_boolean(cmd, 1);
-  if (bool == -1)
+  if (bool == -1) {
     CONF_ERROR(cmd, "expected Boolean parameter");
+  }
 
   ctrls_engine = bool;
   return PR_HANDLED(cmd);
@@ -1021,8 +1020,9 @@ MODRET set_ctrlsinterval(cmd_rec *cmd) {
   CHECK_CONF(cmd, CONF_ROOT);
 
   nsecs = atoi(cmd->argv[1]);
-  if (nsecs <= 0)
+  if (nsecs <= 0) {
     CONF_ERROR(cmd, "must be a positive number");
+  }
 
   /* Remove the existing timer, and re-install it with this new interval. */
   ctrls_interval = nsecs;
@@ -1044,13 +1044,15 @@ MODRET set_ctrlslog(cmd_rec *cmd) {
 
   res = ctrls_openlog();
   if (res < 0) {
-    if (res == -1)
+    if (res == -1) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unable to open '",
-        cmd->argv[1], "': ", strerror(errno), NULL));
+        (char *) cmd->argv[1], "': ", strerror(errno), NULL));
+    }
 
-    if (res == -2)
+    if (res == -2) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
         "unable to log to a world-writable directory", NULL));
+    }
   }
 
   return PR_HANDLED(cmd);
@@ -1064,8 +1066,9 @@ MODRET set_ctrlsmaxclients(cmd_rec *cmd) {
   CHECK_CONF(cmd, CONF_ROOT);
 
   nclients = atoi(cmd->argv[1]);
-  if (nclients <= 0)
+  if (nclients <= 0) {
     CONF_ERROR(cmd, "must be a positive number");
+  }
 
   cl_maxlistlen = nclients;
   return PR_HANDLED(cmd);
@@ -1073,11 +1076,15 @@ MODRET set_ctrlsmaxclients(cmd_rec *cmd) {
 
 /* Default: var/run/proftpd.sock */
 MODRET set_ctrlssocket(cmd_rec *cmd) {
+  char *path;
+
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT);
 
-  if (*cmd->argv[1] != '/')
+  path = cmd->argv[1];
+  if (*path != '/') {
     CONF_ERROR(cmd, "must be an absolute path");
+  }
 
   /* Close the socket. */
   if (ctrls_sockfd >= 0) {
@@ -1089,8 +1096,8 @@ MODRET set_ctrlssocket(cmd_rec *cmd) {
   }
 
   /* Change the path. */
-  if (strcmp(cmd->argv[1], ctrls_sock_file) != 0) {
-    ctrls_sock_file = pstrdup(ctrls_pool, cmd->argv[1]);
+  if (strcmp(path, ctrls_sock_file) != 0) {
+    ctrls_sock_file = pstrdup(ctrls_pool, path);
   }
 
   return PR_HANDLED(cmd);
@@ -1135,29 +1142,33 @@ MODRET set_ctrlssocketowner(cmd_rec *cmd) {
 
   uid = pr_auth_name2uid(cmd->tmp_pool, cmd->argv[1]);
   if (uid == (uid_t) -1) {
-    if (errno != EINVAL)
-      pr_log_debug(DEBUG0, "%s: %s has UID of -1", cmd->argv[0],
-        cmd->argv[1]);
+    if (errno != EINVAL) {
+      pr_log_debug(DEBUG0, "%s: %s has UID of -1", (char *) cmd->argv[0],
+        (char *) cmd->argv[1]);
 
-    else
-      pr_log_debug(DEBUG0, "%s: no such user '%s'", cmd->argv[0],
-        cmd->argv[1]);
+    } else {
+      pr_log_debug(DEBUG0, "%s: no such user '%s'", (char *) cmd->argv[0],
+        (char *) cmd->argv[1]);
+    }
 
-  } else
+  } else {
     ctrls_sock_uid = uid;
+  }
 
   gid = pr_auth_name2gid(cmd->tmp_pool, cmd->argv[2]);
   if (gid == (gid_t) -1) {
-    if (errno != EINVAL)
-      pr_log_debug(DEBUG0, "%s: %s has GID of -1", cmd->argv[0],
-        cmd->argv[2]);
+    if (errno != EINVAL) {
+      pr_log_debug(DEBUG0, "%s: %s has GID of -1", (char *) cmd->argv[0],
+        (char *) cmd->argv[2]);
 
-    else
-      pr_log_debug(DEBUG0, "%s: no such group '%s'", cmd->argv[0],
-        cmd->argv[2]);
+    } else {
+      pr_log_debug(DEBUG0, "%s: no such group '%s'", (char *) cmd->argv[0],
+        (char *) cmd->argv[2]);
+    }
 
-  } else
+  } else {
     ctrls_sock_gid = gid;
+  }
 
   return PR_HANDLED(cmd);
 }

--- a/modules/mod_dso.c
+++ b/modules/mod_dso.c
@@ -574,7 +574,7 @@ MODRET set_moduleorder(cmd_rec *cmd) {
     }
   }
 
-  pr_log_debug(DEBUG4, "%s: reordering modules", cmd->argv[0]);
+  pr_log_debug(DEBUG4, "%s: reordering modules", (char *) cmd->argv[0]);
   for (i = 1; i < cmd->argc; i++) {
     m = pr_module_get(cmd->argv[i]);
 
@@ -596,7 +596,7 @@ MODRET set_moduleorder(cmd_rec *cmd) {
 
     if (pr_module_unload(m) < 0) {
       pr_log_debug(DEBUG0, "%s: error unloading module 'mod_%s.c': %s",
-        cmd->argv[0], m->name, strerror(errno));
+        (char *) cmd->argv[0], m->name, strerror(errno));
     }
 
     m = mn;
@@ -605,12 +605,12 @@ MODRET set_moduleorder(cmd_rec *cmd) {
   for (m = module_list; m; m = m->next) {
     if (pr_module_load(m) < 0) {
       pr_log_debug(DEBUG0, "%s: error loading module 'mod_%s.c': %s",
-        cmd->argv[0], m->name, strerror(errno));
+        (char *) cmd->argv[0], m->name, strerror(errno));
       exit(1);
     }
   }
 
-  pr_log_pri(PR_LOG_NOTICE, "%s: module order is now:", cmd->argv[0]);
+  pr_log_pri(PR_LOG_NOTICE, "%s: module order is now:", (char *) cmd->argv[0]);
   for (m = loaded_modules; m; m = m->next) {
     pr_log_pri(PR_LOG_NOTICE, " mod_%s.c", m->name);
   }

--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -71,7 +71,8 @@ static int facts_filters_allow_path(cmd_rec *cmd, const char *path) {
   if (pre != NULL &&
       pr_regexp_exec(pre, path, 0, NULL, 0, 0, 0) != 0) {
     pr_log_debug(DEBUG2, MOD_FACTS_VERSION
-      ": %s denied by PathAllowFilter on '%s'", cmd->argv[0], cmd->arg);
+      ": %s denied by PathAllowFilter on '%s'", (char *) cmd->argv[0],
+      cmd->arg);
     return -1;
   }
 
@@ -79,7 +80,7 @@ static int facts_filters_allow_path(cmd_rec *cmd, const char *path) {
   if (pre != NULL &&
       pr_regexp_exec(pre, path, 0, NULL, 0, 0, 0) == 0) {
     pr_log_debug(DEBUG2, MOD_FACTS_VERSION
-      ": %s denied by PathDenyFilter on '%s'", cmd->argv[0], cmd->arg);
+      ": %s denied by PathDenyFilter on '%s'", (char *) cmd->argv[0], cmd->arg);
     return -1;
   }
 #endif
@@ -912,7 +913,7 @@ MODRET facts_mff(cmd_rec *cmd) {
 
   if (!dir_check(cmd->tmp_pool, cmd, cmd->group, canon_path, NULL)) {
     pr_log_debug(DEBUG4, MOD_FACTS_VERSION ": %s command denied by <Limit>",
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
     pr_response_add_err(R_550, _("Unable to handle command"));
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -955,7 +956,8 @@ MODRET facts_mff(cmd_rec *cmd) {
       if (ptr2 == NULL) {
         int xerrno = EINVAL;
 
-        pr_response_add_err(R_501, "%s: %s", cmd->argv[1], strerror(xerrno));
+        pr_response_add_err(R_501, "%s: %s", (char *) cmd->argv[1],
+          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;
@@ -978,7 +980,7 @@ MODRET facts_mff(cmd_rec *cmd) {
       if (ptr2) {
         pr_log_debug(DEBUG7, MOD_FACTS_VERSION
           ": %s: ignoring unsupported timestamp precision in '%s'",
-          cmd->argv[0], timestamp);
+          (char *) cmd->argv[0], timestamp);
         *ptr2 = '\0';
       }
 
@@ -1003,7 +1005,8 @@ MODRET facts_mff(cmd_rec *cmd) {
         int xerrno = EINVAL;
 
         *ptr = ';';
-        pr_response_add_err(R_501, "%s: %s", cmd->argv[1], strerror(xerrno));
+        pr_response_add_err(R_501, "%s: %s", (char *) cmd->argv[1],
+          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;
@@ -1033,7 +1036,8 @@ MODRET facts_mff(cmd_rec *cmd) {
         int xerrno = errno;
 
         *ptr = ';';
-        pr_response_add_err(R_501, "%s: %s", cmd->argv[1], strerror(xerrno));
+        pr_response_add_err(R_501, "%s: %s", (char *) cmd->argv[1],
+          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;
@@ -1059,7 +1063,7 @@ MODRET facts_mff(cmd_rec *cmd) {
        */
       pr_log_debug(DEBUG5, MOD_FACTS_VERSION
         ": %s: fact '%s' unsupported for modification, denying request",
-        cmd->argv[0], facts);
+        (char *) cmd->argv[0], facts);
       pr_response_add_err(R_504, _("Cannot modify fact '%s'"), facts);
 
       *ptr = ';';
@@ -1078,7 +1082,7 @@ MODRET facts_mff(cmd_rec *cmd) {
    * were successfully modified are to be included in the response, for
    * possible client parsing.  This means that the list is NOT localisable.
    */
-  pr_response_add(R_213, "%s %s", cmd->argv[1], path);
+  pr_response_add(R_213, "%s %s", (char *) cmd->argv[1], path);
   return PR_HANDLED(cmd);
 }
 
@@ -1140,7 +1144,7 @@ MODRET facts_mfmt(cmd_rec *cmd) {
 
   if (!dir_check(cmd->tmp_pool, cmd, cmd->group, canon_path, NULL)) {
     pr_log_debug(DEBUG4, MOD_FACTS_VERSION ": %s command denied by <Limit>",
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
     pr_response_add_err(R_550, _("Unable to handle command"));
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -1171,8 +1175,8 @@ MODRET facts_mfmt(cmd_rec *cmd) {
   ptr = strchr(timestamp, '.');
   if (ptr) {
     pr_log_debug(DEBUG7, MOD_FACTS_VERSION
-      ": %s: ignoring unsupported timestamp precision in '%s'", cmd->argv[0],
-      timestamp);
+      ": %s: ignoring unsupported timestamp precision in '%s'",
+      (char *) cmd->argv[0], timestamp);
     *ptr = '\0';
   }
 
@@ -1244,7 +1248,7 @@ MODRET facts_mlsd(cmd_rec *cmd) {
 
   if (!dir_check(cmd->tmp_pool, cmd, cmd->group, (char *) decoded_path, NULL)) {
     pr_log_debug(DEBUG4, MOD_FACTS_VERSION ": %s command denied by <Limit>",
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
     pr_response_add_err(R_550, _("Unable to handle command"));
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -1266,7 +1270,7 @@ MODRET facts_mlsd(cmd_rec *cmd) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG4, MOD_FACTS_VERSION ": unable to stat '%s' (%s), "
-      "denying %s", decoded_path, strerror(xerrno), cmd->argv[0]);
+      "denying %s", decoded_path, strerror(xerrno), (char *) cmd->argv[0]);
 
     pr_response_add_err(R_550, "%s: %s", path, strerror(xerrno));
 
@@ -1500,7 +1504,7 @@ MODRET facts_mlst(cmd_rec *cmd) {
   if (!dir_check(cmd->tmp_pool, cmd, cmd->group, (char *) decoded_path,
       &hidden)) {
     pr_log_debug(DEBUG4, MOD_FACTS_VERSION ": %s command denied by <Limit>",
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
     pr_response_add_err(R_550, _("Unable to handle command"));
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -1633,8 +1637,9 @@ MODRET facts_opts_mlst(cmd_rec *cmd) {
 
   /* Convert underscores to spaces in the method name, for prettier logging. */
   for (i = 0; method[i]; i++) {
-    if (method[i] == '_')
+    if (method[i] == '_') {
       method[i] = ' ';
+    }
   }
 
   if (cmd->argc > 2) {

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -615,6 +615,7 @@ static int parse_classes(char *s, int *classes) {
 MODRET set_extendedlog(cmd_rec *cmd) {
   config_rec *c = NULL;
   int argc;
+  char *path;
 
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON);
 
@@ -626,25 +627,25 @@ MODRET set_extendedlog(cmd_rec *cmd) {
 
   c = add_config_param(cmd->argv[0], 3, NULL, NULL, NULL);
 
-  if (strncasecmp(cmd->argv[1], "syslog:", 7) == 0) {
+  path = cmd->argv[1];
+  if (strncasecmp(path, "syslog:", 7) == 0) {
     char *ptr;
 
-    ptr = strchr(cmd->argv[1], ':');
+    ptr = strchr(path, ':');
 
     if (pr_log_str2sysloglevel(++ptr) < 0) {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unknown syslog level: '",
         ptr, "'", NULL));
-
-    } else {
-      c->argv[0] = pstrdup(log_pool, cmd->argv[1]);
     }
 
-  } else if (cmd->argv[1][0] != '/') {
+    c->argv[0] = pstrdup(log_pool, path);
+
+  } else if (path[0] != '/') {
     CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "relative paths not allowed: '",
-        cmd->argv[1], "'", NULL));
+      path, "'", NULL));
 
   } else {
-    c->argv[0] = pstrdup(log_pool, cmd->argv[1]);
+    c->argv[0] = pstrdup(log_pool, path);
   }
 
   if (argc > 2) {
@@ -1232,7 +1233,8 @@ static char *get_next_meta(pool *p, cmd_rec *cmd, unsigned char **f) {
           *ptr = toupper((int) *ptr);
         }
 
-        snprintf(argp, sizeof(arg), "%s %s", cmd->argv[0], cmd->argv[1]);
+        snprintf(argp, sizeof(arg), "%s %s", (char *) cmd->argv[0],
+          (char *) cmd->argv[1]);
       }
 
       m++;

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -2337,8 +2337,10 @@ static int nlstdir(cmd_rec *cmd, const char *dir) {
   if (c != NULL) {
     unsigned char *ignore = get_param_ptr(c->subset, "IgnoreHidden", FALSE);
 
-    if (ignore && *ignore == TRUE)
+    if (ignore &&
+        *ignore == TRUE) {
       ignore_hidden = TRUE;
+    }
   }
 
   j = 0;
@@ -2480,14 +2482,14 @@ MODRET genericlist(cmd_rec *cmd) {
      * If not, keep looking for other applicable ListOptions.
      */
     if (list_flags & LS_FL_NLST_ONLY) {
-      pr_log_debug(DEBUG10, "%s: skipping NLSTOnly ListOptions", cmd->argv[0]);
+      pr_log_debug(DEBUG10, "%s: skipping NLSTOnly ListOptions",
+        (char *) cmd->argv[0]);
       c = find_config_next(c, c->next, CONF_PARAM, "ListOptions", FALSE);
       continue;
     }
 
     list_options = c->argv[0];
     list_strict_opts = *((unsigned char *) c->argv[1]);
-
     list_ndepth.max = *((unsigned int *) c->argv[2]);
 
     /* We add one to the configured maxdepth in order to allow it to
@@ -2496,8 +2498,9 @@ MODRET genericlist(cmd_rec *cmd) {
      * layer deeper.  For the checks to work, the maxdepth of 2 needs to
      * handled internally as a maxdepth of 3.
      */
-    if (list_ndepth.max)
+    if (list_ndepth.max) {
       list_ndepth.max += 1;
+    }
 
     list_nfiles.max = *((unsigned int *) c->argv[3]);
     list_ndirs.max = *((unsigned int *) c->argv[4]);
@@ -2589,7 +2592,8 @@ MODRET ls_stat(cmd_rec *cmd) {
     if (!dir_check(cmd->tmp_pool, cmd, cmd->group, session.cwd, NULL)) {
       int xerrno = EPERM;
 
-      pr_response_add_err(R_500, "%s: %s", cmd->argv[0], strerror(xerrno));
+      pr_response_add_err(R_500, "%s: %s", (char *) cmd->argv[0],
+        strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -2685,13 +2689,15 @@ MODRET ls_stat(cmd_rec *cmd) {
      * If not, keep looking for other applicable ListOptions.
      */
     if (list_flags & LS_FL_LIST_ONLY) {
-      pr_log_debug(DEBUG10, "%s: skipping LISTOnly ListOptions", cmd->argv[0]);
+      pr_log_debug(DEBUG10, "%s: skipping LISTOnly ListOptions",
+        (char *) cmd->argv[0]);
       c = find_config_next(c, c->next, CONF_PARAM, "ListOptions", FALSE);
       continue;
     }
 
     if (list_flags & LS_FL_NLST_ONLY) {
-      pr_log_debug(DEBUG10, "%s: skipping NLSTOnly ListOptions", cmd->argv[0]);
+      pr_log_debug(DEBUG10, "%s: skipping NLSTOnly ListOptions",
+        (char *) cmd->argv[0]);
       c = find_config_next(c, c->next, CONF_PARAM, "ListOptions", FALSE);
       continue;
     }
@@ -2833,7 +2839,8 @@ MODRET ls_nlst(cmd_rec *cmd) {
      * If not, keep looking for other applicable ListOptions.
      */
     if (list_flags & LS_FL_LIST_ONLY) {
-      pr_log_debug(DEBUG10, "%s: skipping LISTOnly ListOptions", cmd->argv[0]);
+      pr_log_debug(DEBUG10, "%s: skipping LISTOnly ListOptions",
+        (char *) cmd->argv[0]);
       c = find_config_next(c, c->next, CONF_PARAM, "ListOptions", FALSE);
       continue;
     }
@@ -3293,7 +3300,7 @@ MODRET set_dirfakeusergroup(cmd_rec *cmd) {
 
   if (cmd->argc < 2 ||
       cmd->argc > 3) {
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "syntax: ", cmd->argv[0],
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "syntax: ", (char *) cmd->argv[0],
       " on|off [<id to display>]", NULL));
   }
 
@@ -3387,45 +3394,48 @@ MODRET set_listoptions(cmd_rec *cmd) {
       } else if (strcasecmp(cmd->argv[i], "maxdepth") == 0) {
         int maxdepth = atoi(cmd->argv[++i]);
 
-        if (maxdepth < 1)
+        if (maxdepth < 1) {
           CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
             ": maxdepth must be greater than 0: '", cmd->argv[i],
             "'", NULL));
+        }
 
         *((unsigned int *) c->argv[2]) = maxdepth;
 
       } else if (strcasecmp(cmd->argv[i], "maxfiles") == 0) {
         int maxfiles = atoi(cmd->argv[++i]);
 
-        if (maxfiles < 1)
+        if (maxfiles < 1) {
           CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-            ": maxfiles must be greater than 0: '", cmd->argv[i],
+            ": maxfiles must be greater than 0: '", (char *) cmd->argv[i],
             "'", NULL));
+        }
 
-          *((unsigned int *) c->argv[3]) = maxfiles;
+        *((unsigned int *) c->argv[3]) = maxfiles;
 
       } else if (strcasecmp(cmd->argv[i], "maxdirs") == 0) {
         int maxdirs = atoi(cmd->argv[++i]);
 
-        if (maxdirs < 1)
+        if (maxdirs < 1) {
           CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-            ": maxdirs must be greater than 0: '", cmd->argv[i],
+            ": maxdirs must be greater than 0: '", (char *) cmd->argv[i],
             "'", NULL));
+        }
 
-          *((unsigned int *) c->argv[4]) = maxdirs;
+        *((unsigned int *) c->argv[4]) = maxdirs;
 
       } else if (strcasecmp(cmd->argv[i], "LISTOnly") == 0) {
-          flags |= LS_FL_LIST_ONLY;
+        flags |= LS_FL_LIST_ONLY;
 
       } else if (strcasecmp(cmd->argv[i], "NLSTOnly") == 0) {
-          flags |= LS_FL_NLST_ONLY;
+        flags |= LS_FL_NLST_ONLY;
 
       } else if (strcasecmp(cmd->argv[i], "NoErrorIfAbsent") == 0) {
-          flags |= LS_FL_NO_ERROR_IF_ABSENT;
+        flags |= LS_FL_NO_ERROR_IF_ABSENT;
 
       } else {
         CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown keyword: '",
-          cmd->argv[i], "'", NULL));
+          (char *) cmd->argv[i], "'", NULL));
       }
     }
   }
@@ -3459,8 +3469,10 @@ MODRET set_useglobbing(cmd_rec *cmd) {
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON);
 
-  if ((bool = get_boolean(cmd, 1)) == -1)
+  bool = get_boolean(cmd, 1);
+  if (bool == -1) {
     CONF_ERROR(cmd, "expected Boolean parameter");
+  }
 
   c = add_config_param(cmd->argv[0], 1, NULL);
   c->argv[0] = pcalloc(c->pool, sizeof(unsigned char));

--- a/modules/mod_site.c
+++ b/modules/mod_site.c
@@ -88,10 +88,11 @@ MODRET site_chgrp(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[i],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[i], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("SITE %s: Illegal character sequence in command"), cmd->argv[1]);
+        _("SITE %s: Illegal character sequence in command"),
+        (char *) cmd->argv[1]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -105,8 +106,8 @@ MODRET site_chgrp(cmd_rec *cmd) {
   pre = get_param_ptr(CURRENT_CONF, "PathAllowFilter", FALSE);
   if (pre != NULL &&
       pr_regexp_exec(pre, arg, 0, NULL, 0, 0, 0) != 0) {
-    pr_log_debug(DEBUG2, "'%s %s' denied by PathAllowFilter", cmd->argv[0],
-      arg);
+    pr_log_debug(DEBUG2, "'%s %s' denied by PathAllowFilter",
+      (char *) cmd->argv[0], arg);
     pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -117,8 +118,8 @@ MODRET site_chgrp(cmd_rec *cmd) {
   pre = get_param_ptr(CURRENT_CONF, "PathDenyFilter", FALSE);
   if (pre != NULL &&
       pr_regexp_exec(pre, arg, 0, NULL, 0, 0, 0) == 0) {
-    pr_log_debug(DEBUG2, "'%s %s' denied by PathDenyFilter", cmd->argv[0],
-      arg);
+    pr_log_debug(DEBUG2, "'%s %s' denied by PathDenyFilter",
+      (char *) cmd->argv[0], arg);
     pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -151,7 +152,8 @@ MODRET site_chgrp(cmd_rec *cmd) {
       int xerrno = EINVAL;
 
       pr_log_debug(DEBUG9,
-        "SITE CHGRP: Unable to resolve group name '%s' to GID", cmd->argv[1]);
+        "SITE CHGRP: Unable to resolve group name '%s' to GID",
+        (char *) cmd->argv[1]);
       pr_response_add_err(R_550, "%s: %s", arg, strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
@@ -165,7 +167,7 @@ MODRET site_chgrp(cmd_rec *cmd) {
     int xerrno = errno;
 
     (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-      "error chown'ing '%s' to GID %s: %s", cmd->argv[0], session.user,
+      "error chown'ing '%s' to GID %s: %s", (char *) cmd->argv[0], session.user,
       pr_uid2str(cmd->tmp_pool, session.uid),
       pr_gid2str(cmd->tmp_pool, session.gid), path,
       pr_gid2str(cmd->tmp_pool, gid), strerror(xerrno));
@@ -175,18 +177,17 @@ MODRET site_chgrp(cmd_rec *cmd) {
     pr_cmd_set_errno(cmd, xerrno);
     errno = xerrno;
     return PR_ERROR(cmd);
-
-  } else {
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[0]);
   }
 
+  pr_response_add(R_200, _("SITE %s command successful"),
+    (char *) cmd->argv[0]);
   return PR_HANDLED(cmd);
 }
 
 MODRET site_chmod(cmd_rec *cmd) {
   int res;
   mode_t mode = 0;
-  char *dir, *endp, *tmp, *arg = "";
+  char *dir, *endp, *mode_str, *tmp, *arg = "";
   register unsigned int i = 0;
 #ifdef PR_USE_REGEX
   pr_regex_t *pre;
@@ -209,10 +210,11 @@ MODRET site_chmod(cmd_rec *cmd) {
     if (decoded_path == NULL) {
       int xerrno = errno;
 
-      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s", cmd->argv[i],
-        strerror(xerrno));
+      pr_log_debug(DEBUG8, "'%s' failed to decode properly: %s",
+        (char *) cmd->argv[i], strerror(xerrno));
       pr_response_add_err(R_550,
-        _("SITE %s: Illegal character sequence in command"), cmd->argv[1]);
+        _("SITE %s: Illegal character sequence in command"),
+        (char *) cmd->argv[1]);
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -226,8 +228,8 @@ MODRET site_chmod(cmd_rec *cmd) {
   pre = get_param_ptr(CURRENT_CONF, "PathAllowFilter", FALSE);
   if (pre != NULL &&
       pr_regexp_exec(pre, arg, 0, NULL, 0, 0, 0) != 0) {
-    pr_log_debug(DEBUG2, "'%s %s %s' denied by PathAllowFilter", cmd->argv[0],
-      cmd->argv[1], arg);
+    pr_log_debug(DEBUG2, "'%s %s %s' denied by PathAllowFilter",
+      (char *) cmd->argv[0], (char *) cmd->argv[1], arg);
     pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -238,8 +240,8 @@ MODRET site_chmod(cmd_rec *cmd) {
   pre = get_param_ptr(CURRENT_CONF, "PathDenyFilter", FALSE);
   if (pre != NULL &&
       pr_regexp_exec(pre, arg, 0, NULL, 0, 0, 0) == 0) {
-    pr_log_debug(DEBUG2, "'%s %s %s' denied by PathDenyFilter", cmd->argv[0],
-      cmd->argv[1], arg);
+    pr_log_debug(DEBUG2, "'%s %s %s' denied by PathDenyFilter",
+      (char *) cmd->argv[0], (char *) cmd->argv[1], arg);
     pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
     pr_cmd_set_errno(cmd, EPERM);
@@ -263,18 +265,18 @@ MODRET site_chmod(cmd_rec *cmd) {
    * This will fail if the chmod is a symbolic, but takes care of the
    * case where an octal number is sent without the leading '0'.
    */
-
-  if (cmd->argv[1][0] != '0') {
-    tmp = pstrcat(cmd->tmp_pool, "0", cmd->argv[1], NULL);
+  mode_str = cmd->argv[1];
+  if (mode_str[0] != '0') {
+    tmp = pstrcat(cmd->tmp_pool, "0", mode_str, NULL);
 
   } else {
-    tmp = cmd->argv[1];
+    tmp = mode_str;
   }
 
-  mode = strtol(tmp,&endp,0);
+  mode = strtol(tmp, &endp, 0);
   if (endp && *endp) {
     /* It's not an absolute number, try symbolic */
-    char *cp = cmd->argv[1];
+    char *cp = mode_str;
     int mask = 0, mode_op = 0, curr_mode = 0, curr_umask = umask(0);
     int invalid = 0;
     char *who, *how, *what;
@@ -442,7 +444,7 @@ MODRET site_chmod(cmd_rec *cmd) {
     }
 
     if (invalid) {
-      pr_response_add_err(R_550, _("'%s': invalid mode"), cmd->argv[1]);
+      pr_response_add_err(R_550, _("'%s': invalid mode"), (char *) cmd->argv[1]);
 
       pr_cmd_set_errno(cmd, EINVAL);
       errno = EINVAL;
@@ -455,7 +457,7 @@ MODRET site_chmod(cmd_rec *cmd) {
     int xerrno = errno;
 
     (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-      "error chmod'ing '%s' to %04o: %s", cmd->argv[0], session.user,
+      "error chmod'ing '%s' to %04o: %s", (char *) cmd->argv[0], session.user,
       pr_uid2str(cmd->tmp_pool, session.uid),
       pr_gid2str(cmd->tmp_pool, session.gid), dir, (unsigned int) mode,
       strerror(xerrno));
@@ -465,11 +467,10 @@ MODRET site_chmod(cmd_rec *cmd) {
     pr_cmd_set_errno(cmd, xerrno);
     errno = xerrno;
     return PR_ERROR(cmd);
-
-  } else {
-    pr_response_add(R_200, _("SITE %s command successful"), cmd->argv[0]);
   }
 
+  pr_response_add(R_200, _("SITE %s command successful"),
+    (char *) cmd->argv[0]);
   return PR_HANDLED(cmd);
 }
 
@@ -488,28 +489,32 @@ MODRET site_help(cmd_rec *cmd) {
         strcasecmp(cmd->argv[1], "SITE") == 0)))) {
 
     for (i = 0; _help[i].cmd; i++) {
-      if (_help[i].implemented)
+      if (_help[i].implemented) {
         pr_response_add(i != 0 ? R_DUP : R_214, "%s", _help[i].cmd);
-      else
+
+      } else {
         pr_response_add(i != 0 ? R_DUP : R_214, "%s",
           pstrcat(cmd->pool, _help[i].cmd, "*", NULL));
+      }
     }
 
   } else {
-    char *cp = NULL;
+    char *arg, *cp = NULL;
 
-    for (cp = cmd->argv[1]; *cp; cp++)
+    arg = cmd->argv[1];
+    for (cp = arg; *cp; cp++) {
       *cp = toupper(*cp);
+    }
 
-    for (i = 0; _help[i].cmd; i++)
-      if (strcasecmp(cmd->argv[1], _help[i].cmd) == 0) {
+    for (i = 0; _help[i].cmd; i++) {
+      if (strcasecmp(arg, _help[i].cmd) == 0) {
         pr_response_add(R_214, _("Syntax: SITE %s %s"),
-          cmd->argv[1], _help[i].syntax);
+          (char *) cmd->argv[1], _help[i].syntax);
         return PR_HANDLED(cmd);
       }
+    }
 
     pr_response_add_err(R_502, _("Unknown command 'SITE %s'"), cmd->arg);
-
     pr_cmd_set_errno(cmd, ENOSYS);
     errno = ENOSYS;
     return PR_ERROR(cmd);
@@ -540,7 +545,7 @@ modret_t *site_dispatch(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-  for (i = 0; site_commands[i].command; i++)
+  for (i = 0; site_commands[i].command; i++) {
     if (strcmp(cmd->argv[0], site_commands[i].command) == 0) {
       if (site_commands[i].requires_auth && cmd_auth_chk &&
           !cmd_auth_chk(cmd)) {
@@ -549,13 +554,14 @@ modret_t *site_dispatch(cmd_rec *cmd) {
         pr_cmd_set_errno(cmd, EPERM);
         errno = EPERM;
         return PR_ERROR(cmd);
-
-      } else {
-        return site_commands[i].handler(cmd);
       }
-    }
 
-  pr_response_add_err(R_500, _("'SITE %s' not understood"), cmd->argv[0]);
+      return site_commands[i].handler(cmd);
+    }
+  }
+
+  pr_response_add_err(R_500, _("'SITE %s' not understood"),
+    (char *) cmd->argv[0]);
 
   pr_cmd_set_errno(cmd, EINVAL);
   errno = EINVAL;

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -1248,8 +1248,8 @@ MODRET xfer_pre_stor(cmd_rec *cmd) {
       !dir_check(cmd->tmp_pool, cmd, cmd->group, path, NULL)) {
     int xerrno = errno;
 
-    pr_log_debug(DEBUG8, "%s %s denied by <Limit> configuration", cmd->argv[0],
-      cmd->arg);
+    pr_log_debug(DEBUG8, "%s %s denied by <Limit> configuration",
+      (char *) cmd->argv[0], cmd->arg);
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -1263,8 +1263,8 @@ MODRET xfer_pre_stor(cmd_rec *cmd) {
       break;
 
     case PR_FILTER_ERR_FAILS_ALLOW_FILTER:
-      pr_log_debug(DEBUG2, "'%s %s' denied by PathAllowFilter", cmd->argv[0],
-        path);
+      pr_log_debug(DEBUG2, "'%s %s' denied by PathAllowFilter",
+        (char *) cmd->argv[0], path);
       pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
       pr_cmd_set_errno(cmd, EPERM);
@@ -1272,8 +1272,8 @@ MODRET xfer_pre_stor(cmd_rec *cmd) {
       return PR_ERROR(cmd);
 
     case PR_FILTER_ERR_FAILS_DENY_FILTER:
-      pr_log_debug(DEBUG2, "'%s %s' denied by PathDenyFilter", cmd->argv[0],
-        path);
+      pr_log_debug(DEBUG2, "'%s %s' denied by PathDenyFilter",
+        (char *) cmd->argv[0], path);
       pr_response_add_err(R_550, _("%s: Forbidden filename"), cmd->arg);
 
       pr_cmd_set_errno(cmd, EPERM);
@@ -1503,7 +1503,7 @@ MODRET xfer_pre_stou(cmd_rec *cmd) {
 
     /* If we can't guarantee a unique filename, refuse the command. */
     pr_response_add_err(R_450, _("%s: unable to generate unique filename"),
-      cmd->argv[0]);
+      (char *) cmd->argv[0]);
 
     pr_cmd_set_errno(cmd, xerrno);
     errno = xerrno;
@@ -1676,7 +1676,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
       ferrno = errno;
 
       (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-        "error opening '%s': %s", cmd->argv[0], session.user,
+        "error opening '%s': %s", (char *) cmd->argv[0], session.user,
         pr_uid2str(cmd->tmp_pool, session.uid),
         pr_gid2str(cmd->tmp_pool, session.gid), session.xfer.path_hidden,
         strerror(ferrno));
@@ -1697,7 +1697,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
       ferrno = errno;
 
       (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-        "error opening '%s': %s", cmd->argv[0], session.user,
+        "error opening '%s': %s", (char *) cmd->argv[0], session.user,
         pr_uid2str(cmd->tmp_pool, session.uid),
         pr_gid2str(cmd->tmp_pool, session.gid), session.xfer.path,
         strerror(ferrno));
@@ -1711,7 +1711,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
       ferrno = errno;
 
       (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-        "error opening '%s': %s", cmd->argv[0], session.user,
+        "error opening '%s': %s", (char *) cmd->argv[0], session.user,
         pr_uid2str(cmd->tmp_pool, session.uid),
         pr_gid2str(cmd->tmp_pool, session.gid), path, strerror(ferrno));
     }
@@ -1890,7 +1890,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
       }
 
       (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-        "error writing to '%s': %s", cmd->argv[0], session.user,
+        "error writing to '%s': %s", (char *) cmd->argv[0], session.user,
         pr_uid2str(cmd->tmp_pool, session.uid),
         pr_gid2str(cmd->tmp_pool, session.gid), stor_fh->fh_path,
         strerror(xerrno));
@@ -2017,7 +2017,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
 
 MODRET xfer_rest(cmd_rec *cmd) {
   off_t pos;
-  char *endp = NULL;
+  char *endp = NULL, *ptr;
 
   if (cmd->argc != 2) {
     pr_response_add_err(R_500, _("'%s' not understood"),
@@ -2031,7 +2031,8 @@ MODRET xfer_rest(cmd_rec *cmd) {
   /* Don't allow negative numbers.  strtoul()/strtoull() will silently
    * handle them.
    */
-  if (*cmd->argv[1] == '-') {
+  ptr = cmd->argv[1];
+  if (*ptr == '-') {
     pr_response_add_err(R_501,
       _("REST requires a value greater than or equal to 0"));
 
@@ -2041,9 +2042,9 @@ MODRET xfer_rest(cmd_rec *cmd) {
   }
 
 #ifdef HAVE_STRTOULL
-  pos = strtoull(cmd->argv[1], &endp, 10);
+  pos = strtoull(ptr, &endp, 10);
 #else
-  pos = strtoul(cmd->argv[1], &endp, 10);
+  pos = strtoul(ptr, &endp, 10);
 #endif /* HAVE_STRTOULL */
 
   if (endp &&
@@ -2068,9 +2069,10 @@ MODRET xfer_rest(cmd_rec *cmd) {
   if ((session.sf_flags & SF_ASCII) &&
       pos != 0 &&
       !(xfer_opts & PR_XFER_OPT_IGNORE_ASCII)) {
-    pr_log_debug(DEBUG5, "%s not allowed in ASCII mode", cmd->argv[0]);
+    pr_log_debug(DEBUG5, "%s not allowed in ASCII mode", (char *) cmd->argv[0]);
     pr_response_add_err(R_501,
-      _("%s: Resuming transfers not allowed in ASCII mode"), cmd->argv[0]);
+      _("%s: Resuming transfers not allowed in ASCII mode"),
+      (char *) cmd->argv[0]);
 
     pr_cmd_set_errno(cmd, EPERM);
     errno = EPERM;
@@ -2224,7 +2226,7 @@ MODRET xfer_retr(cmd_rec *cmd) {
     int xerrno = errno;
 
     (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-      "error opening '%s': %s", cmd->argv[0], session.user,
+      "error opening '%s': %s", (char *) cmd->argv[0], session.user,
       pr_uid2str(cmd->tmp_pool, session.uid),
       pr_gid2str(cmd->tmp_pool, session.gid), dir, strerror(xerrno));
 
@@ -2273,7 +2275,7 @@ MODRET xfer_retr(cmd_rec *cmd) {
       retr_fh = NULL;
 
       (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "
-        "error seeking to byte %" PR_LU " of '%s': %s", cmd->argv[0],
+        "error seeking to byte %" PR_LU " of '%s': %s", (char *) cmd->argv[0],
         session.user, pr_uid2str(cmd->tmp_pool, session.uid),
         pr_gid2str(cmd->tmp_pool, session.gid), (pr_off_t) session.restart_pos,
         dir, strerror(xerrno));
@@ -2517,18 +2519,20 @@ MODRET xfer_type(cmd_rec *cmd) {
 
   } else {
     pr_response_add_err(R_504, _("%s not implemented for '%s' parameter"),
-      cmd->argv[0], cmd->argv[1]);
+      (char *) cmd->argv[0], (char *) cmd->argv[1]);
 
     pr_cmd_set_errno(cmd, ENOSYS);
     errno = ENOSYS;
     return PR_ERROR(cmd);
   }
 
-  pr_response_add(R_200, _("Type set to %s"), cmd->argv[1]);
+  pr_response_add(R_200, _("Type set to %s"), (char *) cmd->argv[1]);
   return PR_HANDLED(cmd);
 }
 
 MODRET xfer_stru(cmd_rec *cmd) {
+  char *stru;
+
   if (cmd->argc != 2) {
     pr_response_add_err(R_501, _("'%s' not understood"),
       pr_cmd_get_displayable_str(cmd, NULL));
@@ -2538,9 +2542,10 @@ MODRET xfer_stru(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-  cmd->argv[1][0] = toupper(cmd->argv[1][0]);
+  stru = cmd->argv[1];
+  stru[0] = toupper(stru[0]);
 
-  switch ((int) cmd->argv[1][0]) {
+  switch ((int) stru[0]) {
     case 'F':
       /* Should 202 be returned instead??? */
       pr_response_add(R_200, _("Structure set to F"));
@@ -2580,6 +2585,8 @@ MODRET xfer_stru(cmd_rec *cmd) {
 }
 
 MODRET xfer_mode(cmd_rec *cmd) {
+  char *mode;
+
   if (cmd->argc != 2) {
     pr_response_add_err(R_501, _("'%s' not understood"),
       pr_cmd_get_displayable_str(cmd, NULL));
@@ -2589,9 +2596,10 @@ MODRET xfer_mode(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-  cmd->argv[1][0] = toupper(cmd->argv[1][0]);
+  mode = cmd->argv[1];
+  mode[0] = toupper(mode[0]);
 
-  switch ((int) cmd->argv[1][0]) {
+  switch ((int) mode[0]) {
     case 'S':
       /* Should 202 be returned instead??? */
       pr_response_add(R_200, _("Mode set to S"));
@@ -2676,8 +2684,8 @@ MODRET xfer_allo(cmd_rec *cmd) {
 
       if (requested_kb > avail_kb) {
         pr_log_debug(DEBUG5, "%s requested %" PR_LU " KB, only %" PR_LU
-          " KB available on '%s'", cmd->argv[0], (pr_off_t) requested_kb,
-          (pr_off_t) avail_kb, path);
+          " KB available on '%s'", (char *) cmd->argv[0],
+          (pr_off_t) requested_kb, (pr_off_t) avail_kb, path);
         pr_response_add_err(R_552, "%s: %s", cmd->arg, strerror(ENOSPC));
 
         pr_cmd_set_errno(cmd, ENOSPC);
@@ -2685,7 +2693,7 @@ MODRET xfer_allo(cmd_rec *cmd) {
         return PR_ERROR(cmd);
       }
 
-      pr_response_add(R_200, _("%s command successful"), cmd->argv[0]);
+      pr_response_add(R_200, _("%s command successful"), (char *) cmd->argv[0]);
     }
 
   } else {
@@ -2943,6 +2951,7 @@ MODRET set_displayfiletransfer(cmd_rec *cmd) {
 MODRET set_hiddenstores(cmd_rec *cmd) {
   int enabled = -1, add_periods = TRUE;
   config_rec *c = NULL;
+  char *prefix = NULL;
 
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON|CONF_DIR);
@@ -2954,8 +2963,9 @@ MODRET set_hiddenstores(cmd_rec *cmd) {
    * get_boolean(): if the value begins AND ends with a period, then treat
    * it as a custom prefix.
    */
-  if ((cmd->argv[1])[0] == '.' &&
-      (cmd->argv[1])[strlen(cmd->argv[1])-1] == '.') {
+  prefix = cmd->argv[1];
+  if (prefix[0] == '.' &&
+      prefix[strlen(prefix)-1] == '.') {
     add_periods = FALSE;
     enabled = -1;
 
@@ -3103,16 +3113,19 @@ MODRET set_maxfilesize(cmd_rec *cmd) {
 
   } else {
     array_header *acl = NULL;
-    int argc = cmd->argc - 4;
-    char **argv = cmd->argv + 3;
+    int argc;
+    void **argv;
 
-    acl = pr_expr_create(cmd->tmp_pool, &argc, argv);
+    argc = cmd->argc - 4;
+    argv = cmd->argv + 3;
+
+    acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) argv);
 
     c = add_config_param(cmd->argv[0], 0);
     c->argc = argc + 3;
-    c->argv = pcalloc(c->pool, ((argc + 4) * sizeof(char *)));
+    c->argv = pcalloc(c->pool, ((argc + 4) * sizeof(void *)));
 
-    argv = (char **) c->argv;
+    argv = c->argv;
 
     /* Copy in the configured bytes */
     *argv = pcalloc(c->pool, sizeof(unsigned long));
@@ -3301,7 +3314,7 @@ MODRET set_transferoptions(cmd_rec *cmd) {
 MODRET set_transferpriority(cmd_rec *cmd) {
   config_rec *c;
   int prio;
-  char *str;
+  char *param, *str;
   unsigned long flags = 0;
 
   CHECK_ARGS(cmd, 2);
@@ -3331,7 +3344,9 @@ MODRET set_transferpriority(cmd_rec *cmd) {
   c = add_config_param(cmd->argv[0], 2, NULL, NULL);
 
   /* Parse the command list. */
-  while ((str = get_cmd_from_list(&cmd->argv[1])) != NULL) {
+
+  param = cmd->argv[1];
+  while ((str = get_cmd_from_list(&param)) != NULL) {
 
     if (strcmp(str, C_APPE) == 0) {
       flags |= PR_XFER_PRIO_FL_APPE;
@@ -3461,10 +3476,13 @@ MODRET set_transferrate(cmd_rec *cmd) {
 
   } else {
     array_header *acl = NULL;
-    int argc = cmd->argc - 4;
-    char **argv = cmd->argv + 3;
+    int argc;
+    void **argv;
 
-    acl = pr_expr_create(cmd->tmp_pool, &argc, argv);
+    argc = cmd->argc - 4;
+    argv = cmd->argv + 3;
+
+    acl = pr_expr_create(cmd->tmp_pool, &argc, (char **) argv);
 
     c = add_config_param(cmd->argv[0], 0);
 
@@ -3475,11 +3493,12 @@ MODRET set_transferrate(cmd_rec *cmd) {
      */
     c->argc = argc + 5;
 
-    c->argv = pcalloc(c->pool, ((c->argc + 1) * sizeof(char *)));
-    argv = (char **) c->argv;
+    c->argv = pcalloc(c->pool, ((c->argc + 1) * sizeof(void *)));
+    argv = c->argv;
 
-    if (xfer_parse_cmdlist(cmd->argv[0], c, cmd->argv[1]) < 0)
+    if (xfer_parse_cmdlist(cmd->argv[0], c, cmd->argv[1]) < 0) {
       CONF_ERROR(cmd, "error with command list");
+    }
 
     /* Note: the command list is at index 0, hence this increment. */
     argv++;
@@ -3523,27 +3542,29 @@ MODRET set_usesendfile(cmd_rec *cmd) {
      */
     bool = get_boolean(cmd, 1);
     if (bool == -1) {
+      char *arg;
       size_t arglen;
 
       /* See if the given parameter is a percentage. */
-      arglen = strlen(cmd->argv[1]);
+      arg = cmd->argv[1];
+      arglen = strlen(arg);
       if (arglen > 1 &&
-          cmd->argv[1][arglen-1] == '%') {
+          arg[arglen-1] == '%') {
           char *ptr = NULL;
   
-          cmd->argv[1][arglen-1] = '\0';
+          arg[arglen-1] = '\0';
 
 #ifdef HAVE_STRTOF
-          sendfile_pct = strtof(cmd->argv[1], &ptr);
+          sendfile_pct = strtof(arg, &ptr);
 #elif HAVE_STRTOD
-          sendfile_pct = strtod(cmd->argv[1], &ptr);
+          sendfile_pct = strtod(arg, &ptr);
 #else
-          sendfile_pct = atof(cmd->argv[1]);
+          sendfile_pct = atof(arg);
 #endif /* !HAVE_STRTOF and !HAVE_STRTOD */
 
           if (ptr && *ptr) {
             CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "bad percentage value '",
-              cmd->argv[1], "%'", NULL));
+              arg, "%'", NULL));
           }
 
           sendfile_pct /= 100.0;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -170,11 +170,11 @@ cmd_rec *pr_cmd_alloc(pool *p, int argc, ...) {
     cmd->argv = pcalloc(newpool, sizeof(void *) * (argc + 1));
     va_start(args, argc);
 
-    for (i = 0; i < argc; i++)
-      cmd->argv[i] = (void *) va_arg(args, char *);
+    for (i = 0; i < argc; i++) {
+      cmd->argv[i] = va_arg(args, void *);
+    }
 
     va_end(args);
-
     cmd->argv[argc] = NULL;
   }
 
@@ -326,7 +326,7 @@ int pr_cmd_strcmp(cmd_rec *cmd, const char *cmd_name) {
 char *pr_cmd_get_displayable_str(cmd_rec *cmd, size_t *str_len) {
   char *res;
   int argc;
-  char **argv;
+  void **argv;
   pool *p;
 
   if (cmd == NULL) {

--- a/src/data.c
+++ b/src/data.c
@@ -942,7 +942,7 @@ int pr_data_xfer(char *cl_buf, size_t cl_size) {
 
         pr_trace_msg(trace_channel, 5,
           "client sent '%s' command during data transfer, denying",
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         resp_list = resp_err_list = NULL;
         resp_pool = pr_response_get_pool();
@@ -950,7 +950,7 @@ int pr_data_xfer(char *cl_buf, size_t cl_size) {
         pr_response_set_pool(cmd->pool);
 
         pr_response_add_err(R_450, _("%s: data transfer in progress"),
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         pr_response_flush(&resp_err_list);
 
@@ -968,7 +968,7 @@ int pr_data_xfer(char *cl_buf, size_t cl_size) {
 
         pr_trace_msg(trace_channel, 5,
           "client sent '%s' command during data transfer, ignoring",
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         resp_list = resp_err_list = NULL;
         resp_pool = pr_response_get_pool();
@@ -976,7 +976,7 @@ int pr_data_xfer(char *cl_buf, size_t cl_size) {
         pr_response_set_pool(cmd->pool);
 
         pr_response_add(R_200, _("%s: data transfer in progress"),
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         pr_response_flush(&resp_list);
 
@@ -990,7 +990,7 @@ int pr_data_xfer(char *cl_buf, size_t cl_size) {
 
         pr_trace_msg(trace_channel, 5,
           "client sent '%s' command during data transfer, dispatching",
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
 
         title_len = pr_proctitle_get(NULL, 0);
         if (title_len > 0) {

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -1108,12 +1108,13 @@ static int check_filter_access(xaset_t *set, const char *name, cmd_rec *cmd) {
     pr_signals_handle();
 
     pr_trace_msg("filter", 8,
-      "comparing %s argument '%s' against %s pattern '%s'", cmd->argv[0],
-      cmd->arg, name, pr_regexp_get_pattern(pre));
+      "comparing %s argument '%s' against %s pattern '%s'",
+      (char *) cmd->argv[0], cmd->arg, name, pr_regexp_get_pattern(pre));
     matched = pr_regexp_exec(pre, cmd->arg, 0, NULL, 0, 0, 0);
     pr_trace_msg("filter", 8,
       "comparing %s argument '%s' against %s pattern '%s' returned %d",
-      cmd->argv[0], cmd->arg, name, pr_regexp_get_pattern(pre), matched);
+      (char *) cmd->argv[0], cmd->arg, name, pr_regexp_get_pattern(pre),
+      matched);
 
     if (matched == 0) {
       res = TRUE;
@@ -1124,8 +1125,8 @@ static int check_filter_access(xaset_t *set, const char *name, cmd_rec *cmd) {
   }
 
   pr_trace_msg("filter", 8,
-    "comparing %s argument '%s' against %s patterns returned %d", cmd->argv[0],
-    cmd->arg, name, res);
+    "comparing %s argument '%s' against %s patterns returned %d",
+    (char *) cmd->argv[0], cmd->arg, name, res);
   return res;
 #else
   return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -265,7 +265,7 @@ static int _dispatch(cmd_rec *cmd, int cmd_type, int validate, char *match) {
           !cmd_auth_chk(cmd)) {
         pr_trace_msg("command", 8,
           "command '%s' failed 'requires_auth' check for mod_%s.c",
-          cmd->argv[0], c->m->name);
+          (char *) cmd->argv[0], c->m->name);
         errno = EACCES;
         return -1;
       }
@@ -572,7 +572,8 @@ int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
 
   if (flags & PR_CMD_DISPATCH_FL_CLEAR_RESPONSE) {
     pr_trace_msg("response", 9,
-      "clearing response lists before dispatching command '%s'", cmd->argv[0]);
+      "clearing response lists before dispatching command '%s'",
+      (char *) cmd->argv[0]);
     pr_response_clear(&resp_list);
     pr_response_clear(&resp_err_list);
   }
@@ -621,7 +622,7 @@ int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
 
       xerrno = errno;
       pr_trace_msg("response", 9, "flushing error response list for '%s'",
-        cmd->argv[0]);
+        (char *) cmd->argv[0]);
       pr_response_flush(&resp_err_list);
 
       /* Restore any previous pool to the Response API. */
@@ -645,7 +646,7 @@ int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
 
       xerrno = errno;
       pr_trace_msg("response", 9, "flushing response list for '%s'",
-        cmd->argv[0]);
+        (char *) cmd->argv[0]);
       pr_response_flush(&resp_list);
 
       errno = xerrno;
@@ -663,7 +664,7 @@ int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
 
       xerrno = errno;
       pr_trace_msg("response", 9, "flushing error response list for '%s'",
-        cmd->argv[0]);
+        (char *) cmd->argv[0]);
       pr_response_flush(&resp_err_list);
 
       errno = xerrno;
@@ -706,12 +707,12 @@ int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
 
       if (success == 1) {
         pr_trace_msg("response", 9, "flushing response list for '%s'",
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
         pr_response_flush(&resp_list);
 
       } else if (success < 0) {
         pr_trace_msg("response", 9, "flushing error response list for '%s'",
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
         pr_response_flush(&resp_err_list);
       }
 
@@ -863,7 +864,7 @@ static void cmd_loop(server_rec *server, conn_t *c) {
       if (cmd->is_ftp == FALSE) {
         pr_log_pri(PR_LOG_WARNING,
           "client sent %s command '%s', disconnecting", cmd->protocol,
-          cmd->argv[0]);
+          (char *) cmd->argv[0]);
         pr_event_generate("core.bad-protocol", cmd);
         pr_session_disconnect(NULL, PR_SESS_DISCONNECT_BAD_PROTOCOL,
           cmd->protocol);

--- a/src/main.c
+++ b/src/main.c
@@ -818,7 +818,7 @@ static cmd_rec *make_ftp_cmd(pool *p, char *buf, size_t buflen, int flags) {
   }
 
   *((char **) push_array(tarr)) = NULL;
-  cmd->argv = (char **) tarr->elts;
+  cmd->argv = tarr->elts;
 
   /* This table will not contain that many entries, so a low number
    * of chains should suffice.

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2004-2014 The ProFTPD Project team
+ * Copyright (c) 2004-2015 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,9 +22,7 @@
  * for OpenSSL in the source distribution.
  */
 
-/* Configuration parser
- * $Id: parser.c,v 1.40 2013-12-30 06:38:59 castaglia Exp $
- */
+/* Configuration parser */
 
 #include "conf.h"
 
@@ -395,8 +393,9 @@ int pr_parser_parse_file(pool *p, const char *path, config_rec *start,
    */
   cs = add_config_source(fh);
 
-  if (start) 
+  if (start) {
     add_config_ctxt(start);
+  }
 
   while ((cmd = pr_parser_parse_line(tmp_pool)) != NULL) {
     pr_signals_handle();
@@ -453,13 +452,13 @@ int pr_parser_parse_file(pool *p, const char *path, config_rec *start,
 
         if (!(flags & PR_PARSER_FL_DYNAMIC_CONFIG)) {
           pr_log_pri(PR_LOG_WARNING, "fatal: unknown configuration directive "
-            "'%s' on line %u of '%s'", cmd->argv[0], cs->cs_lineno,
+            "'%s' on line %u of '%s'", (char *) cmd->argv[0], cs->cs_lineno,
             report_path);
           exit(1);
 
         } else {
           pr_log_pri(PR_LOG_WARNING, "warning: unknown configuration directive "
-            "'%s' on line %u of '%s'", cmd->argv[0], cs->cs_lineno,
+            "'%s' on line %u of '%s'", (char *) cmd->argv[0], cs->cs_lineno,
             report_path);
         }
       }
@@ -523,7 +522,7 @@ cmd_rec *pr_parser_parse_line(pool *p) {
      * it will get purged when the command's pool is destroyed.
      */
 
-    cmd->argv = (char **) arr->elts;
+    cmd->argv = (void **) arr->elts;
 
     /* Perform a fixup on configuration directives so that:
      *
@@ -537,9 +536,10 @@ cmd_rec *pr_parser_parse_line(pool *p) {
      */
 
     if (cmd->argc &&
-        *(cmd->argv[0]) == '<') {
-      char *cp = cmd->argv[cmd->argc-1];
+        *((char *) cmd->argv[0]) == '<') {
+      char *cp;
 
+      cp = cmd->argv[cmd->argc-1];
       if (*(cp + strlen(cp)-1) == '>' &&
           cmd->argc > 1) {
 

--- a/tests/t/lib/ProFTPD/Tests/Config/Order.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Order.pm
@@ -15,11 +15,25 @@ $| = 1;
 my $order = 0;
 
 my $TESTS = {
+  # The single "allow,deny" parameter form
+  order_allowdeny_ok => {
+    order => ++$order,
+    test_class => [qw(forking)],
+  },
+
+  # The double "allow, deny" parameter form with a space
   order_allow_deny_ok => {
     order => ++$order,
     test_class => [qw(forking)],
   },
 
+  # The single "deny,allow" parameter form
+  order_denyallow_ok => {
+    order => ++$order,
+    test_class => [qw(forking)],
+  },
+
+  # The double "deny, allow" parameter form with a space
   order_deny_allow_ok => {
     order => ++$order,
     test_class => [qw(forking)],
@@ -35,7 +49,7 @@ sub list_tests {
   return testsuite_get_runnable_tests($TESTS);
 }
 
-sub order_allow_deny_ok {
+sub order_allowdeny_ok {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -74,6 +88,8 @@ sub order_allow_deny_ok {
     PidFile => $pid_file,
     ScoreboardFile => $scoreboard_file,
     SystemLog => $log_file,
+    TraceLog => $log_file,
+    Trace => 'config:20',
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
@@ -169,7 +185,141 @@ sub order_allow_deny_ok {
   unlink($log_file);
 }
 
-sub order_deny_allow_ok {
+sub order_allow_deny_ok {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  my $config_file = "$tmpdir/config.conf";
+  my $pid_file = File::Spec->rel2abs("$tmpdir/config.pid");
+  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/config.scoreboard");
+
+  my $log_file = File::Spec->rel2abs('tests.log');
+
+  my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
+  my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
+
+  my $user = 'proftpd';
+  my $passwd = 'test';
+  my $home_dir = File::Spec->rel2abs($tmpdir);
+  my $uid = 500;
+  my $gid = 500;
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $home_dir)) {
+      die("Can't set perms on $home_dir to 0755: $!");
+    }
+
+    unless (chown($uid, $gid, $home_dir)) {
+      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    }
+  }
+
+  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
+    '/bin/bash');
+  auth_group_write($auth_group_file, 'ftpd', $gid, $user);
+
+  my $config = {
+    PidFile => $pid_file,
+    ScoreboardFile => $scoreboard_file,
+    SystemLog => $log_file,
+
+    AuthUserFile => $auth_user_file,
+    AuthGroupFile => $auth_group_file,
+    DefaultChdir => '~',
+
+    Limit => {
+      ALL => {
+        Order => 'allow, deny',
+        AllowUser => $user,
+        DenyAll => '',
+      },
+    },
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($user, $passwd);
+
+      my $conn = $client->stor_raw('test.txt');
+      unless ($conn) {
+        die("Failed to STOR test.txt: " . $client->response_code() . " " .
+          $client->response_msg());
+      }
+
+      my $buf = "Hello, World!\n";
+      $conn->write($buf, length($buf));
+      $conn->close();
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+
+      my $expected;
+
+      $expected = 226;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected $expected, got $resp_code"));
+
+      $expected = "Transfer complete";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected '$expected', got '$resp_msg'"));
+
+      $client->quit();
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($config_file, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($pid_file);
+
+  $self->assert_child_ok($pid);
+
+  if ($ex) {
+    die($ex);
+  }
+
+  unlink($log_file);
+}
+
+sub order_denyallow_ok {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -216,6 +366,135 @@ sub order_deny_allow_ok {
     Limit => {
       ALL => {
         Order => 'deny,allow',
+        AllowUser => $user,
+        DenyAll => '',
+      },
+    },
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($user, $passwd);
+
+      my $conn = $client->stor_raw('test.txt');
+      if ($conn) {
+        die("STOR test.txt succeeded unexpectedly");
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+
+      my $expected;
+
+      $expected = 550;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected $expected, got $resp_code"));
+
+      $expected = "test.txt: Operation not permitted";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected '$expected', got '$resp_msg'"));
+
+      $client->quit();
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($config_file, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($pid_file);
+
+  $self->assert_child_ok($pid);
+
+  if ($ex) {
+    die($ex);
+  }
+
+  unlink($log_file);
+}
+
+sub order_deny_allow_ok {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  my $config_file = "$tmpdir/config.conf";
+  my $pid_file = File::Spec->rel2abs("$tmpdir/config.pid");
+  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/config.scoreboard");
+
+  my $log_file = File::Spec->rel2abs('tests.log');
+
+  my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
+  my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
+
+  my $user = 'proftpd';
+  my $passwd = 'test';
+  my $home_dir = File::Spec->rel2abs($tmpdir);
+  my $uid = 500;
+  my $gid = 500;
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $home_dir)) {
+      die("Can't set perms on $home_dir to 0755: $!");
+    }
+
+    unless (chown($uid, $gid, $home_dir)) {
+      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    }
+  }
+
+  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
+    '/bin/bash');
+  auth_group_write($auth_group_file, 'ftpd', $gid, $user);
+
+  my $config = {
+    PidFile => $pid_file,
+    ScoreboardFile => $scoreboard_file,
+    SystemLog => $log_file,
+
+    AuthUserFile => $auth_user_file,
+    AuthGroupFile => $auth_group_file,
+    DefaultChdir => '~',
+
+    Limit => {
+      ALL => {
+        Order => 'deny, allow',
         AllowUser => $user,
         DenyAll => '',
       },


### PR DESCRIPTION
…gv member

to be "void **", rather than "char **".  Void pointers are guaranteed to be
large enough to hold pointers to anything, where as char pointers are not.  And
we sometimes stash non-char data in the cmd_rec.argv area.

This looks like a fair amount of code churn; mostly it's addressing compiler
warnings by providing explicit casts to char * in most places (e.g. logging)
where the variadic function cannot easily tell the type.