### PR TITLE
Remove HAVE_TIMER_T macro and timer_t detection mechanism

### DIFF
--- a/acconfig.h
+++ b/acconfig.h
@@ -60,9 +60,6 @@
 /* Define if you have the <syslog.h> header file. */
 #undef HAVE_SYSLOG_H
 
-/* Define if you already have a typedef for timer_t */
-#undef HAVE_TIMER_T
-
 /* Define if your struct utmp has ut_host */
 #undef HAVE_UT_UT_HOST
 

--- a/config.h.in
+++ b/config.h.in
@@ -121,9 +121,6 @@
 /* Define if you have the <syslog.h> header file. */
 #undef HAVE_SYSLOG_H
 
-/* Define if you already have a typedef for timer_t */
-#undef HAVE_TIMER_T
-
 /* Define if you have the tzname global variable.  */
 #undef HAVE_TZNAME
 

--- a/configure
+++ b/configure
@@ -26812,56 +26812,6 @@ _ACEOF
 
 
 
-{ echo "$as_me:$LINENO: checking for timer_t" >&5
-echo $ECHO_N "checking for timer_t... $ECHO_C" >&6; }
-if test "${pr_cv_header_timer_t+set}" = set; then
-  echo $ECHO_N "(cached) $ECHO_C" >&6
-else
-  cat >conftest.$ac_ext <<_ACEOF
-/* confdefs.h.  */
-_ACEOF
-cat confdefs.h >>conftest.$ac_ext
-cat >>conftest.$ac_ext <<_ACEOF
-/* end confdefs.h.  */
-#include <sys/types.h>
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP ".*typedef.*timer_t;" >/dev/null 2>&1; then
-  pr_cv_header_timer_t="yes"
-else
-  cat >conftest.$ac_ext <<_ACEOF
-/* confdefs.h.  */
-_ACEOF
-cat confdefs.h >>conftest.$ac_ext
-cat >>conftest.$ac_ext <<_ACEOF
-/* end confdefs.h.  */
-#include <limits.h>
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP ".*typedef.*timer_t;" >/dev/null 2>&1; then
-  pr_cv_header_timer_t="yes"
-else
-  pr_cv_header_timer_t="no"
-fi
-rm -f conftest*
-
-fi
-rm -f conftest*
-
-fi
-{ echo "$as_me:$LINENO: result: $pr_cv_header_timer_t" >&5
-echo "${ECHO_T}$pr_cv_header_timer_t" >&6; }
-
-if test "$pr_cv_header_timer_t" = "yes"; then
-
-cat >>confdefs.h <<\_ACEOF
-#define HAVE_TIMER_T 1
-_ACEOF
-
-fi
-
 { echo "$as_me:$LINENO: checking whether time.h and sys/time.h may both be included" >&5
 echo $ECHO_N "checking whether time.h and sys/time.h may both be included... $ECHO_C" >&6; }
 if test "${ac_cv_header_time+set}" = set; then

--- a/configure.in
+++ b/configure.in
@@ -1530,17 +1530,6 @@ AC_TYPE_MODE_T
 AC_TYPE_OFF_T
 AC_TYPE_GETGROUPS
 
-dnl Check to see if timer_t is already defined
-AC_CACHE_CHECK([for timer_t], pr_cv_header_timer_t,
-	AC_EGREP_HEADER([.*typedef.*timer_t;],sys/types.h,
-			pr_cv_header_timer_t="yes",
-	AC_EGREP_HEADER([.*typedef.*timer_t;],limits.h,
-			pr_cv_header_timer_t="yes",pr_cv_header_timer_t="no")))
-
-if test "$pr_cv_header_timer_t" = "yes"; then
-  AC_DEFINE(HAVE_TIMER_T, 1, [Define if you have the timer_t type])
-fi
-
 AC_HEADER_TIME
 AC_STRUCT_TM
 

--- a/include/conf.h
+++ b/include/conf.h
@@ -273,14 +273,6 @@ char *strchr(),*strrchr();
 
 #include "options.h"
 
-/* Solaris 2.5 seems to already have a typedef for 'timer_t', so
- * #define timer_t to something else as a workaround.  However, on AIX,
- * we do NOT want to do this.
- */
-#if defined(HAVE_TIMER_T) && !defined(AIX7)
-# define timer_t p_timer_t
-#endif
-
 /* AIX, when compiled using -D_NO_PROTO, lacks some prototypes without
  * which ProFTPD may do some funny (and not good) things.  Provide the
  * prototypes as necessary here.


### PR DESCRIPTION
When compiling on AIX6.1, following error is raised:

```
In file included from /usr/include/sys/thread.h:41:0,
                 from /usr/include/sys/ptrace.h:28,
                 from /usr/include/sys/proc.h:42,
                 from /usr/include/sys/aacct.h:22,
                 from /usr/include/sys/vfs.h:34,
                 from fsio.c:39:
/usr/include/sys/timer.h:292:2: error: unknown type name 'p_timer_t'
  timer_t            timerid;       /* timer identifier               */
```

which can be tracked down to `include/conf.h`:

```
/* Solaris 2.5 seems to already have a typedef for 'timer_t', so
 * #define timer_t to something else as a workaround.  However, on AIX,
 * we do NOT want to do this.
 */
#if defined(HAVE_TIMER_T) && !defined(AIX7)
# define timer_t p_timer_t
#endif
```

As no `timer_t` is typedef'd in the ProFTPD source, I presume this workaround has become obsolete.
The last notion of `timer_t` has been dropped since bae6cd2330117f4bedeb1f07fe11bcc4619537ff.