### PR TITLE
Attempt to Bug#4206 by speculatively fixing possible causes.  First, …

### DIFF
--- a/modules/mod_lang.c
+++ b/modules/mod_lang.c
@@ -716,9 +716,7 @@ static void lang_postparse_ev(const void *event_data, void *user_data) {
   config_rec *c;
   DIR *dirh;
   server_rec *s;
-#ifdef HAVE_LIBINTL_H
   const char *locale_path = NULL;
-#endif
 
   c = find_config(main_server->conf, CONF_PARAM, "LangEngine", FALSE);
   if (c) {
@@ -888,6 +886,7 @@ static void lang_postparse_ev(const void *event_data, void *user_data) {
 
 static void lang_restart_ev(const void *event_data, void *user_data) {
   destroy_pool(lang_pool);
+  lang_curr = LANG_DEFAULT_LANG;
   lang_list = NULL;
   lang_aliases = NULL;
 


### PR DESCRIPTION
…reset

a static string (allocated out of a pool which is cleared on restart) to its
default.  Next, remove some (useless) #ifdefs which, if mod_lang is built
as a DSO/shared module, could cause problems on module loading IFF the system
does not have the expected header.