### PR TITLE
Add more logging, via the normal auth logging channels, for when SFTP

### DIFF
--- a/contrib/mod_sftp/auth-kbdint.c
+++ b/contrib/mod_sftp/auth-kbdint.c
@@ -56,6 +56,10 @@ int sftp_auth_kbdint(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       "no 'keyboard-interactive' drivers currently registered, unable to "
       "authenticate user '%s' via 'keyboard-interactive' method", user);
 
+    pr_log_auth(PR_LOG_NOTICE,
+      "USER %s (Login failed): keyboard-interactive authentication disabled",
+      user);
+
     *send_userauth_fail = TRUE;
     errno = EPERM;
     return 0;
@@ -65,6 +69,10 @@ int sftp_auth_kbdint(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
       orig_user, (char *) pass_cmd->argv[0]);
+
+    pr_log_auth(PR_LOG_NOTICE,
+      "USER %s (Login failed): blocked by '%s' handler", orig_user,
+      (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
@@ -109,6 +117,12 @@ int sftp_auth_kbdint(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         "cipher algorithm '%s' or MAC algorithm '%s' unacceptable for "
         "keyboard-interactive authentication, denying authentication request",
         cipher_algo, mac_algo);
+
+      pr_log_auth(PR_LOG_NOTICE,
+        "USER %s (Login failed): cipher algorithm '%s' or MAC algorithm '%s' "
+        "unsupported for keyboard-interactive authentication", user,
+        cipher_algo, mac_algo);
+
       *send_userauth_fail = TRUE;
       errno = EPERM;
       return 0;

--- a/contrib/mod_sftp/auth-password.c
+++ b/contrib/mod_sftp/auth-password.c
@@ -55,6 +55,12 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         "cipher algorithm '%s' or MAC algorithm '%s' unacceptable for "
         "password authentication, denying password authentication request",
         cipher_algo, mac_algo);
+
+      pr_log_auth(PR_LOG_NOTICE,
+        "USER %s (Login failed): cipher algorithm '%s' or MAC algorithm '%s' "
+        "unsupported for password authentication", user,
+        cipher_algo, mac_algo);
+
       *send_userauth_fail = TRUE;
       errno = EPERM;
       return 0;
@@ -78,6 +84,10 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
       "authentication request for user '%s' blocked by '%s' handler",
       orig_user, (char *) pass_cmd->argv[0]);
+
+    pr_log_auth(PR_LOG_NOTICE,
+      "USER %s (Login failed): blocked by '%s' handler", orig_user,
+      (char *) pass_cmd->argv[0]);
 
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

--- a/contrib/mod_sftp/auth-publickey.c
+++ b/contrib/mod_sftp/auth-publickey.c
@@ -152,6 +152,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       "unsupported public key algorithm '%s' requested, rejecting request",
       pubkey_algo);
 
+    pr_log_auth(PR_LOG_NOTICE,
+      "USER %s (Login failed): unsupported public key algorithm '%s' requested",
+      user, pubkey_algo);
+
     *send_userauth_fail = TRUE;
     errno = EINVAL;
     return 0;
@@ -268,6 +272,9 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
      */
 
     if (sftp_blacklist_reject_key(pkt->pool, pubkey_data, pubkey_len)) {
+      pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): requested public "
+        "key is blacklisted", user);
+
       *send_userauth_fail = TRUE;
       errno = EPERM;
       return 0;
@@ -293,6 +300,9 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
 
     if (sftp_keystore_verify_user_key(pkt->pool, user, pubkey_data,
         pubkey_len) < 0) {
+      pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): authentication "
+        "via '%s' public key failed", user, pubkey_algo);
+
       *send_userauth_fail = TRUE;
       errno = EACCES;
       return 0;
@@ -336,6 +346,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
         "failed to verify '%s' signature on public key auth request for "
         "user '%s'", pubkey_algo, orig_user);
+
+      pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): signature "
+        "verification of '%s' public key failed", user, pubkey_algo);
+
       *send_userauth_fail = TRUE;
       errno = EACCES;
       return 0;
@@ -368,6 +382,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
         "publickey request reused previously verified publickey "
         "(fingerprint %s), rejecting", fp);
+
+      pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): public key request "
+       "reused previously verified public key (fingerprint %s)", user, fp);
+
       *send_userauth_fail = TRUE;
       errno = EACCES;
       return 0;

--- a/contrib/mod_sftp/auth-publickey.c
+++ b/contrib/mod_sftp/auth-publickey.c
@@ -96,6 +96,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       "authentication request for user '%s' blocked by '%s' handler",
       orig_user, (char *) pass_cmd->argv[0]);
 
+    pr_log_auth(PR_LOG_NOTICE,
+      "USER %s (Login failed): blocked by '%s' handler", orig_user,
+      (char *) pass_cmd->argv[0]);
+
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
     pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
 

--- a/contrib/mod_sftp/disconnect.c
+++ b/contrib/mod_sftp/disconnect.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp disconnect msgs
- * Copyright (c) 2008-2012 TJ Saunders
+ * Copyright (c) 2008-2015 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,8 +20,6 @@
  * give permission to link this program with OpenSSL, and distribute the
  * resulting executable, without including the source code for OpenSSL in the
  * source distribution.
- *
- * $Id: disconnect.c,v 1.10 2012-02-15 23:50:51 castaglia Exp $
  */
 
 #include "mod_sftp.h"
@@ -74,6 +72,7 @@ const char *sftp_disconnect_get_str(uint32_t reason_code) {
 void sftp_disconnect_send(uint32_t reason, const char *explain,
     const char *file, int lineno, const char *func) {
   struct ssh2_packet *pkt;
+  pr_netaddr_t *remote_addr;
   const char *lang = "en-US";
   unsigned char *buf, *ptr;
   uint32_t buflen, bufsz;
@@ -81,6 +80,8 @@ void sftp_disconnect_send(uint32_t reason, const char *explain,
 
   /* Send the client a DISCONNECT mesg. */
   pkt = sftp_ssh2_packet_create(sftp_pool);
+
+  remote_addr = pr_netaddr_get_sess_remote_addr();
 
   buflen = bufsz = 1024;
   ptr = buf = palloc(pkt->pool, bufsz);
@@ -124,8 +125,8 @@ void sftp_disconnect_send(uint32_t reason, const char *explain,
   pkt->payload = ptr;
   pkt->payload_len = (bufsz - buflen);
 
-  (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION, "disconnecting (%s)",
-    explain);
+  (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+    "disconnecting %s (%s)", pr_netaddr_get_ipstr(remote_addr), explain);
 
   /* If we are called very early in the connection lifetime, then the
    * sftp_conn variable may not have been set yet, thus the conditional here.

--- a/src/inet.c
+++ b/src/inet.c
@@ -707,7 +707,8 @@ int pr_inet_set_proto_nodelay(pool *p, conn_t *conn, int nodelay) {
   if (conn->rfd != -1) {
     res = setsockopt(conn->rfd, tcp_level, TCP_NODELAY, (void *) &nodelay,
       sizeof(nodelay));
-    if (res < 0) {
+    if (res < 0 &&
+        errno != EBADF) {
       pr_log_pri(PR_LOG_NOTICE, "error setting read fd %d TCP_NODELAY %d: %s",
        conn->rfd, nodelay, strerror(errno));
     }
@@ -716,7 +717,8 @@ int pr_inet_set_proto_nodelay(pool *p, conn_t *conn, int nodelay) {
   if (conn->wfd != -1) {
     res = setsockopt(conn->wfd, tcp_level, TCP_NODELAY, (void *) &nodelay,
       sizeof(nodelay));
-    if (res < 0) {
+    if (res < 0 &&
+        errno != EBADF) {
       pr_log_pri(PR_LOG_NOTICE, "error setting write fd %d TCP_NODELAY %d: %s",
        conn->wfd, nodelay, strerror(errno));
     }
@@ -769,24 +771,31 @@ int pr_inet_set_proto_opts(pool *p, conn_t *c, int mss, int nodelay,
     if (c->rfd != -1) {
       if (setsockopt(c->rfd, tcp_level, TCP_NODELAY, (void *) &nodelay,
           sizeof(nodelay)) < 0) {
-        pr_log_pri(PR_LOG_NOTICE, "error setting read fd %d TCP_NODELAY: %s",
-          c->rfd, strerror(errno));
+        if (errno != EBADF) {
+          pr_log_pri(PR_LOG_NOTICE, "error setting read fd %d TCP_NODELAY: %s",
+            c->rfd, strerror(errno));
+        }
       }
     }
 
     if (c->wfd != -1) {
       if (setsockopt(c->wfd, tcp_level, TCP_NODELAY, (void *) &nodelay,
           sizeof(nodelay)) < 0) {
-        pr_log_pri(PR_LOG_NOTICE, "error setting write fd %d TCP_NODELAY: %s",
-          c->wfd, strerror(errno));
+        if (errno != EBADF) {
+          pr_log_pri(PR_LOG_NOTICE, "error setting write fd %d TCP_NODELAY: %s",
+            c->wfd, strerror(errno));
+        }
       }
     }
 
     if (c->listen_fd != -1) {
       if (setsockopt(c->listen_fd, tcp_level, TCP_NODELAY, (void *) &nodelay,
           sizeof(nodelay)) < 0) {
-        pr_log_pri(PR_LOG_NOTICE, "error setting listen fd %d TCP_NODELAY: %s",
-          c->listen_fd, strerror(errno));
+        if (errno != EBADF) {
+          pr_log_pri(PR_LOG_NOTICE,
+            "error setting listen fd %d TCP_NODELAY: %s",
+            c->listen_fd, strerror(errno));
+        }
       }
     }
   }


### PR DESCRIPTION
publickey authentication fails.  Also make sure to include the IP address
of the remote client, in the DISCONNECT log message.