### PR TITLE
Move the processing of the DefaultTransferMode directive from mod_aut…

### DIFF
--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -899,8 +899,8 @@ static void ensure_open_passwd(pool *p) {
 static int setup_env(pool *p, cmd_rec *cmd, char *user, char *pass) {
   struct passwd *pw;
   config_rec *c, *tmpc;
-  char *origuser, *ourname,*anonname = NULL,*anongroup = NULL,*ugroup = NULL;
-  char *defaulttransfermode, *defroot = NULL,*defchdir = NULL,*xferlog = NULL;
+  char *origuser, *ourname, *anonname = NULL, *anongroup = NULL, *ugroup = NULL;
+  char *defroot = NULL, *defchdir = NULL, *xferlog = NULL;
   const char *sess_ttyname;
   int aclp, i, res = 0, allow_chroot_symlinks = TRUE, showsymlinks;
   unsigned char *wtmp_log = NULL, *anon_require_passwd = NULL;
@@ -1766,18 +1766,6 @@ static int setup_env(pool *p, cmd_rec *cmd, char *user, char *pass) {
    * among other things, would fail.
    */
   /* pr_auth_endpwent(p); */
-
-  /* Default transfer mode is ASCII */
-  defaulttransfermode = (char *) get_param_ptr(main_server->conf,
-    "DefaultTransferMode", FALSE);
-
-  if (defaulttransfermode &&
-      strcasecmp(defaulttransfermode, "binary") == 0) {
-    session.sf_flags &= (SF_ALL^SF_ASCII);
-
-  } else {
-    session.sf_flags |= SF_ASCII;
-  }
 
   /* Authentication complete, user logged in, now kill the login
    * timer.

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -5951,6 +5951,18 @@ MODRET core_opts(cmd_rec *cmd) {
 MODRET core_post_pass(cmd_rec *cmd) {
   config_rec *c;
 
+  /* Default transfer mode is ASCII */
+  session.sf_flags |= SF_ASCII;
+  c = find_config(main_server->conf, CONF_PARAM, "DefaultTransferMode", FALSE);
+  if (c != NULL) {
+    char *default_transfer_mode;
+
+    default_transfer_mode = c->argv[0];
+    if (strcasecmp(default_transfer_mode, "binary") == 0) {
+      session.sf_flags &= (SF_ALL^SF_ASCII);
+    }
+  }
+
   c = find_config(TOPLEVEL_CONF, CONF_PARAM, "TimeoutIdle", FALSE);
   if (c != NULL) {
     int prev_timeout, timeout;


### PR DESCRIPTION
…h to

mod_core.  The directive handler is in mod_core, and the processing is
more properly done as a post-PASS step.