### PR TITLE
Simplify the list of library dependencies needed by auth-otp.  This s…

### DIFF
--- a/contrib/mod_auth_otp/Makefile.in
+++ b/contrib/mod_auth_otp/Makefile.in
@@ -14,6 +14,7 @@ VPATH=@srcdir@
 MODULE_NAME=mod_auth_otp
 MODULE_OBJS=mod_auth_otp.o base32.o otp.o crypto.o db.o
 SHARED_MODULE_OBJS=mod_auth_otp.lo base32.lo otp.lo crypto.lo db.lo
+UTILS_LIBS=@UTILS_LIBS@
 UTILS_OBJS=base32.o otp.o crypto.o auth-otp.o
 UTILS_API_OBJS=../../src/pool.o \
   ../../src/str.o
@@ -37,7 +38,7 @@ static: $(MODULE_OBJS) auth-otp$(EXEEXT)
 	$(RANLIB) $(MODULE_NAME).a
 
 auth-otp$(EXEEXT): $(UTILS_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(UTILS_OBJS) $(UTILS_API_OBJS) $(LIBS)
+	$(CC) $(LDFLAGS) -o $@ $(UTILS_OBJS) $(UTILS_API_OBJS) $(UTILS_LIBS)
 
 install: install-man install-utils
 	if [ -f $(MODULE_NAME).la ] ; then \

--- a/contrib/mod_auth_otp/configure
+++ b/contrib/mod_auth_otp/configure
@@ -675,6 +675,7 @@ EGREP
 SET_MAKE
 INCLUDES
 LIBDIRS
+UTILS_LIBS
 LIBOBJS
 LTLIBOBJS'
 ac_subst_files=''
@@ -3209,7 +3210,7 @@ else
   { echo "$as_me:$LINENO: result: no" >&5
 echo "${ECHO_T}no" >&6; }
 fi
-rm -f -r conftest*
+rm -f conftest*
 
 
 { echo "$as_me:$LINENO: checking for library containing strerror" >&5
@@ -3363,7 +3364,7 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
 else
   ac_cv_header_stdc=no
 fi
-rm -f -r conftest*
+rm -f conftest*
 
 fi
 
@@ -3384,7 +3385,7 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
 else
   ac_cv_header_stdc=no
 fi
-rm -f -r conftest*
+rm -f conftest*
 
 fi
 
@@ -3787,7 +3788,7 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
 else
   ac_cv_header_stdc=no
 fi
-rm -f -r conftest*
+rm -f conftest*
 
 fi
 
@@ -3808,7 +3809,7 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
 else
   ac_cv_header_stdc=no
 fi
-rm -f -r conftest*
+rm -f conftest*
 
 fi
 
@@ -4130,6 +4131,7 @@ fi
 
 saved_libs="$LIBS"
 LIBS="$LIBS -lcrypto"
+UTILS_LIBS="-lsupp $LIBS"
 
 { echo "$as_me:$LINENO: checking whether linking with OpenSSL functions requires -ldl" >&5
 echo $ECHO_N "checking whether linking with OpenSSL functions requires -ldl... $ECHO_C" >&6; }
@@ -4179,6 +4181,7 @@ eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
     { echo "$as_me:$LINENO: result: yes" >&5
 echo "${ECHO_T}yes" >&6; }
     LIBS="$saved_libs -ldl"
+    UTILS_LIBS="$UTILS_LIBS -ldl"
 
 else
   echo "$as_me: failed program was:" >&5
@@ -4247,6 +4250,7 @@ eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
     { echo "$as_me:$LINENO: result: yes" >&5
 echo "${ECHO_T}yes" >&6; }
     LIBS="$saved_libs -lz"
+    UTILS_LIBS="$UTILS_LIBS -lz"
 
 else
   echo "$as_me: failed program was:" >&5
@@ -4403,6 +4407,7 @@ LIBS="$saved_libs"
 
 INCLUDES="$ac_build_addl_includes"
 LIBDIRS="$ac_build_addl_libdirs"
+
 
 
 
@@ -5090,11 +5095,12 @@ EGREP!$EGREP$ac_delim
 SET_MAKE!$SET_MAKE$ac_delim
 INCLUDES!$INCLUDES$ac_delim
 LIBDIRS!$LIBDIRS$ac_delim
+UTILS_LIBS!$UTILS_LIBS$ac_delim
 LIBOBJS!$LIBOBJS$ac_delim
 LTLIBOBJS!$LTLIBOBJS$ac_delim
 _ACEOF
 
-  if test `sed -n "s/.*$ac_delim\$/X/p" conf$$subs.sed | grep -c X` = 64; then
+  if test `sed -n "s/.*$ac_delim\$/X/p" conf$$subs.sed | grep -c X` = 65; then
     break
   elif $ac_last_try; then
     { { echo "$as_me:$LINENO: error: could not make $CONFIG_STATUS" >&5
@@ -5450,7 +5456,7 @@ do
     cat >>$CONFIG_STATUS <<_ACEOF
     # First, check the format of the line:
     cat >"\$tmp/defines.sed" <<\\CEOF
-/^[	 ]*#[	 ]*undef[	 ][	 ]*$ac_word_re[	 ]*/b def
+/^[	 ]*#[	 ]*undef[	 ][	 ]*$ac_word_re[	 ]*\$/b def
 /^[	 ]*#[	 ]*define[	 ][	 ]*$ac_word_re[(	 ]/b def
 b
 :def

--- a/contrib/mod_auth_otp/configure
+++ b/contrib/mod_auth_otp/configure
@@ -1258,6 +1258,12 @@ if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
 
+Optional Features:
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-devel          enable developer-only code (default=no)
+
+
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
@@ -4039,6 +4045,20 @@ fi
 done
 
 
+UTILS_LIBS="-lsupp -lcrypto"
+
+# Check whether --enable-devel was given.
+if test "${enable_devel+set}" = set; then
+  enableval=$enable_devel;
+    if test x"$enableval" != xno ; then
+      if test `echo $enableval | grep -c coverage` = "1" ; then
+        UTILS_LIBS="--coverage $UTILS_LIBS"
+      fi
+    fi
+
+fi
+
+
 
 # Check whether --with-includes was given.
 if test "${with_includes+set}" = set; then
@@ -4131,7 +4151,6 @@ fi
 
 saved_libs="$LIBS"
 LIBS="$LIBS -lcrypto"
-UTILS_LIBS="-lsupp $LIBS"
 
 { echo "$as_me:$LINENO: checking whether linking with OpenSSL functions requires -ldl" >&5
 echo $ECHO_N "checking whether linking with OpenSSL functions requires -ldl... $ECHO_C" >&6; }

--- a/contrib/mod_auth_otp/configure.in
+++ b/contrib/mod_auth_otp/configure.in
@@ -34,6 +34,23 @@ AC_HEADER_STDC
 
 AC_CHECK_HEADERS(stdlib.h unistd.h limits.h fcntl.h)
 
+UTILS_LIBS="-lsupp -lcrypto"
+
+dnl Need to support/handle the --enable-devel option, to see if coverage
+dnl is being used
+AC_ARG_ENABLE(devel,
+  [AC_HELP_STRING(
+    [--enable-devel],
+    [enable developer-only code (default=no)])
+  ],
+  [
+    if test x"$enableval" != xno ; then
+      if test `echo $enableval | grep -c coverage` = "1" ; then
+        UTILS_LIBS="--coverage $UTILS_LIBS"
+      fi
+    fi
+  ])
+
 dnl Need to support/handle the --with-includes and --with-libraries options
 AC_ARG_WITH(includes,
   [AC_HELP_STRING(
@@ -117,7 +134,6 @@ AC_ARG_WITH(shared,
 
 saved_libs="$LIBS"
 LIBS="$LIBS -lcrypto"
-UTILS_LIBS="-lsupp $LIBS"
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -ldl])
 saved_libs="$LIBS"

--- a/contrib/mod_auth_otp/configure.in
+++ b/contrib/mod_auth_otp/configure.in
@@ -1,5 +1,5 @@
 dnl ProFTPD - mod_auth_otp
-dnl Copyright (c) 2015 TJ Saunders <tj@castaglia.org>
+dnl Copyright (c) 2015-2016 TJ Saunders <tj@castaglia.org>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -117,6 +117,7 @@ AC_ARG_WITH(shared,
 
 saved_libs="$LIBS"
 LIBS="$LIBS -lcrypto"
+UTILS_LIBS="-lsupp $LIBS"
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -ldl])
 saved_libs="$LIBS"
@@ -133,6 +134,7 @@ AC_TRY_LINK(
   ], [
     AC_MSG_RESULT(yes)
     LIBS="$saved_libs -ldl"
+    UTILS_LIBS="$UTILS_LIBS -ldl"
   ], [
     AC_MSG_RESULT(no)
     LIBS="$saved_libs"
@@ -158,6 +160,7 @@ AC_TRY_LINK(
   ], [
     AC_MSG_RESULT(yes)
     LIBS="$saved_libs -lz"
+    UTILS_LIBS="$UTILS_LIBS -lz"
   ], [
     AC_MSG_RESULT(no)
     LIBS="$saved_libs"
@@ -220,6 +223,7 @@ LIBDIRS="$ac_build_addl_libdirs"
 AC_SUBST(INCLUDES)
 AC_SUBST(LDFLAGS)
 AC_SUBST(LIBDIRS)
+AC_SUBST(UTILS_LIBS)
 
 AC_CONFIG_HEADER(mod_auth_otp.h)
 AC_OUTPUT(


### PR DESCRIPTION
…hould

remove the need to link against libsqlite3, libpam, libcap, etc for a tool
which doesn't use/need them.