### PR TITLE
[mod_tls] Introduced TLSOptions option RequirePBSZ, by default it's o…

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -10655,8 +10655,6 @@ MODRET tls_post_pass(cmd_rec *cmd) {
 }
 
 MODRET tls_prot(cmd_rec *cmd) {
-  config_rec *c = NULL;
-  unsigned long tls_opts = 0;
   char *prot;
 
   if (!tls_engine ||
@@ -10677,19 +10675,8 @@ MODRET tls_prot(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-  c = find_config(main_server->conf, CONF_PARAM, "TLSOptions", FALSE);
-  while (c != NULL) {
-    unsigned long opts = 0;
-
-    pr_signals_handle();
-    opts = *((unsigned long *) c->argv[0]);
-    tls_opts |= opts;
-
-    c = find_config_next(c, c->next, CONF_PARAM, "TLSOptions", FALSE);
-  }
-
   if (!(tls_flags & TLS_SESS_PBSZ_OK)) {
-    if ( tls_opts & TLS_OPT_REQUIRE_PBSZ ) {
+    if (tls_opts & TLS_OPT_REQUIRE_PBSZ) {
       pr_response_add_err(R_503,
                           _("You must issue the PBSZ command prior to PROT"));
 

--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -485,7 +485,6 @@ static unsigned char *tls_authenticated = NULL;
 #define TLS_OPT_VERIFY_CERT_CN				0x0800
 #define TLS_OPT_NO_AUTO_ECDH				0x1000
 #define TLS_OPT_ALLOW_WEAK_DH				0x2000
-#define TLS_OPT_REQUIRE_PBSZ        0x4000
 
 /* mod_tls SSCN modes */
 #define TLS_SSCN_MODE_SERVER				0
@@ -10676,16 +10675,16 @@ MODRET tls_prot(cmd_rec *cmd) {
   }
 
   if (!(tls_flags & TLS_SESS_PBSZ_OK)) {
-    if (tls_opts & TLS_OPT_REQUIRE_PBSZ) {
+#if 0
       pr_response_add_err(R_503,
                           _("You must issue the PBSZ command prior to PROT"));
 
       pr_cmd_set_errno(cmd, EPERM);
       errno = EPERM;
       return PR_ERROR(cmd);
-    } else {
+#else
       tls_flags |= TLS_SESS_PBSZ_OK;
-    }
+#endif
   }
 
   /* Check for <Limit> restrictions. */
@@ -11390,9 +11389,6 @@ MODRET set_tlsoptions(cmd_rec *cmd) {
 
     } else if (strcmp(cmd->argv[i], "NoAutoECDH") == 0) {
       opts |= TLS_OPT_NO_AUTO_ECDH;
-
-    } else if (strcmp(cmd->argv[i], "RequirePBSZ") == 0) {
-      opts |= TLS_OPT_REQUIRE_PBSZ;
 
     } else {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown TLSOption '",


### PR DESCRIPTION
…ptional now

RFC2228 requires clients to do PBSZ before PROT, however some broken clients ignore
this requirement. Alone it's no harm, because it's forced to be 0, so PBSZ can be made
optional.

Issue: #279
