### PR TITLE
Use the statvfs(2)/statfs(2) f_bsize (block size) field, rather than …

### DIFF
--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -2828,6 +2828,9 @@ MODRET xfer_allo(cmd_rec *cmd) {
         return PR_ERROR(cmd);
       }
 
+      pr_log_debug(DEBUG9, "%s requested %" PR_LU " KB, %" PR_LU
+        " KB available on '%s'", (char *) cmd->argv[0], (pr_off_t) requested_kb,
+        (pr_off_t) avail_kb, path);
       pr_response_add(R_200, _("%s command successful"), (char *) cmd->argv[0]);
     }
 

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -6440,15 +6440,15 @@ static int fs_getsize(int fd, char *path, off_t *fs_size) {
    * we'll use typecasting.
    */
   if (sizeof(fs.f_bavail) > 4 ||
-      sizeof(fs.f_frsize) > 4) {
+      sizeof(fs.f_bsize) > 4) {
 
     /* In order to return a size in KB, as get_fs_size() does, we need
      * to divide by 1024.
      */
-    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_frsize) / 1024);
+    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_bsize) / 1024);
 
   } else {
-    *fs_size = get_fs_size(fs.f_bavail, fs.f_frsize);
+    *fs_size = get_fs_size(fs.f_bavail, fs.f_bsize);
   }
 
   res = 0;
@@ -6501,7 +6501,7 @@ static int fs_getsize(int fd, char *path, off_t *fs_size) {
     /* In order to return a size in KB, as get_fs_size() does, we need
      * to divide by 1024.
      */
-    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_frsize) / 1024);
+    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_bsize) / 1024);
 
   } else {
     *fs_size = get_fs_size(fs.f_bavail, fs.f_bsize);
@@ -6557,7 +6557,7 @@ static int fs_getsize(int fd, char *path, off_t *fs_size) {
     /* In order to return a size in KB, as get_fs_size() does, we need
      * to divide by 1024.
      */
-    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_frsize) / 1024);
+    *fs_size = (((off_t) fs.f_bavail * (off_t) fs.f_bsize) / 1024);
 
   } else {
     *fs_size = get_fs_size(fs.f_bavail, fs.f_bsize);


### PR DESCRIPTION
…f_frsize

(fragment size), as we want to calculate the "available file system size"
based on f_bavail ("available blocks").