### PR TITLE
Bug#4255: Fix handling of AuthAliasOnly (again)

### DIFF
--- a/include/auth.h
+++ b/include/auth.h
@@ -102,7 +102,8 @@ int pr_auth_requires_pass(pool *, const char *);
  * configuration for that user.  If the user name is not be handled as
  * an anonymous login, NULL is returned.
  */
-config_rec *pr_auth_get_anon_config(pool *p, const char **, char **, char **);
+config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
+  char **real_user, char **anon_user);
 
 /* Wrapper function around the chroot(2) system call, handles setting of
  * appropriate environment variables if necessary.

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -283,7 +283,7 @@ static int auth_sess_init(void) {
   return 0;
 }
 
-static int _do_auth(pool *p, xaset_t *conf, const char *u, char *pw) {
+static int do_auth(pool *p, xaset_t *conf, const char *u, char *pw) {
   char *cpw = NULL;
   config_rec *c;
 
@@ -621,7 +621,7 @@ MODRET auth_post_pass(cmd_rec *cmd) {
 }
 
 /* Handle group based authentication, only checked if pw based fails. */
-static config_rec *_auth_group(pool *p, const char *user, char **group,
+static config_rec *auth_group(pool *p, const char *user, char **group,
     char **ournamep, char **anonnamep, char *pass) {
   config_rec *c;
   char *ourname = NULL, *anonname = NULL;
@@ -897,7 +897,7 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
   struct passwd *pw;
   config_rec *c, *tmpc;
   const char *defchdir = NULL, *defroot = NULL, *origuser, *sess_ttyname;
-  char *ourname, *anonname = NULL, *anongroup = NULL, *ugroup = NULL;
+  char *ourname = NULL, *anonname = NULL, *anongroup = NULL, *ugroup = NULL;
   char *xferlog = NULL;
   int aclp, i, res = 0, allow_chroot_symlinks = TRUE, showsymlinks;
   unsigned char *wtmp_log = NULL, *anon_require_passwd = NULL;
@@ -921,6 +921,18 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
   }
 
   pw = pr_auth_getpwnam(p, user);
+  if (pw == NULL &&
+      c != NULL &&
+      ourname != NULL) {
+    /* If the client is authenticating using an alias (e.g. "AuthAliasOnly on"),
+     * then we need to try checking using the real username, too (Bug#4255).
+     */
+    pr_trace_msg("auth", 16,
+      "no user entry found for <Anonymous> alias '%s', using '%s'", user,
+      ourname);
+    pw = pr_auth_getpwnam(p, ourname);
+  }
+
   if (pw == NULL) {
     int auth_code = PR_AUTH_NOPWD;
 
@@ -977,7 +989,7 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
    * and session.groups lists are stale, and clear them out.
    */
   if (strcmp(pw->pw_name, user) != 0) {
-    pr_log_debug(DEBUG10, "local user name '%s' differs from client-sent "
+    pr_trace_msg("auth", 10, "local user name '%s' differs from client-sent "
       "user name '%s', clearing cached group data", pw->pw_name, user);
     session.gids = NULL;
     session.groups = NULL;
@@ -994,7 +1006,7 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
      */
      res = pr_auth_getgroups(p, pw->pw_name, &session.gids, &session.groups);
      if (res < 1) {
-       pr_log_debug(DEBUG2, "no supplemental groups found for user '%s'",
+       pr_log_debug(DEBUG5, "no supplemental groups found for user '%s'",
          pw->pw_name);
      }
   }
@@ -1008,7 +1020,7 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
   /* If c != NULL from this point on, we have an anonymous login */
   aclp = login_check_limits(main_server->conf, FALSE, TRUE, &i);
 
-  if (c) {
+  if (c != NULL) {
     anongroup = get_param_ptr(c->subset, "GroupName", FALSE);
     if (anongroup == NULL) {
       anongroup = get_param_ptr(main_server->conf, "GroupName",FALSE);
@@ -1060,13 +1072,14 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
     goto auth_failure;
   }
 
-  if (c) {
+  if (c != NULL) {
     anon_require_passwd = get_param_ptr(c->subset, "AnonRequirePassword",
       FALSE);
   }
 
-  if (!c ||
-      (anon_require_passwd && *anon_require_passwd == TRUE)) {
+  if (c == NULL ||
+      (anon_require_passwd != NULL &&
+       *anon_require_passwd == TRUE)) {
     int auth_code;
     const char *user_name = user;
 
@@ -1091,10 +1104,10 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
 
     /* It is possible for the user to have already been authenticated during
      * the handling of the USER command, as by an RFC2228 mechanism.  If
-     * that had happened, we won't need to call _do_auth() here.
+     * that had happened, we won't need to call do_auth() here.
      */
     if (!authenticated_without_pass) {
-      auth_code = _do_auth(p, c ? c->subset : main_server->conf, user_name,
+      auth_code = do_auth(p, c ? c->subset : main_server->conf, user_name,
         pass);
 
     } else {
@@ -1108,7 +1121,7 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
        * passes
        */
 
-      c = _auth_group(p, user, &anongroup, &ourname, &anonname, pass);
+      c = auth_group(p, user, &anongroup, &ourname, &anonname, pass);
       if (c != NULL) {
         if (c->config_type != CONF_ANON) {
           c = NULL;
@@ -3949,21 +3962,27 @@ MODRET set_uselastlog(cmd_rec *cmd) {
 /* usage: UserAlias alias real-user */
 MODRET set_useralias(cmd_rec *cmd) {
   config_rec *c = NULL;
+  char *alias, *real_user;
 
   CHECK_ARGS(cmd, 2);
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON);
 
   /* Make sure that the given names differ. */
-  if (strcmp(cmd->argv[1], cmd->argv[2]) == 0)
-    CONF_ERROR(cmd, "alias and real user names must differ");
+  alias = cmd->argv[1];
+  real_user = cmd->argv[2];
 
-  c = add_config_param_str(cmd->argv[0], 2, cmd->argv[1], cmd->argv[2]);
+  if (strcmp(alias, real_user) == 0) {
+    CONF_ERROR(cmd, "alias and real user names must differ");
+  }
+
+  c = add_config_param_str(cmd->argv[0], 2, alias, real_user);
 
   /* Note: only merge this directive down if it is not appearing in an
    * <Anonymous> context.
    */
-  if (!check_context(cmd, CONF_ANON))
-    c->flags |= CF_MERGEDOWN;
+  if (!check_context(cmd, CONF_ANON)) {
+    c->flags |= CF_MERGEDOWN_MULTI;
+  }
 
   return PR_HANDLED(cmd);
 }

--- a/src/auth.c
+++ b/src/auth.c
@@ -1475,10 +1475,10 @@ int pr_auth_getgroups(pool *p, const char *name, array_header **group_ids,
 }
 
 /* This is one messy function.  Yuck.  Yay legacy code. */
-config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
-    char **user_name, char **anon_name) {
-  config_rec *c = NULL, *topc = NULL;
-  char *config_user_name, *config_anon_name = NULL;
+config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
+    char **real_user, char **anon_name) {
+  config_rec *c = NULL, *topc = NULL, *anon_c = NULL;
+  char *config_user_name = NULL, *config_anon_name = NULL;
   unsigned char is_alias = FALSE, *auth_alias_only = NULL;
   unsigned long config_flags = (PR_CONFIG_FIND_FL_SKIP_DIR|PR_CONFIG_FIND_FL_SKIP_LIMIT|PR_CONFIG_FIND_FL_SKIP_DYNDIR);
 
@@ -1489,9 +1489,9 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
    */
 
   config_user_name = get_param_ptr(main_server->conf, "UserName", FALSE);
-  if (config_user_name &&
-      user_name) {
-    *user_name = config_user_name;
+  if (config_user_name != NULL &&
+      real_user != NULL) {
+    *real_user = config_user_name;
   }
 
   /* If the main_server->conf->set list is large (e.g. there are many
@@ -1510,11 +1510,15 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
     config_flags);
   if (c != NULL) {
     do {
+      const char *alias;
+
       pr_signals_handle();
 
-      if (strncmp(c->argv[0], "*", 2) == 0 ||
-          strcmp(c->argv[0], *login_name) == 0) {
+      alias = c->argv[0];
+      if (strncmp(alias, "*", 2) == 0 ||
+          strcmp(alias, *login_user) == 0) {
         is_alias = TRUE;
+        topc = c;
         break;
       }
 
@@ -1523,25 +1527,26 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
   }
 
   /* This is where things get messy, rapidly. */
-  topc = c;
+  c = topc;
 
-  while (c && c->parent &&
-    (auth_alias_only = get_param_ptr(c->parent->set, "AuthAliasOnly", FALSE))) {
+  while (c != NULL &&
+         c->parent != NULL &&
+         (auth_alias_only = get_param_ptr(c->parent->subset, "AuthAliasOnly", FALSE))) {
 
-    /* while() loops should always handle signals. */
     pr_signals_handle();
 
-    if (auth_alias_only) {
-      /* If AuthAliasOnly is on, ignore this one and continue. */
-      if (*auth_alias_only == TRUE) {
-        c = find_config_next2(c, c->next, CONF_PARAM, "UserAlias", TRUE,
-          config_flags);
-        continue;
-      }
+    /* If AuthAliasOnly is on, ignore this one and continue. */
+    if (auth_alias_only != NULL &&
+        *auth_alias_only == TRUE) {
+      c = find_config_next2(c, c->next, CONF_PARAM, "UserAlias", TRUE,
+        config_flags);
+      continue;
     }
 
     /* At this point, we have found an "AuthAliasOnly off" config in
-     * c->parent->set.  See if there's a UserAlias in the same config set.
+     * c->parent->set (which means that we cannot use the UserAlias, and thus
+     * is_alias is set to false).  See if there's a UserAlias in the same
+     * config set.
      */
 
     is_alias = FALSE;
@@ -1550,22 +1555,26 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
     c = find_config_next2(c, c->next, CONF_PARAM, "UserAlias", TRUE,
       config_flags);
 
-    if (c &&
+    if (c != NULL &&
         (strncmp(c->argv[0], "*", 2) == 0 ||
-         strcmp(c->argv[0], *login_name) == 0)) {
+         strcmp(c->argv[0], *login_user) == 0)) {
       is_alias = TRUE;
     }
   }
 
-  if (c) {
-    *login_name = c->argv[1];
+  /* At this point in time, c is guaranteed (if not null) to be pointing at
+   * a UserAlias config, either the original OR one found in the AuthAliasOnly
+   * config set.
+   */
+  if (c != NULL) {
+    *login_user = c->argv[1];
 
     /* If the alias is applied inside an <Anonymous> context, we have found
      * our anon block.
      */
     if (c->parent &&
         c->parent->config_type == CONF_ANON) {
-      c = c->parent;
+      anon_c = c = c->parent;
 
     } else {
       c = NULL;
@@ -1581,7 +1590,10 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
     find_config_set_top(c);
   }
 
-  if (c) {
+  if (c != NULL) {
+    config_rec *starting_c;
+
+    starting_c = c;
     do {
       pr_signals_handle();
 
@@ -1590,45 +1602,51 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_name,
         config_anon_name = config_user_name;
       }
 
-      if (config_anon_name &&
-          strcmp(config_anon_name, *login_name) == 0) {
+      if (config_anon_name != NULL &&
+          strcmp(config_anon_name, *login_user) == 0) {
         if (anon_name != NULL) {
           *anon_name = config_anon_name;
         }
+        anon_c = c;
         break;
       }
  
     } while ((c = find_config_next(c, c->next, CONF_ANON, NULL,
       FALSE)) != NULL);
+
+    c = starting_c;
   }
 
-  if (!is_alias) {
-    /* Yes, we do want to be using c here.  Otherwise, we risk a regression
-     * of Bug#3501.
-     */
-
+  if (is_alias == FALSE) {
     auth_alias_only = get_param_ptr(c ? c->subset : main_server->conf,
       "AuthAliasOnly", FALSE);
 
-    if (auth_alias_only &&
+    if (auth_alias_only != NULL &&
         *auth_alias_only == TRUE) {
-      if (c &&
+      if (c != NULL &&
           c->config_type == CONF_ANON) {
         c = NULL;
 
       } else {
-        *login_name = NULL;
+        *login_user = NULL;
       }
 
-      auth_alias_only = get_param_ptr(main_server->conf, "AuthAliasOnly",
-        FALSE);
-      if (*login_name &&
+      /* Note: We only need to look for AuthAliasOnly in main_server IFF
+       * c is NOT null.  If c IS null, then we will already have looked up
+       * AuthAliasOnly in main_server above.
+       */
+      if (c != NULL) {
+        auth_alias_only = get_param_ptr(main_server->conf, "AuthAliasOnly",
+          FALSE);
+      }
+
+      if (*login_user &&
           auth_alias_only &&
           *auth_alias_only == TRUE) {
-        *login_name = NULL;
+        *login_user = NULL;
       }
 
-      if ((!login_name || !c) &&
+      if ((!login_user || !c) &&
           anon_name) {
         *anon_name = NULL;
       }

--- a/src/auth.c
+++ b/src/auth.c
@@ -1477,7 +1477,7 @@ int pr_auth_getgroups(pool *p, const char *name, array_header **group_ids,
 /* This is one messy function.  Yuck.  Yay legacy code. */
 config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
     char **real_user, char **anon_name) {
-  config_rec *c = NULL, *topc = NULL, *anon_c = NULL;
+  config_rec *c = NULL, *topc = NULL;
   char *config_user_name = NULL, *config_anon_name = NULL;
   unsigned char is_alias = FALSE, *auth_alias_only = NULL;
   unsigned long config_flags = (PR_CONFIG_FIND_FL_SKIP_DIR|PR_CONFIG_FIND_FL_SKIP_LIMIT|PR_CONFIG_FIND_FL_SKIP_DYNDIR);
@@ -1574,7 +1574,7 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
      */
     if (c->parent &&
         c->parent->config_type == CONF_ANON) {
-      anon_c = c = c->parent;
+      c = c->parent;
 
     } else {
       c = NULL;
@@ -1607,7 +1607,6 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
         if (anon_name != NULL) {
           *anon_name = config_anon_name;
         }
-        anon_c = c;
         break;
       }
  

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
@@ -35,6 +35,11 @@ my $TESTS = {
     test_class => [qw(bug forking rootprivs)],
   },
 
+  authaliasonly_on_anon_bug4255 => {
+    order => ++$order,
+    test_class => [qw(bug forking rootprivs)],
+  },
+
 };
 
 sub new {
@@ -48,49 +53,19 @@ sub list_tests {
 sub authaliasonly_on {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/config.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/config.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/config.scoreboard");
-
-  my $log_file = File::Spec->rel2abs('tests.log');
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
+  my $setup = test_setup($tmpdir, 'config');
 
   my $alias = 'ftp';
 
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
-  auth_group_write($auth_group_file, 'ftpd', $gid, $user);
-
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
 
-    UserAlias => "$alias $user",
+    UserAlias => "$alias $setup->{user}",
     AuthAliasOnly => 'on',
 
     IfModules => {
@@ -100,7 +75,8 @@ sub authaliasonly_on {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -117,14 +93,14 @@ sub authaliasonly_on {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($alias, $passwd);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      $client->login($alias, $setup->{passwd});
       $client->quit();
 
-      $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      eval { $client->login($user, $passwd) };
+      $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      eval { $client->login($setup->{user}, $setup->{passwd}) };
       unless ($@) {
-        die("Login using user '$user' succeeded unexpectedly");
+        die("Login using user '$setup->{user}' succeeded unexpectedly");
       }
     };
 
@@ -136,7 +112,7 @@ sub authaliasonly_on {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -146,15 +122,10 @@ sub authaliasonly_on {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub authaliasonly_off_bug2070 {
@@ -368,19 +339,18 @@ sub authaliasonly_on_anon_bug3501 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
       my ($resp_code, $resp_msg) = $client->user($config_user);
 
       my $expected;
 
       $expected = 331;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "Password required for $config_user";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
     };
@@ -513,11 +483,11 @@ sub authaliasonly_on_system_bug3501 {
 
       $expected = 331;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "Password required for $user";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
     };
@@ -548,6 +518,98 @@ sub authaliasonly_on_system_bug3501 {
   }
 
   unlink($log_file);
+}
+
+sub authaliasonly_on_anon_bug4255 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my ($config_user, $config_group) = config_get_identity();
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    User => $config_user,
+    Group => $config_group,
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthAliasOnly => 'on',
+
+    Anonymous => {
+      $setup->{home_dir} => {
+        User => $config_user,
+        Group => $config_group,
+        RequireValidShell => 'off',
+        UserAlias => "anonymous $config_user",
+      },
+    },
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my $port;
+  ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my ($resp_code, $resp_msg) = $client->login("anonymous", 'ftp@nospam.org');
+
+      my $expected = 331;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "Password required for $config_user";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      $client->quit();
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 1;


### PR DESCRIPTION
Most of the changes here are formatting/style changes; this particular area of code is quite old.  But with these tweaks, and the improved (and added-to!) regression tests for the AuthAliasOnly directive, hopefully this will keep this feature stable for a bit.