### PR TITLE
Add support for MD5 Crypt password scheme through OpenSSL

### DIFF
--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -36,6 +36,19 @@
 
 #if defined(HAVE_OPENSSL) || defined(PR_USE_OPENSSL)
 # include <openssl/evp.h>
+# include <openssl/md5.h>
+
+static unsigned const char cov_2char[64]={
+  /* from crypto/des/fcrypt.c */
+  0x2E,0x2F,0x30,0x31,0x32,0x33,0x34,0x35,
+  0x36,0x37,0x38,0x39,0x41,0x42,0x43,0x44,
+  0x45,0x46,0x47,0x48,0x49,0x4A,0x4B,0x4C,
+  0x4D,0x4E,0x4F,0x50,0x51,0x52,0x53,0x54,
+  0x55,0x56,0x57,0x58,0x59,0x5A,0x61,0x62,
+  0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6A,
+  0x6B,0x6C,0x6D,0x6E,0x6F,0x70,0x71,0x72,
+  0x73,0x74,0x75,0x76,0x77,0x78,0x79,0x7A
+};
 #endif
 
 /* default information for tables and fields */
@@ -813,6 +826,184 @@ static modret_t *sql_auth_openssl(cmd_rec *cmd, const char *plaintext,
     return PR_HANDLED(cmd);
   }
 
+  return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+}
+
+/* Extracted from OpenSSL /apps/passwd.c
+ *
+ * MD5-based password algorithm (should probably be available as a library
+ * function; then the static buffer would not be acceptable).
+ * For magic string "1", this should be compatible to the MD5-based BSD
+ * password algorithm.
+ * For 'magic' string "apr1", this is compatible to the MD5-based Apache
+ * password algorithm.
+ * (Apparently, the Apache password algorithm is identical except that the
+ * 'magic' string was changed -- the laziest application of the NIH principle
+ * I've ever encountered.)
+ */
+static char *md5crypt(const char *passwd, const char *magic, const char *salt) {
+  static char out_buf[6 + 9 + 24 + 2]; /* "$apr1$..salt..$.......md5hash..........\0" */
+  unsigned char buf[MD5_DIGEST_LENGTH];
+  char *salt_out;
+  int n;
+  unsigned int i;
+  EVP_MD_CTX md,md2;
+  size_t passwd_len, salt_len;
+
+  passwd_len = strlen(passwd);
+  out_buf[0] = '$';
+  out_buf[1] = 0;
+  assert(strlen(magic) <= 4); /* "1" or "apr1" */
+  strncat(out_buf, magic, 4);
+  strncat(out_buf, "$", 1);
+  strncat(out_buf, salt, 8);
+  assert(strlen(out_buf) <= 6 + 8); /* "$apr1$..salt.." */
+  salt_out = out_buf + 2 + strlen(magic);
+  salt_len = strlen(salt_out);
+  assert(salt_len <= 8);
+
+  EVP_MD_CTX_init(&md);
+  EVP_DigestInit_ex(&md,EVP_md5(), NULL);
+  EVP_DigestUpdate(&md, passwd, passwd_len);
+  EVP_DigestUpdate(&md, "$", 1);
+  EVP_DigestUpdate(&md, magic, strlen(magic));
+  EVP_DigestUpdate(&md, "$", 1);
+  EVP_DigestUpdate(&md, salt_out, salt_len);
+
+  EVP_MD_CTX_init(&md2);
+  EVP_DigestInit_ex(&md2,EVP_md5(), NULL);
+  EVP_DigestUpdate(&md2, passwd, passwd_len);
+  EVP_DigestUpdate(&md2, salt_out, salt_len);
+  EVP_DigestUpdate(&md2, passwd, passwd_len);
+  EVP_DigestFinal_ex(&md2, buf, NULL);
+
+  for (i = passwd_len; i > sizeof buf; i -= sizeof buf)
+    EVP_DigestUpdate(&md, buf, sizeof buf);
+  EVP_DigestUpdate(&md, buf, i);
+
+  n = passwd_len;
+  while (n) {
+    EVP_DigestUpdate(&md, (n & 1) ? "\0" : passwd, 1);
+    n >>= 1;
+  }
+  EVP_DigestFinal_ex(&md, buf, NULL);
+
+  for (i = 0; i < 1000; i++) {
+    EVP_DigestInit_ex(&md2,EVP_md5(), NULL);
+    EVP_DigestUpdate(&md2, (i & 1) ? (unsigned const char *) passwd : buf,
+        (i & 1) ? passwd_len : sizeof buf);
+    if (i % 3)
+      EVP_DigestUpdate(&md2, salt_out, salt_len);
+    if (i % 7)
+      EVP_DigestUpdate(&md2, passwd, passwd_len);
+    EVP_DigestUpdate(&md2, (i & 1) ? buf : (unsigned const char *) passwd,
+        (i & 1) ? sizeof buf : passwd_len);
+    EVP_DigestFinal_ex(&md2, buf, NULL);
+  }
+  EVP_MD_CTX_cleanup(&md2);
+
+  {
+    /* transform buf into output string */
+
+    unsigned char buf_perm[sizeof buf];
+    int dest, source;
+    char *output;
+
+    /* silly output permutation */
+    for (dest = 0, source = 0; dest < 14; dest++, source = (source + 6) % 17)
+      buf_perm[dest] = buf[source];
+    buf_perm[14] = buf[5];
+    buf_perm[15] = buf[11];
+#ifndef PEDANTIC /* Unfortunately, this generates a "no effect" warning */
+    assert(16 == sizeof buf_perm);
+#endif
+
+    output = salt_out + salt_len;
+    assert(output == out_buf + strlen(out_buf));
+
+    *output++ = '$';
+
+    for (i = 0; i < 15; i += 3) {
+      *output++ = cov_2char[buf_perm[i+2] & 0x3f];
+      *output++ = cov_2char[((buf_perm[i+1] & 0xf) << 2) |
+        (buf_perm[i+2] >> 6)];
+      *output++ = cov_2char[((buf_perm[i] & 3) << 4) |
+        (buf_perm[i+1] >> 4)];
+      *output++ = cov_2char[buf_perm[i] >> 2];
+    }
+    assert(i == 15);
+    *output++ = cov_2char[buf_perm[i] & 0x3f];
+    *output++ = cov_2char[buf_perm[i] >> 6];
+    *output = 0;
+    assert(strlen(out_buf) < sizeof(out_buf));
+  }
+  EVP_MD_CTX_cleanup(&md);
+
+  return out_buf;
+}
+
+static modret_t *sql_auth_openssl_md5crypt(cmd_rec *cmd, const char *plaintext,
+    const char *ciphertext) {
+  /* The ciphertext argument of the form "{md5-crypt}$1$saltsalt$passwd_hash".
+   */
+
+  char *ciphname;               /* ptr to name of the digest function */
+  char *md5cvalue;              /* ptr to md5crypted value we're comparing to */
+  char *saltvalue;              /* ptr to the salt value we're comparing to */
+  char *copytext;               /* temporary copy of the ciphertext string */
+  char *saltcopy;               /* temporary copy of the salt string */
+
+  sql_log(DEBUG_WARN, "'%s' vs '%s'", plaintext, ciphertext);
+  if (ciphertext[0] != '{') {
+    sql_log(DEBUG_WARN, "%s", "no {md5-crypt} found in password hash");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+  }
+
+  /* We need a copy of the ciphertext. */
+  copytext = pstrdup(cmd->tmp_pool, ciphertext);
+
+  ciphname = copytext + 1;
+
+  md5cvalue = (char *) strchr(copytext, '}');
+  if (md5cvalue == NULL) {
+    sql_log(DEBUG_WARN, "%s", "no terminating '}' for md5-crypt");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+  }
+
+  *md5cvalue = '\0';
+  md5cvalue++;
+
+  if (strcmp(ciphname, "md5-crypt")) {
+    sql_log(DEBUG_WARN, "no such cipher '%s' supported", ciphname);
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+  }
+
+  if (strlen(md5cvalue) != 34) {
+    sql_log(DEBUG_WARN, "%s", "invalid length for md5-crypt password");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+  }
+
+  if (md5cvalue[1] != '1') {
+    sql_log(DEBUG_WARN, "%s", "not a md5-crypt password");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
+  }
+
+  saltvalue = md5cvalue;
+  saltvalue += 3;
+  /* We need a copy of the salt. */
+  saltcopy = pstrdup(cmd->tmp_pool, saltvalue);
+  saltvalue = saltcopy;
+  saltvalue[8]='\0';
+
+  sql_log(DEBUG_WARN, "checking '%s' with salt '%s'", plaintext, saltvalue);
+
+  char *static_buf = md5crypt(plaintext, "1", saltvalue);
+
+  if (strcmp((char *) static_buf, md5cvalue) == 0) {
+    return PR_HANDLED(cmd);
+  }
+
+  sql_log(DEBUG_WARN, "got '%s', expected '%s'", static_buf, md5cvalue);
   return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
 }
 #endif
@@ -6916,6 +7107,7 @@ static void sql_mod_unload_ev(const void *event_data, void *user_data) {
 
 #if defined(HAVE_OPENSSL) || defined(PR_USE_OPENSSL)
     (void) sql_unregister_authtype("OpenSSL");
+    (void)sql_unregister_authtype("OpenSSL-MD5Crypt");
 #endif /* HAVE_OPENSSL */
 
     close(sql_logfd);
@@ -7007,6 +7199,7 @@ static int sql_init(void) {
 
 #if defined(HAVE_OPENSSL) || defined(PR_USE_OPENSSL)
   (void) sql_register_authtype("OpenSSL", sql_auth_openssl);
+  (void) sql_register_authtype("OpenSSL-MD5Crypt", sql_auth_openssl_md5crypt);
 #endif /* HAVE_OPENSSL */
 
   return 0;
@@ -7771,4 +7964,3 @@ module sql_module = {
   /* Module version */
   MOD_SQL_VERSION
 };
-


### PR DESCRIPTION
I've been patching `contrib/mod_sql.c` myself for a while now (~5 years) when building proftpd to be able to use md5-crypt passwords.

First time I patched it, it was because I had a FreeBSD system that was using system passwords to authenticate and I was migrating them to an SQL database. After that, you just keep the passwords in that format.

I thought it would finally be nice to contribute it so that it's widely available.

Here's a brief description on how to use it:

* Build proftpd with-module `mod_sql` and your `mod_sql_[database]` of choice
* Setup sql modules in `proftpd.conf` (`LoadModule`. `SQLBackend`, etc.)
* Use the `OpenSSL-MD5Crypt` `SQLAuthTypes` option.
* Store password in the database as `{md5-crypt}$1$...`