### PR TITLE
Change mod_auth_unix's way of obtaining the group membership for a us…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -336,6 +336,9 @@
 /* Define if you have the getgrouplist function.  */
 #undef HAVE_GETGROUPLIST
 
+/* Define if you have the getgroups function.  */
+#undef HAVE_GETGROUPS
+
 /* Define if you have the getgrset function.  */
 #undef HAVE_GETGRSET
 
@@ -389,6 +392,9 @@
 
 /* Define if you have the inet_pton function.  */
 #undef HAVE_INET_PTON
+
+/* Define if you have the initgroups function.  */
+#undef HAVE_INITGROUPS
 
 /* Define if you have the lgetxattr function.  */
 #undef HAVE_LGETXATTR

--- a/configure
+++ b/configure
@@ -33143,7 +33143,8 @@ rm -f core conftest.err conftest.$ac_objext conftest_ipa8_conftest.oo \
 
 
 
-for ac_func in getcwd getenv getgrouplist getgrset gethostbyname2 gethostname getnameinfo
+
+for ac_func in getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5
@@ -33241,7 +33242,8 @@ done
 
 
 
-for ac_func in gettimeofday hstrerror inet_aton inet_ntop inet_pton
+
+for ac_func in gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5

--- a/configure.in
+++ b/configure.in
@@ -1818,8 +1818,8 @@ AC_TRY_LINK(
   ]
 )
 
-AC_CHECK_FUNCS(getcwd getenv getgrouplist getgrset gethostbyname2 gethostname getnameinfo)
-AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton)
+AC_CHECK_FUNCS(getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo)
+AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups)
 AC_CHECK_FUNCS(loginrestrictions)
 AC_CHECK_FUNCS(memcpy mempcpy memset_s mkdir mkstemp mlock mlockall munlock munlockall)
 AC_CHECK_FUNCS(pathconf posix_fadvise putenv regcomp rmdir select setgroups socket statfs strchr strcoll strerror)

--- a/doc/modules/mod_auth_unix.html
+++ b/doc/modules/mod_auth_unix.html
@@ -33,7 +33,7 @@ The <code>AuthUnixOptions</code> directive is used to tweak various
 Unix-specific authentication behaviors in <code>mod_auth_unix</code>.  The
 currently implemented options are:
 <ul>
-  <li><code>aixNoRLogin</code><br>
+  <li><code>AIXNoRLogin</code><br>
     <p>
     In <a href="http://bugs.proftpd.org/show_bug.cgi?id=1896">Bug#1896</a>,
     support for checking some AIX-specific functions for whether a login
@@ -44,7 +44,7 @@ currently implemented options are:
     to allow FTP logins.  To enable this specific behavior, a new
     <code>AuthUnixOptions</code> setting (only honored on AIX) was added:
 <pre>
-        AuthUnixOptions aixNoRLogin
+        AuthUnixOptions AIXNoRLogin
 </pre>
     If this setting is used on any other server, it is silently ignored.
     <a href="http://bugs.proftpd.org/show_bug.cgi?id=3300">Bug#3300</a> has
@@ -52,7 +52,7 @@ currently implemented options are:
   </li>
 
   <p>
-  <li><code>magicTokenChroot</code><br>
+  <li><code>MagicTokenChroot</code><br>
     <p>
     This option causes <code>mod_auth_unix</code> to examine the home
     directory retrieved for a user for the magic "/./" token.  If found,
@@ -70,7 +70,7 @@ currently implemented options are:
   </li>
 
   <p>
-  <li><code>noGetgrouplist</code><br>
+  <li><code>NoGetgrouplist</code><br>
     <p>
     On systems which support it, the <code>getgrouplist(3)</code> function
     can be used to get the group membership list of a user in a <i>much</i>
@@ -80,10 +80,28 @@ currently implemented options are:
     Use this option to disable use of the <code>getgrouplist(3)</code>
     function, <i>e.g.</i>:
 <pre>
-        AuthUnixOptions noGetgrouplist
+        AuthUnixOptions NoGetgrouplist
 </pre>
     This setting has no effect on systems which do not support the
     <code>getgrouplist(3)</code> function.
+  </li>
+
+  <p>
+  <li><code>NoInitgroups</code><br>
+    <p>
+    On systems which support it, the <code>initgroups(3)</code> function
+    can be used to get the group membership list of a user in a <i>much</i>
+    faster way.  However, there are limits to the number of groups to which
+    a user can belong, use of this function means that groups which exceed
+    that limit <b>will be silently ignored</b>.  Thus for sites which need
+    users to belong to a <i>large</i> number of groups, use this option to
+    disable the use of the <code>initgroups(3)</code> function, <i>e.g.</i>:
+<pre>
+        AuthUnixOptions NoInitgroups
+</pre>
+    This setting has no effect on systems which do not support the
+    <code>initgroups(3)</code> function.
+  </li>
 </ul>
 
 <p>

--- a/modules/mod_auth_unix.c
+++ b/modules/mod_auth_unix.c
@@ -1439,16 +1439,16 @@ MODRET set_authunixoptions(cmd_rec *cmd) {
   c = add_config_param(cmd->argv[0], 1, NULL);
 
   for (i = 1; i < cmd->argc; i++) {
-    if (strcmp(cmd->argv[i], "AIXNoRLogin") == 0) {
+    if (strcasecmp(cmd->argv[i], "AIXNoRLogin") == 0) {
       opts |= AUTH_UNIX_OPT_AIX_NO_RLOGIN;
 
-    } else if (strcmp(cmd->argv[i], "NoGetgrouplist") == 0) {
+    } else if (strcasecmp(cmd->argv[i], "NoGetgrouplist") == 0) {
       opts |= AUTH_UNIX_OPT_NO_GETGROUPLIST;
 
-    } else if (strcmp(cmd->argv[i], "NoInitgroups") == 0) {
+    } else if (strcasecmp(cmd->argv[i], "NoInitgroups") == 0) {
       opts |= AUTH_UNIX_OPT_NO_INITGROUPS;
 
-    } else if (strcmp(cmd->argv[i], "MagicTokenChroot") == 0) {
+    } else if (strcasecmp(cmd->argv[i], "MagicTokenChroot") == 0) {
       opts |= AUTH_UNIX_OPT_MAGIC_TOKEN_CHROOT;
 
     } else {


### PR DESCRIPTION
…er, such

that it uses the following methods, in this order: initgroups, getgrouplist,
getgrset, getgrent.  The getgrent method is by far the slowest, so it is used
as a last resort.  But the use of initgroups is new; it can be toggled via
a new AuthUnixOption value.

Addresses Issue #338 .
