### PR TITLE
Address potential SQL Injection when using mod_sql_odbc

### DIFF
--- a/contrib/mod_sql_odbc.c
+++ b/contrib/mod_sql_odbc.c
@@ -198,7 +198,7 @@ static void sqlodbc_escape_string(char *to, const char *from, size_t fromlen) {
         break;
 
       case '\'':
-        *to++ = '\\';
+        *to++ = '\'';
         *to++ = '\'';
         break;
 


### PR DESCRIPTION
According to SQL99 (and later, and maybe earlier too) quotation sign (') should be escaped as double quotation ('') but module escaped it incorrectly (\').
Oracle doesn’t understand escape sequence used currently which leads to SQL injection.