### PR TITLE
Bug#4064: Upgrade to Test-Unit 0.25 for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - sudo apt-get install -y cppcheck rats
   # for integration/regression tests
   - sudo apt-get install -y libtest-unit-perl
-  - sudo apt-get install -y libwww-perl
+  - sudo apt-get install -y libwww-perl libnet-telnet-perl
   - sudo apt-get install -y libssh2-1-dev libnet-ssh2-perl
   # for test code coverage
   - sudo apt-get install -y lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ install:
   - sudo apt-get install -y libpcre3-dev
   # for static code analysis
   - sudo apt-get install -y cppcheck rats
+  # for integration/regression tests
+  - sudo apt-get install -y libtest-unit-perl
+  - sudo apt-get install -y libwww-perl
+  - sudo apt-get install -y libssh2-1-dev libnet-ssh2-perl
   # for test code coverage
   - sudo apt-get install -y lcov
   - gem install coveralls-lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,13 @@ before_script:
 script:
   # - find . -type f -name "*.c" -print | grep -v tests | xargs cppcheck 2>&1
   # - find . -type f -name "*.c" -print | grep -v tests | xargs rats --language=c
-  - ./configure LIBS=-lodbc --enable-devel=coverage --enable-ctrls --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-tests --with-modules=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap:mod_wrap2:mod_wrap2_file:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_ifsession
-  - make
-  - make TEST_VERBOSE=1 check-api
-  - make clean
   - ./configure LIBS=-lodbc --enable-devel --enable-ctrls --enable-dso --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-tests --with-shared=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap:mod_wrap2:mod_wrap2_file:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_ifsession
   - make
+  - make clean
+  - ./configure LIBS=-lodbc --enable-devel=coverage --enable-ctrls --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-tests --with-modules=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap:mod_wrap2:mod_wrap2_file:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_ifsession
+  - make
+  - make TEST_VERBOSE=1 api-tests
+  - make integration-tests
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - ./configure LIBS=-lodbc --enable-devel=coverage --enable-ctrls --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-tests --with-modules=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap:mod_wrap2:mod_wrap2_file:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_ifsession
   - make
   - make TEST_VERBOSE=1 api-tests
-  - make integration-tests
+  # - make integration-tests
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}

--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,7 @@ DESTDIR=
 include ./Make.rules
 
 DIRS=@ADDL_DIRS@
+ENABLE_UNIT_TESTS=@ENABLE_UNIT_TESTS@
 EXEEXT=@EXEEXT@
 INSTALL_DEPS=@INSTALL_DEPS@
 LIBTOOL_DEPS=@LIBTOOL_DEPS@
@@ -75,31 +76,31 @@ ftpwho$(EXEEXT): lib utils
 
 # Run the API tests
 check-api: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-api)
+	test -z "$(ENABLE_UNIT_TESTS)" || (cd tests/ && $(MAKE) api-tests)
 
 # Run the FTP command testsuite
-check-commands: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-commands)
+check-commands: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-commands)
 
 # Run the FTP configuration testsuite
-check-configs: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-configs)
+check-configs: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-configs)
 
 # Run the FTP logging testsuite
-check-logging: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-logging)
+check-logging: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-logging)
 
 # Run the FTP module testsuite
-check-modules: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-modules)
+check-modules: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-modules)
 
 # Run the FTP utils testsuite
-check-utils: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check-utils)
+check-utils: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-utils)
 
 # Run the entire testsuite
-check: proftpd$(EXEEXT)
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) check)
+check: proftpd$(EXEEXT) dummy
+	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) integration-tests)
 
 # BSD install -d doesn't work, so ...
 $(DESTDIR)$(localedir) $(DESTDIR)$(includedir) $(DESTDIR)$(includedir)/proftpd $(DESTDIR)$(libdir) $(DESTDIR)$(pkgconfigdir) $(DESTDIR)$(libdir)/proftpd $(DESTDIR)$(libexecdir) $(DESTDIR)$(localstatedir) $(DESTDIR)$(sysconfdir) $(DESTDIR)$(bindir) $(DESTDIR)$(sbindir) $(DESTDIR)$(mandir) $(DESTDIR)$(mandir)/man1 $(DESTDIR)$(mandir)/man5 $(DESTDIR)$(mandir)/man8:
@@ -195,7 +196,7 @@ clean:
 	cd src/     && $(MAKE) clean
 	cd tests/   && $(MAKE) clean
 	cd utils/   && $(MAKE) clean
-	test -z "$(ENABLE_TESTS)" || (cd tests/ && $(MAKE) clean)
+	test -z "$(ENABLE_UNIT_TESTS)" || (cd tests/ && $(MAKE) clean)
 
 	@dirs="$(DIRS)"; \
 	for dir in $$dirs; do \

--- a/Makefile.in
+++ b/Makefile.in
@@ -75,7 +75,7 @@ ftpwho$(EXEEXT): lib utils
 	$(CC) $(LDFLAGS) -o $@ $(BUILD_FTPWHO_OBJS) $(UTILS_LIBS)
 
 # Run the API tests
-check-api: proftpd$(EXEEXT)
+api-tests: proftpd$(EXEEXT)
 	test -z "$(ENABLE_UNIT_TESTS)" || (cd tests/ && $(MAKE) api-tests)
 
 # Run the FTP command testsuite
@@ -99,8 +99,8 @@ check-utils: proftpd$(EXEEXT) dummy
 	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) check-utils)
 
 # Run the entire testsuite
-check: proftpd$(EXEEXT) dummy
-	test -z "$(ENABLE_INTEGRATION_TESTS)" || (cd tests/ && $(MAKE) integration-tests)
+integration-tests: proftpd$(EXEEXT) dummy
+	(cd tests/ && $(MAKE) integration-tests)
 
 # BSD install -d doesn't work, so ...
 $(DESTDIR)$(localedir) $(DESTDIR)$(includedir) $(DESTDIR)$(includedir)/proftpd $(DESTDIR)$(libdir) $(DESTDIR)$(pkgconfigdir) $(DESTDIR)$(libdir)/proftpd $(DESTDIR)$(libexecdir) $(DESTDIR)$(localstatedir) $(DESTDIR)$(sysconfdir) $(DESTDIR)$(bindir) $(DESTDIR)$(sbindir) $(DESTDIR)$(mandir) $(DESTDIR)$(mandir)/man1 $(DESTDIR)$(mandir)/man5 $(DESTDIR)$(mandir)/man8:

--- a/configure
+++ b/configure
@@ -883,7 +883,7 @@ install_group
 ALLOCA
 pkgconfigdir
 ENABLE_NLS
-ENABLE_TESTS
+ENABLE_UNIT_TESTS
 GLUE_MODULE_OBJS
 INSTALL_STRIP
 INSTALL_DEPS
@@ -20377,7 +20377,7 @@ _ACEOF
 fi
 
 
-ENABLE_TESTS="\"\""
+ENABLE_UNIT_TESTS="\"\""
 # Check whether --enable-tests was given.
 if test "${enable_tests+set}" = set; then
   enableval=$enable_tests;  if test x"$enableval" = x"yes" ; then
@@ -20589,7 +20589,7 @@ cat >>confdefs.h <<\_ACEOF
 #define HAVE_LIBCHECK 1
 _ACEOF
 
-         ENABLE_TESTS="1"
+         ENABLE_UNIT_TESTS="1"
 
 cat >>confdefs.h <<\_ACEOF
 #define PR_USE_TESTS 1
@@ -42883,7 +42883,7 @@ install_group!$install_group$ac_delim
 ALLOCA!$ALLOCA$ac_delim
 pkgconfigdir!$pkgconfigdir$ac_delim
 ENABLE_NLS!$ENABLE_NLS$ac_delim
-ENABLE_TESTS!$ENABLE_TESTS$ac_delim
+ENABLE_UNIT_TESTS!$ENABLE_UNIT_TESTS$ac_delim
 GLUE_MODULE_OBJS!$GLUE_MODULE_OBJS$ac_delim
 INSTALL_STRIP!$INSTALL_STRIP$ac_delim
 INSTALL_DEPS!$INSTALL_DEPS$ac_delim

--- a/configure.in
+++ b/configure.in
@@ -953,7 +953,7 @@ AC_ARG_ENABLE(sia,
   ])
 
 dnl Test support
-ENABLE_TESTS="\"\""
+ENABLE_UNIT_TESTS="\"\""
 AC_ARG_ENABLE(tests,
   [AC_HELP_STRING(
     [--enable-tests],
@@ -964,7 +964,7 @@ AC_ARG_ENABLE(tests,
 
       AC_CHECK_LIB(check, tcase_create,
         [AC_DEFINE(HAVE_LIBCHECK, 1, [Define if libcheck is present.])
-         ENABLE_TESTS="1"
+         ENABLE_UNIT_TESTS="1"
          AC_DEFINE(PR_USE_TESTS, 1, [Define if testsuite support is enabled.])
         ],
         [
@@ -3772,7 +3772,7 @@ AC_DEFINE_UNQUOTED(PR_BUILD_LIBS, $my_libs, [Define the build LIBS])
 
 dnl And finally, generate the appropriate Make* and config.h
 AC_SUBST(ENABLE_NLS)
-AC_SUBST(ENABLE_TESTS)
+AC_SUBST(ENABLE_UNIT_TESTS)
 AC_SUBST(GLUE_MODULE_OBJS)
 AC_SUBST(INSTALL_STRIP)
 AC_SUBST(INSTALL_DEPS)

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -3389,7 +3389,7 @@ static char *resolve_short_tag(cmd_rec *cmd, char tag) {
         len = snprintf(argp, sizeof(arg), "%0.3f", transfer_secs);
 
       } else {
-        len = sstrncpy(argp, "-", sizeof(arg));
+        len = sstrncpy(argp, "0.0", sizeof(arg));
       }
       break;
 

--- a/doc/contrib/mod_sql_passwd.html
+++ b/doc/contrib/mod_sql_passwd.html
@@ -352,10 +352,12 @@ optional second parameter to <code>SQLPasswordUserSalt</code> controls how
 this module will use the salt:
 <pre>
   SQLPasswordUserSalt name Prepend
+  SQLPasswordUserSalt sql:/get-user-salt Prepend
 </pre>
 tells <code>mod_sql_passwd</code> to prepend the salt as a prefix, and:
 <pre>
   SQLPasswordUserSalt name Append
+  SQLPasswordUserSalt sql:/get-user-salt Append
 </pre>
 will cause the salt to be appended as a sufix.  <b>Note</b> that the default
 behavior is to <i>append</i> the salt as a suffix.

--- a/doc/howto/Testing.html
+++ b/doc/howto/Testing.html
@@ -126,12 +126,12 @@ but I would rather not do that if possible.)
 <b>Integration Tests</b><br>
 The current integration tests are written in Perl, and rely on the
 <code>Test-Unit</code> Perl package.  Specifically, you <b>must</b> use
-<code>Test-Unit-0.14</code>, <b>not</b> <code>Test-Unit-0.25</code>.  Not sure
+<code>Test-Unit-0.25</code>, <b>not</b> <code>Test-Unit-0.14</code>.  Not sure
 which version of <code>Test-Unit</code> you have, if at all?  Run the following
 command:
 <pre>
-  $ perl -MTest::Unit -e 'print $Test::Unit::VERSION, "\n";'
-  0.14
+  $ perl -MTest::Unit -e 'print $Test::Unit::VERSION; print "\n";'
+  0.25
 </pre>
 
 <p>

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -1502,11 +1502,11 @@ static char *get_next_meta(pool *p, cmd_rec *cmd, unsigned char **f,
           len = snprintf(argp, sizeof(arg), "%0.3f", transfer_secs);
 
         } else {
-          len = sstrncpy(argp, "-", sizeof(arg));
+          len = sstrncpy(argp, "0.0", sizeof(arg));
         }
 
       } else {
-        len = sstrncpy(argp, "-", sizeof(arg));
+        len = sstrncpy(argp, "0.0", sizeof(arg));
       }
 
       m++;

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -996,8 +996,10 @@ static void stor_abort(void) {
         *delete_stores == TRUE) {
       pr_log_debug(DEBUG5, "removing aborted file '%s'", session.xfer.path);
       if (pr_fsio_unlink(session.xfer.path) < 0) {
-        pr_log_debug(DEBUG0, "error deleting aborted file '%s': %s",
-          session.xfer.path, strerror(errno));
+        if (errno != ENOENT) {
+          pr_log_debug(DEBUG0, "error deleting aborted file '%s': %s",
+            session.xfer.path, strerror(errno));
+        }
       }
     }
   }

--- a/src/data.c
+++ b/src/data.c
@@ -991,6 +991,7 @@ static void poll_ctrl(void) {
         pr_response_add_err(R_450, _("%s: data transfer in progress"),
           (char *) cmd->argv[0]);
 
+        pr_cmd_dispatch_phase(cmd, LOG_CMD_ERR, 0);
         pr_response_flush(&resp_err_list);
 
         destroy_pool(cmd->pool);
@@ -1017,6 +1018,7 @@ static void poll_ctrl(void) {
         pr_response_add(R_200, _("%s: data transfer in progress"),
           (char *) cmd->argv[0]);
 
+        pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
         pr_response_flush(&resp_list);
 
         destroy_pool(cmd->pool);

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -109,10 +109,8 @@ api-tests$(EXEEXT): $(TEST_API_OBJS) $(TEST_API_DEPS)
 	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -o $@ $(TEST_API_DEPS) $(TEST_API_OBJS) $(LIBS) $(TEST_API_LIBS)
 	./$@
 
-running-tests:
+integration-tests:
 	perl tests.pl
-
-check-api: dummy api-tests$(EXEEXT)
 
 check-commands:
 	perl tests.pl --file-pattern '^t\/(commands\/|logins\.t)'
@@ -129,7 +127,7 @@ check-modules:
 check-utils:
 	perl tests.pl --file-pattern '^t\/utils\/'
 
-check: check-api running-tests
+check: check-api integration-tests
 
 clean:
 	$(LIBTOOL) --mode=clean $(RM) *.o *.gcda *.gcno api/*.o api-tests$(EXEEXT) api-tests.log

--- a/tests/api/stubs.c
+++ b/tests/api/stubs.c
@@ -80,6 +80,10 @@ int pr_cmd_dispatch(cmd_rec *cmd) {
   return 0;
 }
 
+int pr_cmd_dispatch_phase(cmd_rec *cmd, int phase, int flags) {
+  return 0;
+}
+
 int pr_cmd_read(cmd_rec **cmd) {
   if (next_cmd != NULL) {
     *cmd = next_cmd;

--- a/tests/t/lib/ProFTPD/TestSuite/Utils.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/Utils.pm
@@ -1375,27 +1375,23 @@ sub testsuite_get_runnable_tests {
   }
 
   if (defined($ENV{PROFTPD_TEST_DISABLE_CLASS})) {
-    my $test_classes = [split(':', $ENV{PROFTPD_TEST_DISABLE_CLASS})];
+    my $skip_classes = [split(':', $ENV{PROFTPD_TEST_DISABLE_CLASS})];
     my $new_runnables = [];
 
     foreach my $test (@$runnables) {
       my $skip_test = 0;
 
-      foreach my $test_class (@$test_classes) {
-        foreach my $class (@{ $tests->{$test}->{test_class} }) {
-          if ($class eq $test_class) {
+      foreach my $skip_class (@$skip_classes) {
+        foreach my $test_class (@{ $tests->{$test}->{test_class} }) {
+          if ($test_class eq $skip_class) {
             $skip_test = 1;
             last;
           }
-
-          if ($skip_test) {
-            last;
-          }
         }
+      }
 
-        unless ($skip_test) {
-          push(@$new_runnables, $test);
-        }
+      unless ($skip_test) {
+        push(@$new_runnables, $test);
       }
     }
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
@@ -94,7 +94,7 @@ my $TESTS = {
 
   appe_fails_rel_symlink_not_reg_chrooted_bug4219 => {
     order => ++$order,
-    test_class => [qw(forking)],
+    test_class => [qw(forking rootprivs)],
   },
 
   appe_fails_abs_symlink_not_reg => {
@@ -104,7 +104,7 @@ my $TESTS = {
 
   appe_fails_abs_symlink_not_reg_chrooted_bug4219 => {
     order => ++$order,
-    test_class => [qw(forking)],
+    test_class => [qw(forking rootprivs)],
   },
 
   appe_fails_login_required => {
@@ -175,7 +175,7 @@ sub appe_ok_raw_active {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('bar');
@@ -256,7 +256,7 @@ sub appe_ok_raw_passive {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('bar');
@@ -342,7 +342,7 @@ sub appe_ok_file_new {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('bar');
@@ -452,7 +452,7 @@ sub appe_ok_file_existing {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('bar');
@@ -542,7 +542,7 @@ sub appe_ok_files_new_and_existing_bug3612 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       # 1.  STOR foo
@@ -713,7 +713,7 @@ sub appe_fails_abs_symlink_new {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -826,7 +826,7 @@ sub appe_fails_abs_symlink_new_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -947,7 +947,7 @@ sub appe_fails_rel_symlink_new {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1069,7 +1069,7 @@ sub appe_fails_rel_symlink_new_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1188,7 +1188,7 @@ sub appe_ok_abs_symlink_existing {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1313,7 +1313,7 @@ sub appe_ok_abs_symlink_existing_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1439,7 +1439,7 @@ sub appe_ok_rel_symlink_existing {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1568,7 +1568,7 @@ sub appe_ok_rel_symlink_existing_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/test.lnk');
@@ -1654,7 +1654,7 @@ sub appe_fails_not_reg {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw($setup->{home_dir});
@@ -1766,7 +1766,7 @@ sub appe_fails_abs_symlink_not_reg {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/foo.d');
@@ -1873,7 +1873,7 @@ sub appe_fails_abs_symlink_not_reg_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/foo.d');
@@ -1989,7 +1989,7 @@ sub appe_fails_rel_symlink_not_reg {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/foo.d');
@@ -2106,7 +2106,7 @@ sub appe_fails_rel_symlink_not_reg_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('test.d/foo.d');
@@ -2185,7 +2185,7 @@ sub appe_fails_login_required {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       my ($resp_code, $resp_msg);
 
       my $path = $setup->{config_file};
@@ -2270,7 +2270,7 @@ sub appe_fails_no_path {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg);
@@ -2380,7 +2380,7 @@ sub appe_fails_eperm {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
       $client->port();
 
@@ -2472,7 +2472,7 @@ sub appe_hiddenstores_bug4144 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->appe_raw('bar');

--- a/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
@@ -728,7 +728,7 @@ sub dele_symlink_bug3754 {
     }
 
     unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
-      die("Can't set owner of $home_dir to $setup->{uid}/$setup->{gid}: $!");
+      die("Can't set owner of $setup->{home_dir} to $setup->{uid}/$setup->{gid}: $!");
     }
   }
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
@@ -1150,7 +1150,7 @@ sub eprt_during_xfer_bug3487 {
       while ($conn->read($tmp, 32768, 30)) {
         $buf .= $tmp;
       }
-      $conn->close();
+      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
@@ -873,7 +873,7 @@ sub epsv_during_xfer_bug3487 {
       while ($conn->read($tmp, 32768, 30)) {
         $buf .= $tmp;
       }
-      $conn->close();
+      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();

--- a/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
@@ -71,6 +71,11 @@ sub feat_ok {
     $expected_nfeat += 1;
   }
 
+  my $have_digest = feature_have_module_compiled('mod_digest.c');
+  if ($have_digest) {
+    $expected_nfeat += 8;
+  }
+
   my ($port, $config_user, $config_group) = config_write($setup->{config_file},
     $config);
 
@@ -112,7 +117,7 @@ sub feat_ok {
         ' MFMT' => 1,
         ' TVFS' => 1,
         ' MFF modify;UNIX.group;UNIX.mode;' => 1,
-        ' MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*' => 1,
+        ' MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*;' => 1,
         ' REST STREAM' => 1,
         ' SIZE' => 1,
         'End' => 1,
@@ -140,6 +145,17 @@ sub feat_ok {
 
       if ($have_copy) {
         $feats->{' SITE COPY'} = 1;
+      }
+
+      if ($have_digest) {
+        $feats->{' HASH CRC32;MD5;SHA-1*;SHA-256;SHA-512;'} = 1;
+        $feats->{' MD5'} = 1;
+        $feats->{' XCRC'} = 1;
+        $feats->{' XMD5'} = 1;
+        $feats->{' XSHA'} = 1;
+        $feats->{' XSHA1'} = 1;
+        $feats->{' XSHA256'} = 1;
+        $feats->{' XSHA512'} = 1;
       }
 
       for (my $i = 0; $i < $nfeat; $i++) {

--- a/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
@@ -112,7 +112,7 @@ sub feat_ok {
         ' MFMT' => 1,
         ' TVFS' => 1,
         ' MFF modify;UNIX.group;UNIX.mode;' => 1,
-        ' MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.mode*;UNIX.owner*;' => 1,
+        ' MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*' => 1,
         ' REST STREAM' => 1,
         ' SIZE' => 1,
         'End' => 1,

--- a/tests/t/lib/ProFTPD/Tests/Commands/HELP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/HELP.pm
@@ -33,46 +33,15 @@ sub list_tests {
 sub help_ok {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/cmds.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/cmds.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/cmds.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/cmds.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/cmds.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'cmds');
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
 
     IfModules => {
       'mod_delay.c' => {
@@ -81,11 +50,13 @@ sub help_ok {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   my $auth_helps = [
-    ' NOOP    FEAT    OPTS    AUTH*   CCC*    CONF*   ENC*    MIC*    ',
-    ' PBSZ*   PROT*   TYPE    STRU    MODE    RETR    STOR    STOU    ',
+    ' NOOP    FEAT    OPTS    HOST    CLNT    AUTH*   CCC*    CONF*   ',
+    ' ENC*    MIC*    PBSZ*   PROT*   TYPE    STRU    MODE    RETR    ',
+    ' STOR    STOU    APPE    REST    ABOR    USER    PASS    ACCT*   ',
   ];
 
   # Open pipes, for use between the parent and child processes.  Specifically,
@@ -113,12 +84,12 @@ sub help_ok {
 
       $expected = 214;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 9;
       my $nhelp = scalar(@$resp_msgs);
       $self->assert($expected == $nhelp,
-        test_msg("Expected $expected, got $nhelp"));
+        test_msg("Expected HELP count $expected, got $nhelp"));
 
       my $helps = [(
         'The following commands are recognized (* =>\'s unimplemented):',
@@ -126,8 +97,7 @@ sub help_ok {
         ' EPRT    EPSV    ALLO*   RNFR    RNTO    DELE    MDTM    RMD     ',
         ' XRMD    MKD     XMKD    PWD     XPWD    SIZE    SYST    HELP    ',
         @$auth_helps,
-        ' APPE    REST    ABOR    USER    PASS    ACCT*   REIN*   LIST    ',
-        ' NLST    STAT    SITE    MLSD    MLST    ',
+        ' REIN*   LIST    NLST    STAT    SITE    MLSD    MLST    ',
         'Direct comments to root@127.0.0.1',
       )];
 
@@ -146,7 +116,7 @@ sub help_ok {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -156,18 +126,10 @@ sub help_ok {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 1;

--- a/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
@@ -901,9 +901,9 @@ sub have_sys_hostaddr {
   foreach my $req (@$required) {
     eval "use $req";
     if ($@) {
-      print STDERR "\nWARNING:\n + Module '$req' not found, skipping test\n";
+      print STDERR " + warning: Module '$req' not found, skipping test\n";
       if ($ENV{TEST_VERBOSE}) {
-        print STDERR "Unable to load $req: $@\n";
+        print STDERR " + unable to load $req: $@\n";
       }
 
       return undef;

--- a/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
@@ -6,7 +6,6 @@ use strict;
 
 use File::Spec;
 use IO::Handle;
-use Sys::HostAddr;
 
 use ProFTPD::TestSuite::FTP;
 use ProFTPD::TestSuite::Utils qw(:auth :config :running :test :testsuite);
@@ -894,11 +893,34 @@ sub host_known_ipv6_same_host_ok {
   test_cleanup($setup->{log_file}, $ex);
 }
 
+sub have_sys_hostaddr {
+  my $required = [qw(
+    Sys::HostAddr
+  )];
+
+  foreach my $req (@$required) {
+    eval "use $req";
+    if ($@) {
+      print STDERR "\nWARNING:\n + Module '$req' not found, skipping test\n";
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "Unable to load $req: $@\n";
+      }
+
+      return undef;
+    }
+  }
+
+  return 1;
+}
+
 sub host_known_ipv4_different_host_fails {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+
+  return unless have_sys_hostaddr();
   my $setup = test_setup($tmpdir, 'cmds');
 
+  require Sys::HostAddr;
   my $ipv4_addr = Sys::HostAddr->new();
   my $v4_addrs = $ipv4_addr->addresses();
 
@@ -1013,8 +1035,11 @@ EOC
 sub host_known_ipv6_different_host_fails {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+
+  return unless have_sys_hostaddr();
   my $setup = test_setup($tmpdir, 'cmds');
 
+  require Sys::HostAddr;
   my $ipv6_addr = Sys::HostAddr->new(ipv => 6);
   my $v6_addrs = $ipv6_addr->addresses();
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
@@ -1947,7 +1947,9 @@ sub list_bug2821 {
   my $test_file_prefix = File::Spec->rel2abs("$tmpdir/test_");
 
   my $count = 110000;
-  print STDOUT "# Creating $count files in $tmpdir\n";
+  if ($ENV{TEST_VERBOSE}) {
+    print STDOUT "# Creating $count files in $tmpdir\n";
+  }
   for (my $i = 1; $i <= $count; $i++) {
     my $test_file = 'test_' . sprintf("%07s", $i);
     my $test_path = "$home_dir/$test_file";
@@ -2123,7 +2125,9 @@ sub list_unsorted_buffering_bug4060 {
   mkpath($test_dir);
 
   my $count = 100000;
-  print STDOUT "# Creating $count files in $test_dir\n";
+  if ($ENV{TEST_VERBOSE}) {
+    print STDOUT "# Creating $count files in $test_dir\n";
+  }
   for (my $i = 1; $i <= $count; $i++) {
     my $test_file = 'test_' . sprintf("%07s", $i);
     my $test_path = "$test_dir/$test_file";
@@ -2294,7 +2298,9 @@ sub list_opt_C {
   my $test_file_prefix = File::Spec->rel2abs($tmpdir);
 
   my $count = 100;
-  print STDOUT "# Creating $count files in $tmpdir\n";
+  if ($ENV{TEST_VERBOSE}) {
+    print STDOUT "# Creating $count files in $tmpdir\n";
+  }
   for (my $i = 1; $i <= $count; $i++) {
     my $test_file = sprintf("%04s", $i);
     my $test_path = "$home_dir/$test_file";
@@ -5350,14 +5356,18 @@ sub list_opt_R {
   my $dir_count = 10;
   my $file_count = 10;
 
-  print STDOUT "# Creating $dir_count directories in $tmpdir\n";
+  if ($ENV{TEST_VERBOSE}) {
+    print STDOUT "# Creating $dir_count directories in $tmpdir\n";
+  }
   for (my $i = 1; $i <= $dir_count; $i++) {
     my $test_dir = sprintf("%04s", $i);
     my $dir_path = "$home_dir/$test_dir";
 
     mkpath($dir_path);
 
-    print STDOUT "# Creating $file_count files in $dir_path\n";
+    if ($ENV{TEST_VERBOSE}) {
+      print STDOUT "# Creating $file_count files in $dir_path\n";
+    }
     for (my $j = 1; $j <= $file_count; $j++) {
       my $test_file = sprintf("%02s%02s", $i, $j);
       my $file_path = "$dir_path/$test_file";

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
@@ -146,7 +146,7 @@ sub mlst_file_ok {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('cmds.conf');
@@ -157,7 +157,7 @@ sub mlst_file_ok {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/cmds\.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/cmds\.conf$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -225,7 +225,7 @@ sub mlst_file_chrooted_ok {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('cmds.conf');
@@ -236,7 +236,7 @@ sub mlst_file_chrooted_ok {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; /cmds.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; /cmds.conf$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -346,7 +346,7 @@ sub mlst_dir_ok {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/foo$');
+      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/foo$');
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 
@@ -465,7 +465,7 @@ sub mlst_dir_cwd_bug4198 {
 
       # Note that, per Bug#4198, we do NOT expect to see a type fact of
       # "cdir" here, just "dir".
-      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*$');
+      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$');
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 
@@ -560,7 +560,7 @@ sub mlst_symlink_showsymlinks_off_bug3318 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('test.lnk');
@@ -571,7 +571,7 @@ sub mlst_symlink_showsymlinks_off_bug3318 {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/test\.lnk$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/test\.lnk$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -656,7 +656,7 @@ sub mlst_symlink_showsymlinks_on_bug3318 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('test.lnk');
@@ -667,7 +667,7 @@ sub mlst_symlink_showsymlinks_on_bug3318 {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/test\.txt$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/test\.txt$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -761,7 +761,7 @@ sub mlst_symlink_showsymlinks_on_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('test.lnk');
@@ -772,7 +772,7 @@ sub mlst_symlink_showsymlinks_on_chrooted_bug4219 {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=(a)?dfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/test\.lnk$';
+      $expected = 'modify=\d+;perm=(a)?dfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/test\.lnk$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -866,7 +866,7 @@ sub mlst_symlink_showsymlinks_on_use_slink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('test.lnk');
@@ -877,7 +877,7 @@ sub mlst_symlink_showsymlinks_on_use_slink {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = ' modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=slink:' . $dst_path . ';unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/test\.lnk$';
+      $expected = ' modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=slink:' . $dst_path . ';unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/test\.lnk$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -980,7 +980,7 @@ sub mlst_symlink_showsymlinks_on_use_slink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->mlst('test.lnk');
@@ -991,7 +991,7 @@ sub mlst_symlink_showsymlinks_on_use_slink_chrooted_bug4219 {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = ' modify=\d+;perm=(a)?dfr(w)?;size=\d+;type=OS.unix=slink:\/test\.txt;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/test\.lnk$';
+      $expected = ' modify=\d+;perm=(a)?dfr(w)?;size=\d+;type=OS.unix=slink:\/test\.txt;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/test\.lnk$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -1092,7 +1092,6 @@ sub mlst_no_path_ok {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1104,7 +1103,7 @@ sub mlst_no_path_ok {
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
 
-      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/(.*?)$');
+      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/(.*?)$');
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -1212,7 +1211,6 @@ sub mlst_fails_enoent {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1348,7 +1346,6 @@ sub mlst_fails_eperm {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       chmod(0660, $sub_dir);
@@ -1489,7 +1486,6 @@ sub mlst_hidden_file_ok {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1618,7 +1614,6 @@ sub mlst_path_with_spaces_ok {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1630,7 +1625,7 @@ sub mlst_path_with_spaces_ok {
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/foo bar$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/foo bar$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -1745,7 +1740,6 @@ sub mlst_nonascii_chars_bug3032 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1757,7 +1751,7 @@ sub mlst_nonascii_chars_bug3032 {
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/.*\/' . $test_name;
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*\/' . $test_name;
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -1878,7 +1872,6 @@ sub mlst_greek_letters {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1890,7 +1883,7 @@ sub mlst_greek_letters {
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; \/*.*\/' . $test_name . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/*.*\/' . $test_name . '$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
@@ -465,7 +465,7 @@ sub mlst_dir_cwd_bug4198 {
 
       # Note that, per Bug#4198, we do NOT expect to see a type fact of
       # "cdir" here, just "dir".
-      $expected = ' modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$';
+      $expected = ' modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
@@ -465,7 +465,7 @@ sub mlst_dir_cwd_bug4198 {
 
       # Note that, per Bug#4198, we do NOT expect to see a type fact of
       # "cdir" here, just "dir".
-      $expected = 'modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$';
+      $expected = ' modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
@@ -465,7 +465,7 @@ sub mlst_dir_cwd_bug4198 {
 
       # Note that, per Bug#4198, we do NOT expect to see a type fact of
       # "cdir" here, just "dir".
-      $expected = ('modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$');
+      $expected = 'modify=\d+;perm=flcdmpe;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+:UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; \/.*$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
@@ -205,7 +205,7 @@ sub nlst_ok_raw_active {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->nlst_raw();
@@ -318,7 +318,7 @@ sub nlst_ok_raw_passive {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->nlst_raw();
@@ -436,7 +436,7 @@ sub nlst_ok_file {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->nlst_raw($test_file);
@@ -532,7 +532,7 @@ sub nlst_ok_dir {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->nlst_raw($setup->{home_dir});
@@ -664,7 +664,7 @@ sub nlst_ok_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -805,7 +805,7 @@ sub nlst_ok_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -937,7 +937,6 @@ sub nlst_ok_no_path {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->nlst_raw();
@@ -1487,7 +1486,6 @@ sub nlst_fails_enoent {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1616,7 +1614,6 @@ sub nlst_fails_enoent_glob {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->port();
 
@@ -1755,7 +1752,6 @@ sub nlst_fails_eperm {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->port();
 
@@ -1864,7 +1860,9 @@ sub nlst_bug2821 {
     }
 
     if ($i % 10000 == 0) {
-      print STDOUT "# Created file $test_file\n";
+      if ($ENV{TEST_VERBOSE}) {
+        print STDOUT "# Created file $test_file\n";
+      }
     }
   }
 
@@ -1912,7 +1910,6 @@ sub nlst_bug2821 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       # One of the symptoms of Bug#2821 is that a LIST (or NLST) glob
@@ -2072,7 +2069,6 @@ sub nlst_nonascii_chars_bug3032 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->nlst_raw("-B test*");
@@ -2790,7 +2786,6 @@ EOL
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       $client->cwd("foo/baz");
@@ -2931,7 +2926,6 @@ sub nlst_dash_filename_bug3476 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->nlst_raw('-test.txt');
@@ -3066,7 +3060,6 @@ sub nlst_opt_noerrorifabsent_bug3506 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->nlst_raw($test_file);

--- a/tests/t/lib/ProFTPD/Tests/Commands/PASV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PASV.pm
@@ -368,7 +368,7 @@ sub pasv_during_xfer_bug3487 {
       while ($conn->read($tmp, 32768, 30)) {
         $buf .= $tmp;
       }
-      $conn->close();
+      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();

--- a/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
@@ -350,7 +350,6 @@ sub port_fails_bad_format {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -1224,21 +1223,13 @@ EOC
 
       my $expected = 425;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 'Unable to build data connection: Address already in use';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
-      ($resp_code, $resp_msg) = $client->quit();
-
-      $expected = 221;
-      $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
-
-      $expected = 'Goodbye.';
-      $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+      $client->quit();
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
@@ -128,7 +128,6 @@ sub rest_ok {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -339,7 +338,6 @@ sub rest_fails_negative_offset {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -463,7 +461,6 @@ sub rest_fails_bad_offset {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg);
@@ -587,7 +584,6 @@ sub rest_fails_offset_and_ascii {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('ascii');
 
@@ -743,7 +739,6 @@ sub rest_2gb_last_byte {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
 
@@ -756,11 +751,11 @@ sub rest_2gb_last_byte {
 
       $expected = 350;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "Restarting at $rest_len. Send STORE or RETRIEVE to initiate transfer";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       # Now attempt a download; we expect to get just one byte.
       my $conn = $client->retr_raw($test_file);
@@ -771,18 +766,12 @@ sub rest_2gb_last_byte {
 
       my $buf;
       $conn->read($buf, 1024, 30);
-      $conn->close();
+      sleep(1);
+      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-
-      $expected = 226;
-      $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
-
-      $expected = "Transfer complete";
-      $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+      $self->assert_transfer_ok($resp_code, $resp_msg);
 
       my $buflen = length($buf);
       $expected = 1;
@@ -921,7 +910,6 @@ sub rest_4gb_last_byte {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
 
@@ -934,11 +922,11 @@ sub rest_4gb_last_byte {
 
       $expected = 350;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "Restarting at $rest_len. Send STORE or RETRIEVE to initiate transfer";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       # Now attempt a download; we expect to get just one byte.
       my $conn = $client->retr_raw($test_file);
@@ -949,18 +937,12 @@ sub rest_4gb_last_byte {
 
       my $buf;
       $conn->read($buf, 1024, 30);
-      $conn->close();
+      sleep(1);
+      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-
-      $expected = 226;
-      $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
-
-      $expected = "Transfer complete";
-      $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+      $self->assert_transfer_ok($resp_code, $resp_msg);
 
       my $buflen = length($buf);
       $expected = 1;

--- a/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
@@ -177,7 +177,7 @@ sub retr_ok_raw_active {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw($test_file);
@@ -266,7 +266,7 @@ sub retr_ok_raw_passive {
       # pause a little here.
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw($test_file);
@@ -361,7 +361,7 @@ sub retr_ok_file {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw($test_file);
@@ -479,7 +479,7 @@ sub retr_ok_ascii_file_bug4237 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('ascii');
 
@@ -637,7 +637,7 @@ sub retr_abs_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -755,7 +755,7 @@ sub retr_abs_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -875,7 +875,7 @@ sub retr_rel_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -997,7 +997,7 @@ sub retr_rel_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1086,7 +1086,7 @@ sub retr_fails_not_reg {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw($setup->{home_dir});
@@ -1168,7 +1168,7 @@ sub retr_fails_login_required {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       my ($resp_code, $resp_msg);
       eval { ($resp_code, $resp_msg) = $client->retr() };
@@ -1253,7 +1253,7 @@ sub retr_fails_no_path {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw();
@@ -1338,7 +1338,7 @@ sub retr_fails_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       $client->port();
@@ -1428,7 +1428,7 @@ sub retr_fails_enoent_glob {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->port();
 
@@ -1527,7 +1527,7 @@ sub retr_fails_abs_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -1630,7 +1630,7 @@ sub retr_fails_abs_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -1734,7 +1734,7 @@ sub retr_fails_rel_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -1840,7 +1840,7 @@ sub retr_fails_rel_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -1936,7 +1936,7 @@ sub retr_fails_eperm {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
       $client->port();
 
@@ -2046,7 +2046,7 @@ sub retr_ok_dir_with_spaces {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw('sub dir/test.txt');
@@ -2142,7 +2142,7 @@ sub retr_leading_whitespace {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw(' test.txt');
@@ -2253,7 +2253,7 @@ sub retr_bug3496 {
       # pause a little here.
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw($test_file);
@@ -2265,7 +2265,7 @@ sub retr_bug3496 {
       # Close the _control_ connection immediately
       $client->{ftp}->close();
 
-      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client2->login($setup->{user}, $setup->{passwd});
     };
 
@@ -2334,7 +2334,7 @@ sub retr_2nd_transfer_terminates_1st_transfer_bug4010 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client1->login($setup->{user}, $setup->{passwd});
 
       my $conn1 = $client1->retr_raw($test_file);
@@ -2349,7 +2349,7 @@ sub retr_2nd_transfer_terminates_1st_transfer_bug4010 {
 
       # Now, log in a second time with same user/passwd, do a directory
       # listing, then close the client.
-      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client2->login($setup->{user}, $setup->{passwd});
 
       my $conn2 = $client2->list_raw('foo.bar.baz');

--- a/tests/t/lib/ProFTPD/Tests/Commands/RMD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RMD.pm
@@ -148,7 +148,7 @@ sub rmd_ok {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->rmd($test_dir);
@@ -156,11 +156,11 @@ sub rmd_ok {
 
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "RMD command successful";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
     if ($@) {
       $ex = $@;
@@ -252,7 +252,7 @@ sub rmd_abs_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -261,11 +261,11 @@ sub rmd_abs_symlink {
 
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "RMD command successful";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $self->assert(!-d $test_dir,
         test_msg("Directory $test_dir exists unexpectedly"));
@@ -362,7 +362,7 @@ sub rmd_abs_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -371,14 +371,13 @@ sub rmd_abs_symlink_chrooted_bug4219 {
 
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "RMD command successful";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
-      $self->assert(!-d $test_dir,
-        test_msg("Directory $test_dir exists unexpectedly"));
+      $self->assert(!-d $test_dir, "Directory $test_dir exists unexpectedly");
     };
     if ($@) {
       $ex = $@;
@@ -474,7 +473,7 @@ sub rmd_rel_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -588,7 +587,7 @@ sub rmd_rel_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -670,7 +669,7 @@ sub rmd_fails_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->rmd($test_dir) };
@@ -755,7 +754,7 @@ sub rmd_fails_eperm {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       # Make it such that perms on the parent dir do not allow writes
@@ -854,7 +853,7 @@ sub rmd_fails_enotdir {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->rmd($test_dir) };
@@ -947,7 +946,7 @@ sub rmd_fails_enotempty {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->rmd($test_dir) };
@@ -1042,7 +1041,7 @@ sub rmd_fails_eloop {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->rmd($test_dir) };
@@ -1150,7 +1149,7 @@ sub rmd_fails_abs_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -1261,7 +1260,7 @@ sub rmd_fails_abs_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -1375,7 +1374,7 @@ sub rmd_fails_rel_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -1491,7 +1490,7 @@ sub rmd_fails_rel_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'sub.d/test.d';
@@ -1577,7 +1576,7 @@ sub xrmd_ok {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->xrmd($test_dir);
@@ -1656,7 +1655,7 @@ sub rmd_with_spaces {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $dir = 'foo bar baz';

--- a/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
@@ -49,7 +49,7 @@ my $TESTS = {
 
   rnfr_rel_symlink_chrooted_bug4219 => {
     order => ++$order,
-    test_class => [qw(forking)],
+    test_class => [qw(forking rootprivs)],
   },
 
   rnfr_rel_symlink_enoent => {
@@ -59,7 +59,7 @@ my $TESTS = {
 
   rnfr_rel_symlink_enoent_chrooted_bug4219 => {
     order => ++$order,
-    test_class => [qw(forking)],
+    test_class => [qw(forking rootprivs)],
   },
 
   rnfr_fails_login_required => {
@@ -143,7 +143,7 @@ sub rnfr_ok {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->rnfr($test_file);
@@ -242,7 +242,7 @@ sub rnfr_abs_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -344,7 +344,7 @@ sub rnfr_abs_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -437,7 +437,7 @@ sub rnfr_abs_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -532,7 +532,7 @@ sub rnfr_abs_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -646,7 +646,7 @@ sub rnfr_rel_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -762,7 +762,7 @@ sub rnfr_rel_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -870,7 +870,7 @@ sub rnfr_rel_symlink_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -980,7 +980,7 @@ sub rnfr_rel_symlink_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -1190,7 +1190,7 @@ sub rnfr_fails_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->rnfr($test_file) };

--- a/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
@@ -1375,7 +1375,7 @@ sub rnfr_during_xfer_bug3492 {
       while ($conn->read($tmp, 32768, 30)) {
         $buf .= $tmp;
       }
-      $conn->close();
+      eval { $conn->close() };
 
       $client->quit();
     };

--- a/tests/t/lib/ProFTPD/Tests/Commands/STOR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STOR.pm
@@ -162,7 +162,7 @@ sub stor_ok_raw_active {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw('test.txt');
@@ -248,7 +248,7 @@ sub stor_ok_raw_passive {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw('test.txt');
@@ -334,7 +334,7 @@ sub stor_ok_binary_file {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -426,7 +426,7 @@ sub stor_ok_ascii_file {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('ascii');
 
@@ -520,7 +520,7 @@ sub stor_ok_ascii_file_bug4237 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('ascii');
 
@@ -663,7 +663,7 @@ sub stor_abs_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -782,7 +782,7 @@ sub stor_abs_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -904,7 +904,7 @@ sub stor_rel_symlink {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1028,7 +1028,7 @@ sub stor_rel_symlink_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1121,7 +1121,7 @@ sub stor_fails_not_reg {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw($setup->{home_dir});
@@ -1200,7 +1200,7 @@ sub stor_fails_login_required {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       eval { $client->stor($setup->{config_file}, '/dev/null') };
       unless ($@) {
@@ -1281,7 +1281,7 @@ sub stor_fails_no_path {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->stor($setup->{config_file}, '') };
@@ -1375,7 +1375,7 @@ sub stor_fails_eperm {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($setup->{user}, $setup->{passwd});
       $client->port();
 
@@ -1486,7 +1486,7 @@ sub stor_fails_abs_symlink_dir_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1598,7 +1598,7 @@ sub stor_fails_abs_symlink_dir_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1723,7 +1723,7 @@ sub stor_fails_rel_symlink_dir_enoent {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1850,7 +1850,7 @@ sub stor_fails_rel_symlink_dir_enoent_chrooted_bug4219 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -1936,7 +1936,7 @@ sub stor_leading_whitespace {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw(' test.txt');
@@ -2022,7 +2022,7 @@ sub stor_multiple_periods {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw('multi...dot...file.txt');

--- a/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
@@ -128,7 +128,7 @@ sub stou_ok_raw_active {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client->login($user, $passwd);
 
       my $conn = $client->stou_raw('bar');
@@ -139,7 +139,7 @@ sub stou_ok_raw_active {
 
       my $buf = "Foo!\n";
       $conn->write($buf, length($buf));
-      $conn->close();
+      eval { $conn->close() };
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
@@ -256,8 +256,7 @@ sub stou_ok_raw_passive {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
-
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
 
       my $conn = $client->stou_raw('bar');
@@ -268,7 +267,7 @@ sub stou_ok_raw_passive {
 
       my $buf = "Foo!\n";
       $conn->write($buf, length($buf));
-      $conn->close();
+      eval { $conn->close() };
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
@@ -397,11 +396,10 @@ sub stou_ok_file {
 
       my $buf = "Foo!\n";
       $conn->write($buf, length($buf));
-      $conn->close();
+      eval { $conn->close() };
 
-      my ($resp_code, $resp_msg);
-      $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg();
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
 
       my $expected;
 
@@ -496,7 +494,7 @@ sub stou_file_umask_bug4223 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stou_raw('bar');
@@ -593,7 +591,7 @@ sub stou_file_umask_chrooted_bug4223 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stou_raw('/bar');
@@ -817,7 +815,6 @@ sub stou_fails_eperm {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->port();
       $client->cwd('foo');

--- a/tests/t/lib/ProFTPD/Tests/Config/AllowForeignAddress.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AllowForeignAddress.pm
@@ -96,10 +96,10 @@ sub fxp_denied {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client1->login($setup->{user}, $setup->{passwd});
 
-      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0);
       $client2->login($setup->{user}, $setup->{passwd});
 
       # Get the PASV address from the first connection, and give it
@@ -242,10 +242,10 @@ sub fxp_allowed {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client1->login($setup->{user}, $setup->{passwd});
 
-      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0);
       $client2->login($setup->{user}, $setup->{passwd});
 
       # Get the PASV address from the first connection, and give it
@@ -344,6 +344,7 @@ sub fxp_allowed_2gb {
   }
 
   my $dst_file = File::Spec->rel2abs("$tmpdir/dst.txt");
+  my $timeout_idle = 30;
 
   my $config = {
     PidFile => $setup->{pid_file},
@@ -354,6 +355,7 @@ sub fxp_allowed_2gb {
     AuthGroupFile => $setup->{auth_group_file},
 
     AllowForeignAddress => 'on',
+    TimeoutIdle => $timeout_idle,
 
     IfModules => {
       'mod_delay.c' => {
@@ -380,10 +382,10 @@ sub fxp_allowed_2gb {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
+      my $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1);
       $client1->login($setup->{user}, $setup->{passwd});
 
-      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0);
       $client2->login($setup->{user}, $setup->{passwd});
 
       # Get the PASV address from the first connection, and give it
@@ -392,11 +394,11 @@ sub fxp_allowed_2gb {
 
       my $expected = 227;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = '^Entering Passive Mode \(\d+,\d+,\d+,\d+,\d+,\d+\)';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       # This will actually work, since both our connections are
       # from 127.0.0.1, which means we shouldn't run afoul of the
@@ -408,11 +410,11 @@ sub fxp_allowed_2gb {
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = 'PORT command successful';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $tmpfile = 'tmpfile.bin';
       ($resp_code, $resp_msg) = $client1->stor($src_file, $tmpfile);
@@ -424,13 +426,12 @@ sub fxp_allowed_2gb {
       $client1->quit();
       $client2->quit();
 
-      $self->assert(-f $dst_file,
-        test_msg("File $dst_file does not exist as expected"));
+      $self->assert(-f $dst_file, "File $dst_file does not exist as expected");
 
       my $dst_size = -s $dst_file;
       my $expected = -s $src_file;
       $self->assert($expected == $dst_size,
-        test_msg("Expected file size $expected, got $dst_size"));
+        "Expected file size $expected, got $dst_size");
     };
     if ($@) {
       $ex = $@;

--- a/tests/t/lib/ProFTPD/Tests/Config/DeferWelcome.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DeferWelcome.pm
@@ -233,7 +233,7 @@ sub deferwelcome_off_serverident_on {
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
-      $expected = 'ProFTPD \S+ Server \(ProFTPD\) \[\S+\]';
+      $expected = 'ProFTPD Server \(ProFTPD\) \[\S+\]';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
@@ -409,11 +409,11 @@ sub deferwelcome_on_serverident_on {
       my $expected;
       $expected = 220;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'ProFTPD \S+ Server ready\.';
+      $expected = 'ProFTPD Server ready\.';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeGroup.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeGroup.pm
@@ -475,11 +475,11 @@ sub dirfakegroup_mlst_bug3604 {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=(\d+);UNIX.mode=\d+;UNIX.owner=\d+; (.*?)\/config\.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=(\d+);UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)\/config\.conf$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected '$expected', got '$resp_msg'");
 
       $client->quit();
 
@@ -487,7 +487,7 @@ sub dirfakegroup_mlst_bug3604 {
       my $file_gid = $2;
 
       $self->assert($file_gid == $fake_gid,
-        test_msg("Expected $fake_gid, got $file_gid"));
+        "Expected GID $fake_gid, got $file_gid");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeMode.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeMode.pm
@@ -475,11 +475,11 @@ sub dirfakemode_mlst_bug3604 {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=(\d+);UNIX.owner=\d+; (.*?)\/config\.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=(\d+);UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)\/config\.conf$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
 
@@ -487,7 +487,7 @@ sub dirfakemode_mlst_bug3604 {
       my $file_mode = $2;
 
       $self->assert($file_mode == $fake_mode,
-        test_msg("Expected $fake_mode, got $file_mode"));
+        "Expected mode $fake_mode, got $file_mode");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeUser.pm
@@ -491,11 +491,11 @@ sub dirfakeuser_mlst_bug3604 {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=(\d+); (.*?)\/config\.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=(\d+);UNIX.ownername=\S+; (.*?)\/config\.conf$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
 
@@ -503,7 +503,7 @@ sub dirfakeuser_mlst_bug3604 {
       my $file_uid = $2;
 
       $self->assert($file_uid == $fake_uid,
-        test_msg("Expected $fake_uid, got $file_uid"));
+        "Expected UID $fake_uid, got $file_uid");
     };
 
     if ($@) {
@@ -972,11 +972,11 @@ sub dirfakeuser_off_mlst_bug3734 {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=(\d+); (.*?)\/config\.conf$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=(\d+);UNIX.ownername=\S+; (.*?)\/config\.conf$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayFileTransfer.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayFileTransfer.pm
@@ -120,7 +120,6 @@ sub displayfilexfer_abs_path {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->retr_raw('config.conf');
@@ -258,22 +257,20 @@ sub displayfilexfer_rel_path {
 
       my $buf;
       $conn->read($buf, 32768, 30);
-      $conn->close();
+      eval { $conn->close() };
 
-      my ($resp_code, $resp_msg);
-
-      $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg(1);
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg(1);
 
       my $expected;
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Hello user!";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -408,22 +405,20 @@ sub displayfilexfer_chrooted {
 
       my $buf;
       $conn->read($buf, 32768, 30);
-      $conn->close();
+      eval { $conn->close() };
 
-      my ($resp_code, $resp_msg);
-
-      $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg(1);
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg(1);
 
       my $expected;
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Hello user!";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -523,7 +518,6 @@ sub displayfilexfer_multiline {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my $conn = $client->retr_raw('config.conf');
@@ -534,22 +528,20 @@ sub displayfilexfer_multiline {
 
       my $buf;
       $conn->read($buf, 32768, 30);
-      $conn->close();
+      eval { $conn->close() };
 
-      my ($resp_code, $resp_msg);
-
-      $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg(3);
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg(3);
 
       my $expected;
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = " Hello user!";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -625,7 +617,7 @@ sub displayfilexfer_non_path {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->retr_raw('config.conf');
@@ -643,7 +635,7 @@ sub displayfilexfer_non_path {
 
       my $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/EnvVars.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/EnvVars.pm
@@ -117,21 +117,19 @@ sub envvar_bug2048 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
-
       $client->quit();
 
       my $expected;
 
       $expected = 220;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'ProFTPD \S+ Server \(' . $server_name . '\) \[\S+\]';
+      $expected = 'ProFTPD Server \(' . $server_name . '\) \[\S+\]';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -243,22 +241,20 @@ sub envvar_bug3502 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
-
       $client->quit();
 
       my $expected;
 
       $expected = 220;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $expected_server_name = 'Green Goat';
-      $expected = 'ProFTPD \S+ Server \(' . $expected_server_name . '\) \[\S+\]';
+      $expected = 'ProFTPD Server \(' . $expected_server_name . '\) \[\S+\]';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -385,22 +381,20 @@ EOC
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $vhost_port);
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
-
       $client->quit();
 
       my $expected;
 
       $expected = 220;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $server_name = 'Green Goat';
-      $expected = 'ProFTPD \S+ Server \(' . $server_name . '\) \[\S+\]';
+      $expected = 'ProFTPD Server \(' . $server_name . '\) \[\S+\]';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/FactsOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FactsOptions.pm
@@ -178,7 +178,7 @@ sub factsoptions_use_slink_mlsd_rel_symlinked_file {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$3} = { type => $1, unique => $2 };
         }
       }
@@ -347,7 +347,7 @@ sub factsoptions_use_slink_mlsd_rel_symlinked_dir {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$3} = { type => $1, unique => $2 };
         }
       }
@@ -519,16 +519,16 @@ sub factsoptions_use_slink_mlst_rel_symlinked_file {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       if ($^O eq 'darwin') {
         # MacOSX-specific hack, due to how it handles tmp files
         $test_symlink = ('/private' . $test_symlink);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS\.unix=slink:(\S+);unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_symlink . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS\.unix=slink:(\S+);unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_symlink . '$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -822,16 +822,16 @@ sub factsoptions_use_slink_mlst_rel_symlinked_dir {
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected $expected, got $resp_code");
 
       if ($^O eq 'darwin') {
         # MacOSX-specific hack, due to how it handles tmp files
         $test_symlink = ('/private' . $test_symlink);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=slink:(\S+);unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_symlink . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=slink:(\S+);unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_symlink . '$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected '$expected', got '$resp_msg'");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
@@ -1700,7 +1700,7 @@ sub showsymlinks_off_mlsd_rel_symlinked_file {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=\S+;unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=\S+;unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$2} = $1;
         }
       }
@@ -1867,7 +1867,7 @@ sub showsymlinks_on_mlsd_rel_symlinked_file {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$3} = { type => $1, unique => $2 };
         }
       }
@@ -2033,7 +2033,7 @@ sub showsymlinks_off_mlsd_rel_symlinked_dir {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=\S+;unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=\S+;unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$2} = $1;
         }
       }
@@ -2192,7 +2192,7 @@ sub showsymlinks_on_mlsd_rel_symlinked_dir {
       my $res = {};
       my $lines = [split(/\n/, $buf)];
       foreach my $line (@$lines) {
-        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX\.mode=\d+;UNIX.owner=\d+; (.*?)$/) {
+        if ($line =~ /^modify=\S+;perm=\S+;type=(\S+);unique=(\S+);UNIX\.group=\d+;UNIX.groupname=\S+;UNIX\.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; (.*?)$/) {
           $res->{$3} = { type => $1, unique => $2 };
         }
       }
@@ -2368,7 +2368,7 @@ sub showsymlinks_off_mlst_rel_symlinked_file {
         $test_symlink = ('/private' . $test_symlink);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_symlink . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_symlink . '$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -2675,7 +2675,7 @@ sub showsymlinks_on_mlst_rel_symlinked_file {
         $test_file = ('/private' . $test_file);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_file . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_file . '$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -2974,7 +2974,7 @@ sub showsymlinks_off_mlst_rel_symlinked_dir {
         $test_symlink = ('/private' . $test_symlink);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=dir;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_symlink . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=dir;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_symlink . '$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -3265,7 +3265,7 @@ sub showsymlinks_on_mlst_rel_symlinked_dir {
         $test_dir = ('/private' . $test_dir);
       }
 
-      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.mode=\d+;UNIX.owner=\d+; ' . $test_dir . '$';
+      $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=OS.unix=symlink;unique=\S+;UNIX.group=\d+;UNIX.groupname=\S+;UNIX.mode=\d+;UNIX.owner=\d+;UNIX.ownername=\S+; ' . $test_dir . '$';
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
     };
@@ -3720,7 +3720,7 @@ sub showsymlinks_on_stat_rel_symlinked_file {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       unless ($resp_msg =~ /^\s+(\S+)\s+\d+\s+\S+\s+\S+\s+.*?\s+\d{2}:\d{2}\s+(.*)?$/) {
         die("Response '$resp_msg' does not match expected pattern");
@@ -3739,17 +3739,8 @@ sub showsymlinks_on_stat_rel_symlinked_file {
       $self->assert($expected eq $info,
         test_msg("Expected '$expected', got '$info'"));
 
-      # XXX Possible bug; this should look like:
-      #
-      #  foo/test.lnk -> foo/test.txt
-      #
-      # instead of:
-      #
-      #  foo/test.lnk -> test.txt
-
-      $expected = "$name -> test.txt";
-      $self->assert($expected eq $path,
-        test_msg("Expected '$expected', got '$path'"));
+      $expected = "$name -> foo/test.txt";
+      $self->assert($expected eq $path, "Expected '$expected', got '$path'");
     };
 
     if ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
@@ -4858,19 +4858,21 @@ sub extlog_ftp_deflate_raw_bytes_bug3554 {
         # Only watch for the QUIT command, to get the session total.
         next unless $cmd eq 'QUIT';
 
-        my $expected = 100;
-        $self->assert($expected == $bytes_in,
-          test_msg("Expected $expected, got $bytes_in"));
-
-        # Why would this number vary so widely?  It's because of the notation
+        # Why would these numbers vary so widely?  It's because of the notation
         # used to express the port number in a PASV response.  That port
         # number is ephemeral, chosen by the kernel.
 
-        my $expected_min = 221;
-        my $expected_max = 225;
+        my $expected_min = 70;
+        my $epxected_max = 100;
+        $self->assert($expected_min <= $bytes_in &&
+                      $expected_max >= $bytes_in,
+          "Expected received bytes $expected_min-$expected_max, got $bytes_in");
+
+        $expected_min = 221;
+        $expected_max = 225;
         $self->assert($expected_min <= $bytes_out &&
                       $expected_max >= $bytes_out,
-          test_msg("Expected $expected_min - $expected_max, got $bytes_out"));
+          "Expected sent bytes $expected_min-$expected_max, got $bytes_out");
       }
     }
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
@@ -168,7 +168,6 @@ sub deflate_opts_modez_level {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->opts("MODE Z LEVEL 7");
@@ -177,11 +176,11 @@ sub deflate_opts_modez_level {
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = 'OPTS MODE Z OK';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -290,7 +289,6 @@ sub deflate_feat {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->feat();
  
       my $resp_code = $client->response_code();
@@ -300,7 +298,7 @@ sub deflate_feat {
 
       $expected = 211;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $nfeat = scalar(@$resp_msgs);
 
@@ -431,7 +429,6 @@ sub deflate_list {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->mode('Z');
 
@@ -446,7 +443,7 @@ sub deflate_list {
       while ($conn->read($data, 32768, 30)) {
         $buf .= $data;
       }
-      $conn->close();
+      eval { $conn->close() };
 
       my $inflated = uncompress($buf);
 
@@ -599,7 +596,6 @@ sub deflate_list_alternating_modes {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
 
       # Get a directory listing in alternating modes; first MODE Z, then
@@ -671,7 +667,7 @@ sub deflate_list_alternating_modes {
           die("Unexpected name '$mismatch' appeared in LIST data")
         }
 
-        $conn->close();
+        eval { $conn->close() };
       }
 
       $client->quit();
@@ -786,7 +782,6 @@ sub deflate_rest {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->mode('Z');
 
@@ -796,11 +791,11 @@ sub deflate_rest {
 
       $expected = 350;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Restarting at 0. Send STORE or RETRIEVE to initiate transfer";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -938,7 +933,6 @@ sub deflate_retr {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->mode('Z');
 
@@ -964,9 +958,9 @@ sub deflate_retr {
       $md5 = $ctx->hexdigest();
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
+        "Expected MD5 '$expected_md5', got '$md5'");
 
-      $conn->close();
+      eval { $conn->close() };
       $client->quit();
     };
 
@@ -1118,7 +1112,6 @@ sub deflate_rest_retr {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
       $client->mode('Z');
@@ -1135,8 +1128,7 @@ sub deflate_rest_retr {
       while ($conn->read($data, 32768, 30)) {
         $buf .= $data;
       }
-
-      $conn->close();
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -1169,8 +1161,7 @@ sub deflate_rest_retr {
       }
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
-
+        "Expected MD5 '$expected_md5', got '$md5'");
     };
 
     if ($@) {
@@ -1290,7 +1281,6 @@ sub deflate_stor {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->mode('Z');
 
@@ -1303,7 +1293,7 @@ sub deflate_stor {
       my $buf = "Ab" x 8192;
       my $deflated = compress($buf); 
       $conn->write($deflated, length($deflated));
-      $conn->close();
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -1322,7 +1312,7 @@ sub deflate_stor {
       }
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
+        "Expected MD5 '$expected_md5', got '$md5'");
     };
 
     if ($@) {
@@ -1475,7 +1465,6 @@ sub deflate_rest_stor {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
       $client->mode('Z');
@@ -1490,7 +1479,7 @@ sub deflate_rest_stor {
       my $buf = "Ab" x 4096;
       my $deflated = compress($buf);
       $conn->write($deflated, length($deflated));
-      $conn->close();
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -1509,8 +1498,7 @@ sub deflate_rest_stor {
       }
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
-
+        "Expected MD5 '$expected_md5', got '$md5'");
     };
 
     if ($@) {
@@ -1641,7 +1629,6 @@ sub deflate_stor_64kb_binary {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
       $client->mode('Z');
@@ -1654,11 +1641,11 @@ sub deflate_stor_64kb_binary {
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = 'OPTS MODE Z OK';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $conn = $client->stor_raw('zmode.pdf');
       unless ($conn) {
@@ -1743,11 +1730,11 @@ sub deflate_stor_64kb_binary {
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Transfer complete";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
 
@@ -1766,7 +1753,7 @@ sub deflate_stor_64kb_binary {
       }
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
+        "Expected MD5 '$expected_md5', got '$md5'");
     };
 
     if ($@) {
@@ -1897,7 +1884,6 @@ sub deflate_stor_64kb_binary_chunks {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-
       $client->login($user, $passwd);
       $client->type('binary');
       $client->mode('Z');
@@ -1910,11 +1896,11 @@ sub deflate_stor_64kb_binary_chunks {
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = 'OPTS MODE Z OK';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $conn = $client->stor_raw('zmode.pdf');
       unless ($conn) {
@@ -2024,11 +2010,11 @@ sub deflate_stor_64kb_binary_chunks {
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Transfer complete";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
 
@@ -2047,7 +2033,7 @@ sub deflate_stor_64kb_binary_chunks {
       }
 
       $self->assert($expected_md5 eq $md5,
-        test_msg("Expected '$expected_md5', got '$md5'"));
+        "Expected MD5 '$expected_md5', got '$md5'");
     };
 
     if ($@) {
@@ -2192,7 +2178,7 @@ sub deflate_mode_z_tls {
 
       $expected = '504 Unable to handle MODE Z at this time';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -2303,7 +2289,7 @@ sub deflate_netio_close_bad_cmd_sequence_bug3828 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
 
       eval { $client->mlsd("DoesNotExist") };

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
@@ -393,23 +393,16 @@ sub delay_extra_user_cmd_bug3622 {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
 
-      eval { $client->user($user) };
-      unless ($@) {
-        die("Second USER command succeeded unexpectedly");
-      }
-
-      my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg();
-
+      my ($resp_code, $resp_msg) = $client->user($user);
       my $expected;
 
-      $expected = 500;
+      $expected = 230;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
-      $expected = 'Bad sequence of commands';
+      $expected = "User $user logged in";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_digest.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_digest.pm
@@ -341,25 +341,19 @@ sub new {
 sub list_tests {
   # Check for the required Perl modules:
   #
-  #  Digest-CRC
   #  Digest-MD5
-  #  Digest-SHA1
-  #  Digest-SHA256
 
   my $required = [qw(
-    Digest::CRC
     Digest::MD5
-    Digest::SHA1
-    Digest::SHA256
   )];
 
   foreach my $req (@$required) {
     eval "use $req";
     if ($@) {
-      print STDERR "\nWARNING:\n + Module '$req' not found, skipping all tests\n";
+      print STDERR " + WARNING: Module '$req' not found, skipping all tests\n";
 
       if ($ENV{TEST_VERBOSE}) {
-        print STDERR "Unable to load $req: $@\n";
+        print STDERR "# Unable to load $req: $@\n";
       }
 
       return qw(testsuite_empty_test);
@@ -382,6 +376,21 @@ sub set_up {
   unless (chmod(0400, $rsa_host_key, $dsa_host_key)) {
     die("Can't set perms on $rsa_host_key, $dsa_host_key: $!");
   }
+}
+
+sub have_digest {
+  my $module_name = shift;
+
+  eval { require $module_name };
+  if ($@) {
+    if ($ENV{TEST_VERBOSE}) {
+      print STDOUT "# Missing $module_name, skipping test\n";
+    }
+
+    return undef;
+  }
+
+  return 1;
 }
 
 sub digest_hash_feat {
@@ -431,7 +440,7 @@ sub digest_hash_feat {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->feat();
 
       my $resp_code = $client->response_code();
@@ -528,7 +537,7 @@ sub digest_hash_opts {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my ($resp_code, $resp_msg) = $client->opts('HASH');
@@ -633,11 +642,11 @@ sub digest_hash_opts {
 }
 
 sub digest_hash_crc32 {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -704,7 +713,7 @@ sub digest_hash_crc32 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -759,11 +768,11 @@ sub digest_hash_crc32 {
 }
 
 sub digest_hash_crc32_abs_symlink {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -855,7 +864,7 @@ sub digest_hash_crc32_abs_symlink {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -910,11 +919,11 @@ sub digest_hash_crc32_abs_symlink {
 }
 
 sub digest_hash_crc32_abs_symlink_chrooted_bug4219 {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -1008,7 +1017,7 @@ sub digest_hash_crc32_abs_symlink_chrooted_bug4219 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -1063,11 +1072,11 @@ sub digest_hash_crc32_abs_symlink_chrooted_bug4219 {
 }
 
 sub digest_hash_crc32_rel_symlink {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -1163,7 +1172,7 @@ sub digest_hash_crc32_rel_symlink {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -1218,11 +1227,11 @@ sub digest_hash_crc32_rel_symlink {
 }
 
 sub digest_hash_crc32_rel_symlink_chrooted_bug4219 {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -1320,7 +1329,7 @@ sub digest_hash_crc32_rel_symlink_chrooted_bug4219 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -1375,11 +1384,11 @@ sub digest_hash_crc32_rel_symlink_chrooted_bug4219 {
 }
 
 sub digest_hash_md5 {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::MD5;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -1446,7 +1455,7 @@ sub digest_hash_md5 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'MD5';
@@ -1501,11 +1510,11 @@ sub digest_hash_md5 {
 }
 
 sub digest_hash_sha1 {
+  return unless have_digest('Digest::SHA1');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA1;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -1572,7 +1581,7 @@ sub digest_hash_sha1 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'SHA-1';
@@ -1627,11 +1636,11 @@ sub digest_hash_sha1 {
 }
 
 sub digest_hash_sha256 {
+  return unless have_digest('Digest::SHA256');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA256;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -1700,7 +1709,7 @@ sub digest_hash_sha256 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'SHA-256';
@@ -1755,11 +1764,11 @@ sub digest_hash_sha256 {
 }
 
 sub digest_hash_sha512 {
+  return unless have_digest('Digest::SHA256');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA256;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -1828,7 +1837,7 @@ sub digest_hash_sha512 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'SHA-512';
@@ -1931,7 +1940,7 @@ sub digest_hash_failed_not_logged_in {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       my $algo = 'CRC32';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
@@ -2038,7 +2047,7 @@ sub digest_hash_failed_enoent {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -2147,7 +2156,7 @@ sub digest_hash_failed_not_file {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -2271,7 +2280,7 @@ sub digest_hash_failed_config_limit {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -2386,7 +2395,7 @@ sub digest_hash_failed_blacklisted_files {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $algo = 'CRC32';
@@ -2450,11 +2459,11 @@ sub digest_hash_failed_blacklisted_files {
 }
 
 sub digest_xcrc {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -2521,7 +2530,7 @@ sub digest_xcrc {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
       $client->quit();
@@ -2562,11 +2571,11 @@ sub digest_xcrc {
 }
 
 sub digest_xcrc_abs_symlink {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -2658,7 +2667,7 @@ sub digest_xcrc_abs_symlink {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -2698,11 +2707,11 @@ sub digest_xcrc_abs_symlink {
 }
 
 sub digest_xcrc_abs_symlink_chrooted_bug4219 {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -2796,7 +2805,7 @@ sub digest_xcrc_abs_symlink_chrooted_bug4219 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -2836,11 +2845,11 @@ sub digest_xcrc_abs_symlink_chrooted_bug4219 {
 }
 
 sub digest_xcrc_rel_symlink {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -2936,7 +2945,7 @@ sub digest_xcrc_rel_symlink {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -2976,11 +2985,11 @@ sub digest_xcrc_rel_symlink {
 }
 
 sub digest_xcrc_rel_symlink_chrooted_bug4219 {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
   mkpath($test_dir);
@@ -3078,7 +3087,7 @@ sub digest_xcrc_rel_symlink_chrooted_bug4219 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $path = 'test.d/test.lnk';
@@ -3118,11 +3127,11 @@ sub digest_xcrc_rel_symlink_chrooted_bug4219 {
 }
 
 sub digest_xcrc_2gb {
+  return unless have_digest('Digest::CRC');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.dat");
   if (open(my $fh, "> $test_file")) {
@@ -3215,7 +3224,7 @@ sub digest_xcrc_2gb {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->quote('XCRC', 'test.dat');
 
@@ -3261,11 +3270,11 @@ sub digest_xcrc_2gb {
 }
 
 sub digest_md5 {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::MD5;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3332,7 +3341,7 @@ sub digest_md5 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $file = 'test.txt';
@@ -3424,7 +3433,7 @@ sub digest_md5_failed_not_file {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $file = 'test.d';
@@ -3474,11 +3483,11 @@ sub digest_md5_failed_not_file {
 }
 
 sub digest_xmd5 {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::MD5;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3545,7 +3554,7 @@ sub digest_xmd5 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       $client->quit();
@@ -3586,11 +3595,11 @@ sub digest_xmd5 {
 }
 
 sub digest_xsha {
+  return unless have_digest('Digest::SHA1');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA1;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3657,7 +3666,7 @@ sub digest_xsha {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XSHA', 'test.txt');
       $client->quit();
@@ -3698,11 +3707,11 @@ sub digest_xsha {
 }
 
 sub digest_xsha1 {
+  return unless have_digest('Digest::SHA1');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA1;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3769,7 +3778,7 @@ sub digest_xsha1 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XSHA1', 'test.txt');
       $client->quit();
@@ -3810,11 +3819,11 @@ sub digest_xsha1 {
 }
 
 sub digest_xsha256 {
+  return unless have_digest('Digest::SHA256');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA256;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3883,7 +3892,7 @@ sub digest_xsha256 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XSHA256', 'test.txt');
       $client->quit();
@@ -3924,11 +3933,11 @@ sub digest_xsha256 {
 }
 
 sub digest_xsha512 {
+  return unless have_digest('Digest::SHA256');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA256;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -3997,7 +4006,7 @@ sub digest_xsha512 {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       my ($resp_code, $resp_msg) = $client->quote('XSHA512', 'test.txt');
       $client->quit();
@@ -4038,11 +4047,11 @@ sub digest_xsha512 {
 }
 
 sub digest_host {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA1;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4058,7 +4067,7 @@ sub digest_host {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::SHA1->new();
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = $ctx->hexdigest;
     close($fh);
@@ -4143,21 +4152,21 @@ EOC
       sleep(1);
 
       my $algo = 'SHA-1';
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       my ($resp_code, $resp_msg) = $client->host($host);
 
       my $expected = 220;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       ($resp_code, $resp_msg) = $client->opts('HASH');
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->feat();
       $resp_code = $client->response_code();
@@ -4165,7 +4174,7 @@ EOC
 
       $expected = 211;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $expected_feat = ' HASH CRC32;MD5;SHA-1*;SHA-256;SHA-512;';
 
@@ -4178,28 +4187,30 @@ EOC
         }
       }
 
-      $self->assert($found, test_msg("Did not see '$expected_feat'"));
+      $self->assert($found, "Did not see expected FEAT '$expected_feat'");
 
       $client->login($setup->{user}, $setup->{passwd});
 
+      $algo = 'MD5';
+      $client->opts('HASH', $algo);
       ($resp_code, $resp_msg) = $client->quote('HASH', 'test.txt');
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest test.txt";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
-      ($resp_code, $resp_msg) = $client->quote('XSHA1', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = uc($expected_digest);
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -4229,11 +4240,11 @@ EOC
 }
 
 sub digest_path_offset_length {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4249,14 +4260,8 @@ sub digest_path_offset_length {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
-
-    my $buf;
-    unless (read($fh, $buf, 5)) {
-      die("Can't read $test_file: $!");
-    }
-
-    $ctx->add($buf);
+    my $ctx = Digest::MD5->new();
+    $ctx->addfile($fh);
     $expected_digest = uc($ctx->hexdigest);
     close($fh);
 
@@ -4306,20 +4311,20 @@ sub digest_path_offset_length {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt', '0', '5');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt', '0', '5');
       $client->quit();
 
       my $expected;
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -4347,11 +4352,11 @@ sub digest_path_offset_length {
 }
 
 sub digest_path_with_spaces {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test file.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4367,7 +4372,7 @@ sub digest_path_with_spaces {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = uc($ctx->hexdigest);
     close($fh);
@@ -4418,20 +4423,20 @@ sub digest_path_with_spaces {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', '"test file.txt"');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', '"test file.txt"');
       $client->quit();
 
       my $expected;
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -4459,11 +4464,11 @@ sub digest_path_with_spaces {
 }
 
 sub digest_path_with_spaces_offset_length {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test file.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4479,126 +4484,7 @@ sub digest_path_with_spaces_offset_length {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
-
-    my $buf;
-    unless (read($fh, $buf, 5)) {
-      die("Can't read $test_file: $!");
-    }
-
-    $ctx->add($buf);
-    $expected_digest = uc($ctx->hexdigest);
-    close($fh);
-
-  } else {
-    die("Can't read $test_file: $!");
-  }
-
-  my $config = {
-    PidFile => $setup->{pid_file},
-    ScoreboardFile => $setup->{scoreboard_file},
-    SystemLog => $setup->{log_file},
-    TraceLog => $setup->{log_file},
-    Trace => 'digest:20',
-
-    AuthUserFile => $setup->{auth_user_file},
-    AuthGroupFile => $setup->{auth_group_file},
-
-    IfModules => {
-      'mod_delay.c' => {
-        DelayEngine => 'off',
-      },
-
-      'mod_digest.c' => {
-        DigestEngine => 'on',
-      },
-    },
-  };
-
-  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
-    $config);
-
-  # Open pipes, for use between the parent and child processes.  Specifically,
-  # the child will indicate when it's done with its test by writing a message
-  # to the parent.
-  my ($rfh, $wfh);
-  unless (pipe($rfh, $wfh)) {
-    die("Can't open pipe: $!");
-  }
-
-  my $ex;
-
-  # Fork child
-  $self->handle_sigchld();
-  defined(my $pid = fork()) or die("Can't fork: $!");
-  if ($pid) {
-    eval {
-      # Allow server to start up
-      sleep(1);
-
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
-      $client->login($setup->{user}, $setup->{passwd});
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', '"test file.txt"',
-        '0', '5');
-      $client->quit();
-
-      my $expected;
-
-      $expected = 250;
-      $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
-
-      $expected = $expected_digest;
-      $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
-    };
-
-    if ($@) {
-      $ex = $@;
-    }
-
-    $wfh->print("done\n");
-    $wfh->flush();
-
-  } else {
-    eval { server_wait($setup->{config_file}, $rfh) };
-    if ($@) {
-      warn($@);
-      exit 1;
-    }
-
-    exit 0;
-  }
-
-  # Stop server
-  server_stop($setup->{pid_file});
-  $self->assert_child_ok($pid);
-
-  test_cleanup($setup->{log_file}, $ex);
-}
-
-sub digest_caching {
-  my $self = shift;
-  my $tmpdir = $self->{tmpdir};
-  my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
-
-  my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
-  if (open(my $fh, "> $test_file")) {
-    print $fh "Hello, World!\n";
-    unless (close($fh)) {
-      die("Can't write $test_file: $!");
-    }
-
-  } else {
-    die("Can't open $test_file: $!");
-  }
-
-  my $expected_digest;
-
-  if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = uc($ctx->hexdigest);
     close($fh);
@@ -4649,26 +4535,139 @@ sub digest_caching {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
-
-      # We deliberately do this multiple times, to test the in-memory
-      # caching of results.
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', '"test file.txt"',
+        '0', '5');
       $client->quit();
 
       my $expected;
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub digest_caching {
+  return unless have_digest('Digest::MD5');
+
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'digest');
+
+  my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
+  if (open(my $fh, "> $test_file")) {
+    print $fh "Hello, World!\n";
+    unless (close($fh)) {
+      die("Can't write $test_file: $!");
+    }
+
+  } else {
+    die("Can't open $test_file: $!");
+  }
+
+  my $expected_digest;
+
+  if (open(my $fh, "< $test_file")) {
+    my $ctx = Digest::MD5->new();
+    $ctx->addfile($fh);
+    $expected_digest = uc($ctx->hexdigest);
+    close($fh);
+
+  } else {
+    die("Can't read $test_file: $!");
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'digest:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_digest.c' => {
+        DigestEngine => 'on',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Allow server to start up
+      sleep(1);
+
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      # We deliberately do this multiple times, to test the in-memory
+      # caching of results.
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
+      $client->quit();
+
+      my $expected;
+
+      $expected = 250;
+      $self->assert($expected == $resp_code,
+        "Expected response code $expected, got $resp_code");
+
+      $expected = $expected_digest;
+      $self->assert($expected eq $resp_msg,
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -4696,11 +4695,11 @@ sub digest_caching {
 }
 
 sub digest_caching_max_size {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4716,7 +4715,7 @@ sub digest_caching_max_size {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = uc($ctx->hexdigest);
     close($fh);
@@ -4768,20 +4767,20 @@ sub digest_caching_max_size {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       # We deliberately do this multiple times, to test the in-memory
       # caching of results.  After each command, we "touch" the file to
       # change its mtime, meaning a new cache entry.
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my ($atime, $mtime);
       sleep(1);
@@ -4790,14 +4789,14 @@ sub digest_caching_max_size {
         die("Can't update timestamps on $test_file: $!");
       }
 
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       sleep(1);
       $atime = $mtime = time();
@@ -4806,9 +4805,9 @@ sub digest_caching_max_size {
       }
 
       # Now we should have reach the max cache size
-      eval { $client->quote('XCRC', 'test.txt') };
+      eval { $client->quote('XMD5', 'test.txt') };
       unless ($@) {
-        die("XCRC test.txt succeeded unexpectedly");
+        die("XMD5 test.txt succeeded unexpectedly");
       }
 
       $resp_code = $client->response_code();
@@ -4816,7 +4815,7 @@ sub digest_caching_max_size {
 
       $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       sleep(1);
       $atime = $mtime = time();
@@ -4824,9 +4823,9 @@ sub digest_caching_max_size {
         die("Can't update timestamps on $test_file: $!");
       }
 
-      eval { $client->quote('XCRC', 'test.txt') };
+      eval { $client->quote('XMD5', 'test.txt') };
       unless ($@) {
-        die("XCRC test.txt succeeded unexpectedly");
+        die("XMD5 test.txt succeeded unexpectedly");
       }
 
       $resp_code = $client->response_code();
@@ -4836,11 +4835,11 @@ sub digest_caching_max_size {
 
       $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = 'Resource busy';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected response '$expected', got '$resp_msg'"));
+        "Expected response '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -4868,11 +4867,11 @@ sub digest_caching_max_size {
 }
 
 sub digest_caching_max_age_same_file {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -4888,7 +4887,7 @@ sub digest_caching_max_age_same_file {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = uc($ctx->hexdigest);
     close($fh);
@@ -4940,54 +4939,54 @@ sub digest_caching_max_age_same_file {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       # We deliberately do this multiple times, to test the in-memory
       # caching of results.
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       sleep(1);
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       sleep(1);
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test.txt');
 
       $client->quit();
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -5015,11 +5014,11 @@ sub digest_caching_max_age_same_file {
 }
 
 sub digest_caching_max_age_different_file {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file1 = File::Spec->rel2abs("$tmpdir/test1.txt");
   if (open(my $fh, "> $test_file1")) {
@@ -5035,7 +5034,7 @@ sub digest_caching_max_age_different_file {
   my $expected_digest1;
 
   if (open(my $fh, "< $test_file1")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest1 = uc($ctx->hexdigest);
     close($fh);
@@ -5058,7 +5057,7 @@ sub digest_caching_max_age_different_file {
   my $expected_digest2;
 
   if (open(my $fh, "< $test_file2")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest2 = uc($ctx->hexdigest);
     close($fh);
@@ -5110,23 +5109,23 @@ sub digest_caching_max_age_different_file {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       # We deliberately do this multiple times, to test the in-memory
       # caching of results.
-      my ($resp_code, $resp_msg) = $client->quote('XCRC', 'test1.txt');
+      my ($resp_code, $resp_msg) = $client->quote('XMD5', 'test1.txt');
       my $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest1;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
-      eval { $client->quote('XCRC', 'test2.txt') };
+      eval { $client->quote('XMD5', 'test2.txt') };
       unless ($@) {
-        die("XCRC test2.txt succeeded unexpectedly");
+        die("XMD5 test2.txt succeeded unexpectedly");
       }
 
       $resp_code = $client->response_code();
@@ -5134,11 +5133,11 @@ sub digest_caching_max_age_different_file {
 
       $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "test2.txt: Resource busy";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       # Now wait for longer than 5 secs, for the expiry timer to kick in.
       my $delay = 6;
@@ -5147,30 +5146,30 @@ sub digest_caching_max_age_different_file {
       }
       sleep($delay);
 
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test2.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test2.txt');
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest2;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       sleep(1);
-      ($resp_code, $resp_msg) = $client->quote('XCRC', 'test2.txt');
+      ($resp_code, $resp_msg) = $client->quote('XMD5', 'test2.txt');
 
       $client->quit();
 
       $expected = 250;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $expected_digest2;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
     };
 
     if ($@) {
@@ -5198,11 +5197,11 @@ sub digest_caching_max_age_different_file {
 }
 
 sub digest_caching_retr {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -5218,7 +5217,7 @@ sub digest_caching_retr {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = lc($ctx->hexdigest);
     close($fh);
@@ -5270,22 +5269,22 @@ sub digest_caching_retr {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $file = 'test.txt';
 
@@ -5309,12 +5308,12 @@ sub digest_caching_retr {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest $file";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -5344,11 +5343,11 @@ sub digest_caching_retr {
 }
 
 sub digest_caching_rest_retr {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -5364,7 +5363,7 @@ sub digest_caching_rest_retr {
   my $expected_digest;
 
   if (open(my $fh, "< $test_file")) {
-    my $ctx = Digest::CRC->new(type => 'crc32');
+    my $ctx = Digest::MD5->new();
     $ctx->addfile($fh);
     $expected_digest = lc($ctx->hexdigest);
     close($fh);
@@ -5416,22 +5415,22 @@ sub digest_caching_rest_retr {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $file = 'test.txt';
 
@@ -5439,11 +5438,11 @@ sub digest_caching_rest_retr {
 
       $expected = 350;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Restarting at 0. Send STORE or RETRIEVE to initiate transfer";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       # Now we download the file, and see whether mod_digest can
       # opportunistically generate and cache the digest.
@@ -5465,12 +5464,12 @@ sub digest_caching_rest_retr {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest $file";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -5500,16 +5499,16 @@ sub digest_caching_rest_retr {
 }
 
 sub digest_caching_stor {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
 
-  require Digest::CRC;
-
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   my $test_data = "Hello, World!\n";
 
-  my $ctx = Digest::CRC->new(type => 'crc32');
+  my $ctx = Digest::MD5->new();
   $ctx->add($test_data);
   my $expected_digest = lc($ctx->hexdigest);
 
@@ -5555,22 +5554,22 @@ sub digest_caching_stor {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $file = 'test.txt';
 
@@ -5593,12 +5592,12 @@ sub digest_caching_stor {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest $file";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -5628,16 +5627,16 @@ sub digest_caching_stor {
 }
 
 sub digest_caching_rest_stor {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
 
-  require Digest::CRC;
-
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   my $test_data = "Hello, World!\n";
 
-  my $ctx = Digest::CRC->new(type => 'crc32');
+  my $ctx = Digest::MD5->new();
   $ctx->add($test_data);
   my $expected_digest = lc($ctx->hexdigest);
 
@@ -5683,22 +5682,22 @@ sub digest_caching_rest_stor {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $file = 'test.txt';
 
@@ -5706,11 +5705,11 @@ sub digest_caching_rest_stor {
 
       $expected = 350;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "Restarting at 0. Send STORE or RETRIEVE to initiate transfer";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       # Now we upload the file, and see whether mod_digest can
       # opportunistically generate and cache the digest.
@@ -5731,12 +5730,12 @@ sub digest_caching_rest_stor {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest $file";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -5766,16 +5765,16 @@ sub digest_caching_rest_stor {
 }
 
 sub digest_caching_appe {
+  return unless have_digest('Digest::MD5');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
 
-  require Digest::CRC;
-
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   my $test_data = "Hello, World!\n";
 
-  my $ctx = Digest::CRC->new(type => 'crc32');
+  my $ctx = Digest::MD5->new();
   $ctx->add($test_data);
   my $expected_digest = lc($ctx->hexdigest);
 
@@ -5821,22 +5820,22 @@ sub digest_caching_appe {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       my $file = 'test.txt';
 
@@ -5859,12 +5858,12 @@ sub digest_caching_appe {
 
       $expected = 213;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       my $filesz = -s $test_file;
       $expected = "$algo 0-$filesz $expected_digest $file";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -5940,7 +5939,7 @@ sub digest_failed_not_logged_in {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       eval { $client->quote('XCRC', 'test.txt') };
       unless ($@) {
         die("XCRC test.txt succeeded unexpectedly");
@@ -6032,7 +6031,7 @@ sub digest_failed_enoent {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       eval { $client->quote('XCRC', 'test.txt') };
       unless ($@) {
@@ -6128,7 +6127,7 @@ sub digest_failed_not_file {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       eval { $client->quote('XCRC', 'test.d') };
       unless ($@) {
@@ -6229,7 +6228,7 @@ sub digest_failed_blacklisted_files {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       foreach my $test_file (@$test_files) {
@@ -6338,7 +6337,7 @@ sub digest_failed_start_pos_invalid_number {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->quote('XCRC', $test_file, 'a', '5') };
@@ -6443,7 +6442,7 @@ sub digest_failed_end_pos_invalid_number {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->quote('XCRC', $test_file, '1', 'a') };
@@ -6548,7 +6547,7 @@ sub digest_failed_end_pos_too_large {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->quote('XCRC', $test_file, '0', '1000') };
@@ -6653,7 +6652,7 @@ sub digest_failed_start_pos_after_end_pos {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       my $start_pos = 10;
@@ -6721,11 +6720,11 @@ sub digest_failed_start_pos_after_end_pos {
 }
 
 sub digest_config_algorithms {
+  return unless have_digest('Digest::SHA256');
+
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::SHA256;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -6796,7 +6795,7 @@ sub digest_config_algorithms {
       sleep(1);
 
       my $algo = 'SHA-256';
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       my ($resp_code, $resp_msg) = $client->opts('HASH');
 
@@ -6942,7 +6941,7 @@ sub digest_config_default_algo {
       sleep(1);
 
       my $algo = 'MD5';
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       my ($resp_code, $resp_msg) = $client->opts('HASH');
 
@@ -7049,7 +7048,7 @@ sub digest_config_engine {
       sleep(1);
 
       my $algo = 'SHA-256';
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       eval { $client->opts('HASH') };
       unless ($@) {
@@ -7209,7 +7208,7 @@ EOC
       sleep(1);
 
       my $algo = 'SHA-1';
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       # We have not logged in yet, thus the per-user setting hasn't taken
       # effect.
@@ -7371,7 +7370,7 @@ sub digest_config_enable {
 
       my $file = 'test.txt';
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->quote('HASH', $file) };
@@ -7507,7 +7506,7 @@ EOC
 
       my $file = 'test.txt';
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
       eval { $client->quote('HASH', $file) };
@@ -7574,8 +7573,6 @@ sub digest_config_max_size {
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
 
-  require Digest::CRC;
-
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
     print $fh "Hello, World!\n";
@@ -7630,21 +7627,21 @@ sub digest_config_max_size {
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       eval { $client->quote('HASH', 'test.txt') };
       unless ($@) {
@@ -7660,7 +7657,7 @@ sub digest_config_max_size {
 
       $expected = "test.txt: Operation not permitted";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       eval { $client->quote('XCRC', 'test.txt') };
       unless ($@) {
@@ -7672,11 +7669,11 @@ sub digest_config_max_size {
 
       $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "test.txt: Operation not permitted";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -7709,8 +7706,6 @@ sub digest_config_max_size_per_user {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'digest');
-
-  require Digest::CRC;
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
   if (open(my $fh, "> $test_file")) {
@@ -7780,21 +7775,21 @@ EOC
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
 
-      my $algo = 'CRC32';
+      my $algo = 'MD5';
       my ($resp_code, $resp_msg) = $client->opts('HASH', $algo);
 
       my $expected;
 
       $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = $algo;
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       eval { $client->quote('HASH', 'test.txt') };
       unless ($@) {
@@ -7806,11 +7801,11 @@ EOC
 
       $expected = 556;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "test.txt: Operation not permitted";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       eval { $client->quote('XCRC', 'test.txt') };
       unless ($@) {
@@ -7822,11 +7817,11 @@ EOC
 
       $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code"));
+        "Expected response code $expected, got $resp_code");
 
       $expected = "test.txt: Operation not permitted";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'"));
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };
@@ -8012,7 +8007,7 @@ EOS
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 
@@ -8180,7 +8175,7 @@ EOS
       # Allow server to start up
       sleep(1);
 
-      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($setup->{user}, $setup->{passwd});
       $client->type('binary');
 

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -5,7 +5,7 @@ use strict;
 use Cwd qw(abs_path);
 use File::Spec;
 use Getopt::Long;
-use Test::Harness qw(&runtests $verbose);
+use TAP::Harness;
 
 my $opts = {};
 GetOptions($opts, 'h|help', 'C|class=s@', 'K|keep-tmpfiles', 'F|file-pattern=s',
@@ -21,7 +21,6 @@ if ($opts->{K}) {
 
 if ($opts->{V}) {
   $ENV{TEST_VERBOSE} = 1;
-  $verbose = 1;
 }
 
 # We use this, rather than use(), since use() is equivalent to a BEGIN
@@ -527,7 +526,23 @@ if (defined($opts->{F})) {
   $test_files = $filtered_files;
 }
 
-runtests(@$test_files) if scalar(@$test_files) > 0;
+if (scalar(@$test_files) > 0) {
+  my $tap_opts = {
+    color => 1,
+    errors => 1,
+    ignore_exit => 1,
+    merge => 0,
+    show_count => 1,
+    trap => 1,
+    verbosity => 1,
+  };
+
+  my $harness = TAP::Harness->new($tap_opts);
+  my $results = $harness->runtests(@$test_files);
+
+} else {
+  print STDOUT "No eligible tests found!\n";
+}
 
 exit 0;
 

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -9,7 +9,7 @@ use TAP::Harness;
 
 my $opts = {};
 GetOptions($opts, 'h|help', 'C|class=s@', 'K|keep-tmpfiles', 'F|file-pattern=s',
-  'V|verbose');
+  'V|verbose', 'quiet');
 
 if ($opts->{h}) {
   usage();
@@ -527,14 +527,22 @@ if (defined($opts->{F})) {
 }
 
 if (scalar(@$test_files) > 0) {
+  my $show_count = 1;
+  my $verbosity = 1;
+
+  if ($opts->{quiet}) {
+    $show_count = 0;
+    $verbosity = 0;
+  }
+
   my $tap_opts = {
     color => 1,
     errors => 1,
     ignore_exit => 1,
     merge => 0,
-    show_count => 1,
+    show_count => $show_count,
     trap => 1,
-    verbosity => 1,
+    verbosity => $verbosity,
   };
 
   my $harness = TAP::Harness->new($tap_opts);


### PR DESCRIPTION
Make sure the ProFTPD integration testsuite runs using the `Test-Unit 0.25` Perl module.