### PR TITLE
If prctl(2) is available (e.g. Linux), *and* we want to disable cored…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -483,6 +483,9 @@
 /* Define if you have the Postgres PQinitOpenSSL function.  */
 #undef HAVE_POSTGRES_PQINITOPENSSL
 
+/* Define if you have the prctl function.  */
+#undef HAVE_PRCTL
+
 /* Define if you have the pstat function.  */
 #undef HAVE_PSTAT
 
@@ -662,6 +665,9 @@
 
 /* Define if you have the <linux/capability.h> header file.  */
 #undef HAVE_LINUX_CAPABILITY_H
+
+/* Define if you have the <linux/prctl.h> header file.  */
+#undef HAVE_LINUX_PRCTL_H
 
 /* Define if you have the <locale.h> header file.  */
 #undef HAVE_LOCALE_H

--- a/configure
+++ b/configure
@@ -22834,7 +22834,8 @@ fi
 
 
 
-for ac_header in fcntl.h signal.h sys/ioctl.h sys/prctl.h sys/resource.h sys/time.h junistd.h memory.h
+
+for ac_header in fcntl.h signal.h linux/prctl.h sys/ioctl.h sys/prctl.h sys/resource.h sys/time.h junistd.h memory.h
 do
 as_ac_Header=`echo "ac_cv_header_$ac_header" | $as_tr_sh`
 if { as_var=$as_ac_Header; eval "test \"\${$as_var+set}\" = set"; }; then
@@ -33552,7 +33553,8 @@ done
 
 
 
-for ac_func in pathconf posix_fadvise putenv regcomp rmdir select setgroups socket statfs strchr strcoll strerror
+
+for ac_func in pathconf posix_fadvise prctl putenv regcomp rmdir select setgroups socket statfs strchr strcoll strerror
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5

--- a/configure.in
+++ b/configure.in
@@ -1353,7 +1353,7 @@ dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(fcntl.h signal.h sys/ioctl.h sys/prctl.h sys/resource.h sys/time.h junistd.h memory.h)
+AC_CHECK_HEADERS(fcntl.h signal.h linux/prctl.h sys/ioctl.h sys/prctl.h sys/resource.h sys/time.h junistd.h memory.h)
 if test x"$force_shadow" != xno ; then
   AC_CHECK_HEADERS(shadow.h,
     [ if test "$use_shadow" = "" && test -f /etc/shadow ; then
@@ -1818,7 +1818,7 @@ AC_CHECK_FUNCS(getcwd getenv getgrouplist getgroups getgrset gethostbyname2 geth
 AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups)
 AC_CHECK_FUNCS(loginrestrictions)
 AC_CHECK_FUNCS(memcpy mempcpy memset_s mkdir mkstemp mlock mlockall munlock munlockall)
-AC_CHECK_FUNCS(pathconf posix_fadvise putenv regcomp rmdir select setgroups socket statfs strchr strcoll strerror)
+AC_CHECK_FUNCS(pathconf posix_fadvise prctl putenv regcomp rmdir select setgroups socket statfs strchr strcoll strerror)
 AC_CHECK_FUNCS(strlcat strlcpy strsep strtod strtof strtol strtoll strtoull setprotoent setspent endprotoent)
 # __snprintf and __vsnprintf are only on solaris and _really_ broken there.
 AC_CHECK_FUNCS(vsnprintf snprintf)

--- a/modules/mod_rlimit.c
+++ b/modules/mod_rlimit.c
@@ -559,7 +559,7 @@ static int rlimit_set_core(int scope) {
     pr_log_debug(DEBUG2, "set core resource limits for daemon");
   }
 
-#if defined(PR_DEVEL_COREDUMP) && \
+#if !defined(PR_DEVEL_COREDUMP) && \
     defined(HAVE_PRCTL) && \
     defined(PR_SET_DUMPABLE)
   if (max == 0) {
@@ -576,7 +576,7 @@ static int rlimit_set_core(int scope) {
         strerror(errno));
     }
   }
-#endif /* --enable-devel=coredump and HAVE_PRCTL and PR_SET_DUMPABLE */
+#endif /* no --enable-devel=coredump and HAVE_PRCTL and PR_SET_DUMPABLE */
 
   errno = xerrno;
   return res;


### PR DESCRIPTION
…umps (which we usually do), *and* the PR_SET_DUMPABLE flag is available, then
use prctl(2) to really ensure that coredumps are disabled.