### PR TITLE
Rename the include/mod_log.h header file to include/logfmt.h, to more…

### DIFF
--- a/include/logfmt.h
+++ b/include/logfmt.h
@@ -1,6 +1,6 @@
 /*
- * ProFTPD: mod_log
- * Copyright (c) 2013-2016 TJ Saunders
+ * ProFTPD: LogFormat
+ * Copyright (c) 2013-2017 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,8 +22,8 @@
  * source distribution.
  */
 
-#ifndef MOD_LOG_H
-#define MOD_LOG_H
+#ifndef PR_LOGFMT_H
+#define PR_LOGFMT_H
 
 /* These "meta" sequences represent the parsed LogFormat variables. */
 #define LOGFMT_META_START		0xff
@@ -79,4 +79,4 @@
 #define LOGFMT_META_XFER_TYPE		49
 #define LOGFMT_META_REMOTE_PORT		50
 
-#endif /* MOD_LOG_H */
+#endif /* PR_LOGFMT_H */

--- a/locale/files.txt
+++ b/locale/files.txt
@@ -159,10 +159,10 @@
 ../include/lastlog.h
 ../include/libsupp.h
 ../include/log.h
+../include/logfmt.h
 ../include/memcache.h
 ../include/mkhome.h
 ../include/mod_ctrls.h
-../include/mod_log.h
 ../include/modules.h
 ../include/netacl.h
 ../include/netaddr.h

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2016 The ProFTPD Project team
+ * Copyright (c) 2001-2017 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 
 #include "conf.h"
 #include "privs.h"
-#include "mod_log.h"
+#include "logfmt.h"
 
 module log_module;
 

--- a/modules/mod_redis.c
+++ b/modules/mod_redis.c
@@ -27,7 +27,7 @@
 
 #include "conf.h"
 #include "privs.h"
-#include "mod_log.h"
+#include "logfmt.h"
 #include "json.h"
 
 #define MOD_REDIS_VERSION		"mod_redis/0.1"


### PR DESCRIPTION
… accurately

reflect its contents, and the fact that it is not a "module" thing, but rather
a core thing now.