### PR TITLE
Bug#4284: Use root privs, when necessary, to allow SITE UTIME to modi…

### DIFF
--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -1,7 +1,6 @@
 /*
  * ProFTPD: mod_site_misc -- a module implementing miscellaneous SITE commands
- *
- * Copyright (c) 2004-2016 The ProFTPD Project
+ * Copyright (c) 2004-2017 The ProFTPD Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1027,7 +1026,7 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
   tvs[0].tv_sec = tvs[1].tv_sec = site_misc_mktime(year, month, day, hour,
     min, sec);
 
-  if (pr_fsio_utimes(path, tvs) < 0) {
+  if (pr_fsio_utimes_with_root(path, tvs) < 0) {
     int xerrno = errno;
 
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
@@ -1209,7 +1208,7 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
   tvs[0].tv_sec = parsed_atime;
   tvs[1].tv_sec = parsed_mtime;
 
-  if (pr_fsio_utimes(path, tvs) < 0) {
+  if (pr_fsio_utimes_with_root(path, tvs) < 0) {
     int xerrno = errno;
 
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));

--- a/include/fsio.h
+++ b/include/fsio.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2016 The ProFTPD Project
+ * Copyright (c) 2001-2017 The ProFTPD Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -279,6 +279,7 @@ int pr_fsio_chroot(const char *);
 int pr_fsio_access(const char *, int, uid_t, gid_t, array_header *);
 int pr_fsio_faccess(pr_fh_t *, int, uid_t, gid_t, array_header *);
 int pr_fsio_utimes(const char *, struct timeval *);
+int pr_fsio_utimes_with_root(const char *, struct timeval *);
 int pr_fsio_futimes(pr_fh_t *, struct timeval *);
 int pr_fsio_fsync(pr_fh_t *fh);
 off_t pr_fsio_lseek(pr_fh_t *, off_t, int);


### PR DESCRIPTION
…fy the

timestamps on files.

This involved refactoring the solution, done for the MFMT command which had
the same issue, into an FSIO API function that both mod_facts and mod_site_misc
can use.