### PR TITLE
If no certificates are available, then mod_tls should respond to an AUTH

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -10618,6 +10618,21 @@ MODRET tls_auth(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
+  /* CAN we even handle an AUTH command?  If we do not have the necessary
+   * certificates, then we should indicate that we cannot.
+   */
+  if (tls_rsa_cert_file == NULL &&
+      tls_dsa_cert_file == NULL &&
+      tls_ec_cert_file == NULL &&
+      tls_pkcs12_file == NULL) {
+    tls_log("Unable to accept AUTH %s due to lack of certificates", cmd->arg);
+    pr_response_add_err(R_431, _("Necessary security resource unavailable"));
+
+    pr_cmd_set_errno(cmd, EPERM);
+    errno = EPERM;
+    return PR_ERROR(cmd);
+  }
+
   /* Convert the parameter to upper case */
   mode = cmd->argv[1];
   for (i = 0; i < strlen(mode); i++) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
@@ -339,6 +339,11 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  tls_config_missing_certs => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
   tls_stapling_on_bug4175 => {
     order => ++$order,
     test_class => [qw(bug forking)],
@@ -10262,6 +10267,100 @@ sub tls_config_limit_sscn_bug3955 {
   }
 
   unlink($log_file);
+}
+
+sub tls_config_missing_certs {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'tls');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'tls:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_tls.c' => {
+        TLSEngine => 'on',
+        TLSLog => $setup->{log_file},
+        TLSProtocol => 'SSLv3 TLSv1',
+        TLSRequired => 'on',
+        TLSOptions => 'EnableDiags',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::FTPSSL;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Give the server a chance to start up
+      sleep(2);
+
+      my $client = Net::FTPSSL->new('127.0.0.1',
+        Encryption => 'E',
+        Port => $port,
+      );
+
+      if ($client) {
+        die("Connected via AUTH TLS unexpectedly");
+      }
+
+      my $errstr = IO::Socket::SSL::errstr();
+      unless ($errstr) {
+        $errstr = $Net::FTPSSL::ERRSTR;
+      }
+
+      $self->assert(qr/^431/, $errstr, "Expected 431, got '$errstr'");
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub starttls_ftp {


### PR DESCRIPTION
command with the 431 response code, indicating that the necessary security
resources are not available.  This makes for a better user experience than
seeing a peculiar TLS "alert" at TLS handshake time.