### PR TITLE
For symmetry, and for use by e.g. mod_proxy, provide a pr_netaddr_v4t…

### DIFF
--- a/include/netaddr.h
+++ b/include/netaddr.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2003-2016 The ProFTPD Project team
+ * Copyright (c) 2003-2017 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -395,10 +395,15 @@ int pr_netaddr_is_v6(const char *);
 int pr_netaddr_is_v4mappedv6(const pr_netaddr_t *);
 
 /* Given an IPv4-mapped IPv6 netaddr, returns an IPv4 netaddr allocated from
- * the given pool.  Returns -1 if the given netaddr is not an IPv4-mapped
+ * the given pool.  Returns NULL if the given netaddr is not an IPv4-mapped
  * IPv6 address.
  */
-pr_netaddr_t *pr_netaddr_v6tov4(pool *p, const pr_netaddr_t *);
+pr_netaddr_t *pr_netaddr_v6tov4(pool *p, const pr_netaddr_t *addr);
+
+/* Given an IPv4 netaddr, return an IPv4-mapped IPv6 netaddr allocated from
+ * the given pool.  Returns NULL if the given netaddr is not an IPv4 address.
+ */
+pr_netaddr_t *pr_netaddr_v4tov6(pool *p, const pr_netaddr_t *addr);
 
 /* Returns TRUE if IPv6 support is enabled, FALSE otherwise. */
 unsigned char pr_netaddr_use_ipv6(void);

--- a/src/netaddr.c
+++ b/src/netaddr.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2003-2016 The ProFTPD Project team
+ * Copyright (c) 2003-2017 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2303,6 +2303,35 @@ pr_netaddr_t *pr_netaddr_v6tov4(pool *p, const pr_netaddr_t *na) {
   pr_netaddr_set_family(res, AF_INET);
   pr_netaddr_set_port(res, pr_netaddr_get_port(na));
   memcpy(&res->na_addr.v4.sin_addr, get_v4inaddr(na), sizeof(struct in_addr));
+
+  return res;
+}
+
+pr_netaddr_t *pr_netaddr_v4tov6(pool *p, const pr_netaddr_t *na) {
+  pr_netaddr_t *res;
+
+  if (p == NULL ||
+      na == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  if (pr_netaddr_get_family(na) != AF_INET) {
+    errno = EPERM;
+    return NULL;
+  }
+
+#ifdef PR_USE_IPV6
+  res = (pr_netaddr_t *) pr_netaddr_get_addr(p,
+    pstrcat(p, "::ffff:", pr_netaddr_get_ipstr(na), NULL), NULL);
+  if (res != NULL) {
+    pr_netaddr_set_port(res, pr_netaddr_get_port(na));
+  }
+
+#else
+  errno = EPERM;
+  res = NULL;
+#endif /* PR_USE_IPV6 */
 
   return res;
 }


### PR DESCRIPTION
…ov6()

function for converting an IPv4 netaddr to an IPv6 netaddr.