### PR TITLE
Fix mod_tls build with LibreSSL

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -828,7 +828,7 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
         break;
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
       case TLS_ST_OK:
 #else
       case SSL_ST_OK:
@@ -852,7 +852,7 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
 
     ssl_state = SSL_get_state(ssl);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
     if (ssl_state == TLS_ST_SR_CLNT_HELLO) {
 #else
     if (ssl_state == SSL3_ST_SR_CLNT_HELLO_A ||


### PR DESCRIPTION
Check LIBRESSL_VERSION_NUMBER in addition to OPENSSL_VERSION_NUMBER

See also: HardenedBSD/hardenedbsd-ports@66197b544a8fea45f1a3ccc9de4131ada009dcbe
PR: 217025