### PR TITLE
Bug#4289: Fix the LDAPSearchScope directive handling, so that it prop…

### DIFF
--- a/contrib/mod_ldap.c
+++ b/contrib/mod_ldap.c
@@ -1831,7 +1831,7 @@ MODRET set_ldapsearchscope(cmd_rec *cmd) {
 
       elt = ((char **) ldap_servers->elts)[i];
       if (ldap_is_ldap_url(elt)) {
-        CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "LDAPSearchScope cannot be used when LDAPServer specifies a URL (see '", elt, "'); specify a search scope in the LDAPServer URL instead", NULL));
+        CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "cannot be used when LDAPServer specifies a URL (see '", elt, "'); specify a search scope in the LDAPServer URL instead", NULL));
       }
     }
   }

--- a/doc/contrib/mod_ldap.html
+++ b/doc/contrib/mod_ldap.html
@@ -552,8 +552,8 @@ value is determined by your LDAP API.
 <p>
 <hr>
 <h3><a name="LDAPSearchScope">LDAPSearchScope</a></h3>
-<strong>Syntax:</strong> LDAPSearchScope <em>onelevel|subtree</em><br>
-<strong>Default:</strong> subtree<br>
+<strong>Syntax:</strong> LDAPSearchScope <em>base|onelevel|subtree</em><br>
+<strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_ldap<br>
 <strong>Compatibility:</strong> 1.2.7rc1 and later
@@ -565,9 +565,45 @@ in the tree from the current level down.  Setting this directive to
 <em>onelevel</em> searches only one level deep in the LDAP tree.
 
 <p>
+<b>Note</b> that the <code>LDAPSearchScope</code> directive <b>cannot</b> be
+used when the LDAP URL syntax, rather than hostname/port, is used for your
+<a href="#LDAPServer"><code>LDAPServer</code></a> configuration.  Why not?
+The search scope can be specified as part of the URL itself.  This, combined
+with the fact that the <code>LDAPServer</code> directive can take
+<i>multiple</i> hosts/URLs, makes it clear to include the search scope in the
+URLs as needed.
+
+<p>
+If you are <b>not</b> using the LDAP URL syntax, then the following will
+use the <em>subtree</em> search scope:
+<pre>
+  LDAPServer ldap.example.com
+</pre>
+or, to make it explicit in your configuration:
+<pre>
+  LDAPServer ldap.example.com
+  LDAPSearchScope subtree
+</pre>
+On the other hand, if you <b>are</b> using LDAP URLs, then you specify the
+search scope as part of the URL:
+<pre>
+  LDAPServer ldap://ldap.example.com/??sub
+</pre>
+It is <b>important</b> that the "/" after the hostname/port be part of your
+LDAP URL when specifying the search scope.  That is, using:
+<pre>
+  LDAPServer ldap://ldap.example.com??sub
+</pre>
+<b>will not work as expected</b>; see
+<a href="https://tools.ietf.org/html/rfc2255">RFC 2255</a>, Section 3.  LDAP
+URL parameters are <b>not</b> like HTTP URL query parameters; LDAP URL
+parameters <b>are</b> order-specific.  And the "/" before any of the
+optional parameters <b>is required</b>.
+
+<p>
 <hr>
 <h3><a name="LDAPServer">LDAPServer</a></h3>
-<strong>Syntax:</strong> LDAPServer <em>&quot;host1:port1 host2:port2&quot;</em><br>
+<strong>Syntax:</strong> LDAPServer <em>&quot;url1|host1:port1 url2|host2:port2&quot;</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_ldap<br>
@@ -577,7 +613,8 @@ in the tree from the current level down.  Setting this directive to
 The <code>LDAPServer</code> directive allows you to to specify the hostname(s)
 and port(s) of the LDAP server(s) to use for LDAP authentication. If no
 <code>LDAPServer</code> configuration directive is present, the default LDAP
-servers specified by your LDAP library will be used.
+servers specified by your LDAP library will be used.  Note that the LDAP
+URL syntax may also be used.
 
 <p>
 To specify multiple LDAP servers, enclose the entire list of servers in
@@ -686,7 +723,7 @@ you (or not), please let us know:
     LDAPAuthBinds on
     LDAPBindDN "cn=SRV_ACC_SVN_AUTH,ou=special accounts,ou=Sales,dc=example,dc=org" ******************
 
-    LDAPUsers ou=Users,ou=Sales,dc=example,dc=org "(&(sAMAccountName=%u)(objectclass=user)(memberOf=cn=Linux Admins,ou=Groups,ou=Sales,dc=example,DC=org))"
+    LDAPUsers ou=Users,ou=Sales,dc=example,dc=org "(&(sAMAccountName=%u)(objectclass=user)(memberOf=cn=Linux Admins,ou=Groups,ou=Sales,dc=example,dc=com))"
     LDAPSearchScope subtree
 
     # Assign default IDs
@@ -722,7 +759,33 @@ only, and should be removed from any production configuration.
 <p><a name="FAQ">
 <b>Frequently Asked Questions</b><br>
 
-<p><a name="LDAPHomedir">
+<p><a name="ScopesFAQ">
+<font color=red>Question</font>: Why is <code>mod_ldap</code> using a "base"
+scope by default, rather than "subtree"?  I configured:
+<pre>
+  LDAPSearchScope subtree
+</pre>
+but it is not working; I see the following in my LDAP server logs:
+<pre>
+  slapd[31709]: conn=20239 op=1 SRCH <b>base</b>="ou=people,dc=example,dc=com" scope=0 deref=0 filter="(&(uid=tj)(objectClass=posixAccount))"
+</pre>
+<font color=blue>Answer</font>: The use of the "base" scope for searches, in
+spite of any <code>LDAPSearchScope</code> directive, happens when a URL, rather
+than hostname/port, are used in the <code>LDAPServer</code> directive. <a href="https://tools.ietf.org/html/rfc2255">RFC 2255</a>, Section 3 specifies that the default scope is "base".
+
+<p>
+Thus instead of:
+<pre>
+  LDAPServer ldap://ldap.example.com
+</pre>
+you will need to use:
+<pre>
+  LDAPServer ldap://ldap.example.com/??sub
+</pre>
+See the <a href="#LDAPSearchScope"><code>LDAPSearchScope</code></a>
+documentation for more details.
+
+<p><a name="HomedirsFAQ">
 <font color=red>Question</font>: How do I use <code>LDAPGenerateHomedir</code>
 and <code>CreateHome</code> together successfully?  Can I use <i>just</i>
 <code>LDAPGenerateHomedir</code>?<br>
@@ -754,10 +817,15 @@ might use something like this:
   &lt;/IfModule&gt;
 </pre>
 
-<p><a name="LDAPMultipleBinds">
+<p><a name="MultipleBindsFAQ">
 <font color=red>Question</font>: In my LDAP server logs, I see ProFTPD make
-<i>multiple</i> binds for the same client logging in; I was expecting just
-<i>one</i> bind.  Is this a bug, or is it expected behavior?<br>
+<i>multiple</i> binds for the same client logging in:
+<pre>
+  slapd[31709]: conn=20239 op=0 BIND dn="cn=admin,dc=example,dc=com" method=128
+  slapd[31709]: conn=20239 op=0 BIND dn="cn=admin,dc=example,dc=com" mech=SIMPLE ssf=0
+</pre>
+I was expecting just <i>one</i> bind.  Is this a bug, or is it expected
+behavior?<br>
 <font color=blue>Answer</font>: Yes, this <em>is</em> the expected behavior.
 See the <a href="#LDAPAuthBinds"><code>LDAPAuthBinds</code></a> directive
 for details.

--- a/doc/contrib/mod_ldap.html
+++ b/doc/contrib/mod_ldap.html
@@ -622,9 +622,17 @@ quotation marks.  For example:
 <pre>
   LDAPServer &quot;host1:port1 host2:port2&quot;
 </pre>
+or:
+<pre>
+  LDAPServer &quot;url1 url2&quot;
+</pre>
+Th default search scope for LDAP URLs is "base" (unless a scope is explicitly
+provided in the URL). This behavior differs from the
+<a href="#LDAPSearchScope"><code>LDAPSearchScope</code></a> directive, which
+defaults to "subtree".
 
 <p>
-<b>Note</b> that to use LDAPS (LDAP over SSL), use the <em>url</em> format,
+<b>Note</b> that to use LDAPS (LDAP over SSL), use the <em>URL</em> format,
 <i>e.g.</i>:
 <pre>
   LDAPServer ldaps://host1:port1 ldaps://host2:port2


### PR DESCRIPTION
…erly

uses the array_header now used for LDAPServer.  Added/improved the related
LDAPSearchScope documentation, and added a related FAQ.