### PR TITLE
Clarify that the ftpquota tool handles limit values of zero as "unlim…

### DIFF
--- a/contrib/ftpquota
+++ b/contrib/ftpquota
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # -------------------------------------------------------------------------
-# Copyright (C) 2000-2013 TJ Saunders <tj@castaglia.org>
+# Copyright (C) 2000-2017 TJ Saunders <tj@castaglia.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
-#
-#  $Id: ftpquota,v 1.6 2013-04-23 23:25:20 castaglia Exp $
 # -------------------------------------------------------------------------
 
 use strict;
@@ -1032,25 +1030,35 @@ usage: $program [options]
  The following options are used to specify specific quota limits:
 
   --Bu                 Specifies the limit of the number of bytes that may be
-  --bytes-upload       uploaded.  Defaults to -1 (unlimited).
+  --bytes-upload       uploaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero is treated as
+                       "unlimited".
 
   --Bd                 Specifies the limit of the number of bytes that may be
-  --bytes-download     downloaded.  Defaults to -1 (unlimited).
+  --bytes-download     downloaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero is treated as
+                       "unlimited".
 
   --Bx                 Specifies the limit of the number of bytes that may be
   --bytes-xfer         transferred.  Note that this total includes uploads,
                        downloads, AND directory listings.  Defaults to
-                       -1 (unlimited).
+                       -1 (unlimited).  Note that any value value less than or
+                       equal to zero is treated as "unlimited".
 
   --Fu                 Specifies the limit of the number of files that may be
-  --files-upload       uploaded.  Defaults to -1 (unlimited).
+  --files-upload       uploaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero is treated as
+                       "unlimited".
 
   --Fd                 Specifies the limit of the number of files that may be
-  --files-download     downloaded.  Defaults to -1 (unlimited).
+  --files-download     downloaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero is treated as
+                       "unlimited".
 
   --Fx                 Specifies the limit of the number of files that may be
   --files-xfer         transferred, including uploads and downloads.  Defaults
-                       to -1 (unlimited).
+                       to -1 (unlimited).  Note that any value less than or
+                       equal to zero is treated as "unlimited".
 
   -L                   Specifies the type of limit, "hard" or "soft", of
   --limit-type         the bytes limits.  If "hard", any uploaded files that

--- a/doc/howto/Quotas.html
+++ b/doc/howto/Quotas.html
@@ -289,7 +289,8 @@ are checked is dependent up on the order in which the groups are returned
 from the auth module providing them, <i>e.g.</i> <code>mod_sql</code>,
 <code>mod_ldap</code>, or perhaps <code>mod_auth_unix</code>.
 
-<p><a name="QuotasOverwrites" title="#QuotasOverwrites"></a><font color=red>Question</font>: Does <code>mod_quotatab</code> handle the case where a client might append to/overwrite an existing file, in terms of tracking bytes?<br>
+<p><a name="QuotasOverwrites" title="#QuotasOverwrites"></a>
+<font color=red>Question</font>: Does <code>mod_quotatab</code> handle the case where a client might append to/overwrite an existing file, in terms of tracking bytes?<br>
 <font color=blue>Answer</font>: Yes.  The <code>mod_quotatab</code> module
 checks the size of the file before the upload/append starts, and then checks
 the size of the file again after the upload/append completes.  The difference
@@ -310,6 +311,34 @@ in this case, on the transferred bytes, the <code>mod_quotatab</code> module
 ends up not changing any tally value for a delete.  More details on this
 can be found in
 <a href="http://bugs.proftpd.org/show_bug.cgi?id=2897">Bug#2897</a>.
+
+<p><a name="QuotasZeroLimits" title="#QuotasZeroLimits"></a>
+<font color=red>Question</font>: Why does the <code>ftpquota</code> tool
+treat limit values of zero as "unlimited"?
+<pre>
+  $ ftpquota --create-table --type=limit
+  $ ftpquota --add-record --type=limit --name=tj --quota-type=user <b>--files-download=0</b>
+  $ ftpquota --show-records --type=limit
+  -------------------------------------------
+    Name: tj
+    Quota Type: User
+    Per Session: False
+    Limit Type: Hard
+      Uploaded bytes: unlimited
+      Downloaded bytes: unlimited
+      Transferred bytes:  unlimited
+      Uploaded files: unlimited
+      <b>Downloaded files: unlimited</b>
+      Transferred files:  unlimited
+</pre>
+I want to use this to prevent a user from uploading/download files.<br>
+<p>
+<font color=blue>Answer</font>:  If you wish to prevent users from uploading
+or downloading, then you should use
+<a href="Limits.html"><code>&lt;Limit&gt;</code></a> sections in your
+ProFTPD configuration; that is what they are designed to do.  The
+<code>ftpquota</code> tool was <em>explicitly designed</em> to not allow
+being used to prevent uploads/downloads; it is for managing <em>quotas</em>.
 
 <p>
 <hr>

--- a/doc/utils/ftpquota.html
+++ b/doc/utils/ftpquota.html
@@ -206,25 +206,35 @@ usage: ftpquota [options]
  The following options are used to specify specific quota limits:
 
   --Bu                 Specifies the limit of the number of bytes that may be
-  --bytes-upload       uploaded.  Defaults to -1 (unlimited).
+  --bytes-upload       uploaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero will be treated as
+                       "unlimited".
 
   --Bd                 Specifies the limit of the number of bytes that may be
-  --bytes-download     downloaded.  Defaults to -1 (unlimited).
+  --bytes-download     downloaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero will be treated as
+                       "unlimited".
 
   --Bx                 Specifies the limit of the number of bytes that may be
   --bytes-xfer         transferred.  Note that this total includes uploads,
                        downloads, AND directory listings.  Defaults to
-                       -1 (unlimited).
+                       -1 (unlimited).  Note that any value less than or equal
+                       to zero will be treated as "unlimited".
 
   --Fu                 Specifies the limit of the number of files that may be
-  --files-upload       uploaded.  Defaults to -1 (unlimited).
+  --files-upload       uploaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero will be treated as
+                       "unlimited".
 
   --Fd                 Specifies the limit of the number of files that may be
-  --files-download     downloaded.  Defaults to -1 (unlimited).
+  --files-download     downloaded.  Defaults to -1 (unlimited).  Note that any
+                       value less than or equal to zero will be treated as
+                       "unlimited".
 
   --Fx                 Specifies the limit of the number of files that may be
   --files-xfer         transferred, including uploads and downloads.  Defaults
-                       to -1 (unlimited).
+                       to -1 (unlimited).  Note that any value less than or
+                       equal to zero will be treated as "unlimited".
 
   -L                   Specifies the type of limit, "hard" or "soft", of
   --limit-type         the bytes limits.  If "hard", any uploaded files that
@@ -266,7 +276,7 @@ usage: ftpquota [options]
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2000-2011 TJ Saunders<br>
+&copy; Copyright 2000-2017 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>


### PR DESCRIPTION
…ited".

Add FAQ explaining why.

Addresses:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700632