### PR TITLE
Implement a pr_fs_split_path() function, for separating a path into its

### DIFF
--- a/include/fsio.h
+++ b/include/fsio.h
@@ -392,6 +392,10 @@ char *pr_fs_decode_path2(pool *, const char *, int);
 
 char *pr_fs_encode_path(pool *, const char *);
 int pr_fs_use_encoding(int);
+
+/* Split the given path into its individual path components. */
+array_header *pr_fs_split_path(pool *p, const char *path);
+
 int pr_fs_valid_path(const char *);
 void pr_fs_virtual_path(const char *, char *, size_t);
 

--- a/src/str.c
+++ b/src/str.c
@@ -851,17 +851,19 @@ array_header *pr_str_text_to_array(pool *p, const char *text, char delimiter) {
 
   ptr = memchr(text, delimiter, text_len);
   while (ptr != NULL) {
-    char *item;
     size_t item_len;
 
     pr_signals_handle();
 
     item_len = ptr - text;
+    if (item_len > 0) {
+      char *item;
 
-    item = palloc(p, item_len + 1);
-    memcpy(item, text, item_len);
-    item[item_len] = '\0';
-    *((char **) push_array(items)) = item;
+      item = palloc(p, item_len + 1);
+      memcpy(item, text, item_len);
+      item[item_len] = '\0';
+      *((char **) push_array(items)) = item;
+    }
 
     text = ++ptr;
 
@@ -875,7 +877,9 @@ array_header *pr_str_text_to_array(pool *p, const char *text, char delimiter) {
     ptr = memchr(text, delimiter, text_len);
   }
 
-  *((char **) push_array(items)) = pstrdup(p, text);
+  if (text_len > 0) {
+    *((char **) push_array(items)) = pstrdup(p, text);
+  }
 
   return items;
 }

--- a/tests/api/str.c
+++ b/tests/api/str.c
@@ -1640,6 +1640,22 @@ START_TEST (text_to_array_test) {
     strerror(errno));
   fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
 
+  text = ",";
+
+  mark_point();
+  res = pr_str_text_to_array(p, text, ',');
+  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+    strerror(errno));
+  fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
+
+  text = ",,,";
+
+  mark_point();
+  res = pr_str_text_to_array(p, text, ',');
+  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+    strerror(errno));
+  fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
+
   text = "foo";
 
   mark_point();
@@ -1672,7 +1688,7 @@ START_TEST (text_to_array_test) {
   res = pr_str_text_to_array(p, text, ',');
   fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 4, "Expected 3 items, got %u", res->nelts);
+  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 


### PR DESCRIPTION
components.  Useful for walking the path.  Fixed some issues with the underlying
pr_str_text_to_array() function while there.