### PR TITLE
Bug#4296: Use the stored netaddr for the remote client for the %{remo…

### DIFF
--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -2696,9 +2696,11 @@ static const char *resolve_long_tag(cmd_rec *cmd, char *tag) {
       tag_len == 11 &&
       strncmp(tag, "remote-port", 12) == 0) {
     char buf[64];
+    const pr_netaddr_t *addr;
 
+    addr = pr_netaddr_get_sess_remote_addr();
     memset(buf, '\0', sizeof(buf));
-    snprintf(buf, sizeof(buf)-1, "%d", session.c->remote_port);
+    snprintf(buf, sizeof(buf)-1, "%d", ntohs(pr_netaddr_get_port(addr)));
     long_tag = pstrdup(cmd->tmp_pool, buf);
   }
 

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -1301,11 +1301,16 @@ static char *get_next_meta(pool *p, cmd_rec *cmd, unsigned char **f,
       m++;
       break;
 
-    case LOGFMT_META_REMOTE_PORT:
+    case LOGFMT_META_REMOTE_PORT: {
+      const pr_netaddr_t *addr;
+
       argp = arg;
-      len = snprintf(argp, sizeof(arg), "%d", session.c->remote_port);
+
+      addr = pr_netaddr_get_sess_remote_addr();
+      len = snprintf(argp, sizeof(arg), "%d", ntohs(pr_netaddr_get_port(addr)));
       m++;
       break;
+    }
 
     case LOGFMT_META_RENAME_FROM: {
       const char *rnfr_path = "-";

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -172,6 +172,11 @@ my $TESTS = {
     test_class => [qw(forking)],
   },
 
+  sql_sqllog_exit_var_remote_port_bug4296 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
   sql_sqllog_var_d_bug3395 => {
     order => ++$order,
     test_class => [qw(bug forking)],
@@ -5467,6 +5472,176 @@ EOS
   chomp($res);
 
   my ($login, $ip_addr) = split(/\|/, $res);
+
+  my $expected;
+
+  $expected = $user;
+  $self->assert($expected eq $login,
+    test_msg("Expected '$expected', got '$login'"));
+
+  $expected = '127.0.0.1';
+  $self->assert($expected eq $ip_addr,
+    test_msg("Expected '$expected', got '$ip_addr'"));
+
+  unlink($log_file);
+}
+
+sub sql_sqllog_exit_var_remote_port_bug4296 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  my $config_file = "$tmpdir/sqlite.conf";
+  my $pid_file = File::Spec->rel2abs("$tmpdir/sqlite.pid");
+  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/sqlite.scoreboard");
+
+  my $log_file = test_get_logfile();
+
+  my $auth_user_file = File::Spec->rel2abs("$tmpdir/sqlite.passwd");
+  my $auth_group_file = File::Spec->rel2abs("$tmpdir/sqlite.group");
+
+  my $user = 'proftpd';
+  my $passwd = 'test';
+  my $group = 'ftpd';
+  my $home_dir = File::Spec->rel2abs($tmpdir);
+  my $uid = 500;
+  my $gid = 500;
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $home_dir)) {
+      die("Can't set perms on $home_dir to 0755: $!");
+    }
+
+    unless (chown($uid, $gid, $home_dir)) {
+      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    }
+  }
+
+  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
+    '/bin/bash');
+  auth_group_write($auth_group_file, $group, $gid, $user);
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create users, groups tables and populate them
+  my $db_script = File::Spec->rel2abs("$tmpdir/proftpd.sql");
+
+  if (open(my $fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE ftpsessions (
+  user TEXT,
+  ip_addr TEXT,
+  port NUMBER
+);
+EOS
+
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script);
+
+  # Make sure that, if we're running as root, the database file has
+  # the permissions/privs set for use by proftpd
+  if ($< == 0) {
+    unless (chmod(0666, $db_file)) {
+      die("Can't set perms on $db_file to 0666: $!");
+    }
+  }
+
+  my $config = {
+    PidFile => $pid_file,
+    ScoreboardFile => $scoreboard_file,
+    SystemLog => $log_file,
+
+    AuthUserFile => $auth_user_file,
+    AuthGroupFile => $auth_group_file,
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sql.c' => {
+        SQLEngine => 'log',
+        SQLBackend => 'sqlite3',
+        SQLConnectInfo => $db_file,
+        SQLLogFile => $log_file,
+        SQLNamedQuery => 'logout FREEFORM "INSERT INTO ftpsessions (user, ip_addr, port) VALUES (\'%u\', \'%L\', %{remote-port})"',
+        SQLLog => 'EXIT logout',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($user, $passwd);
+      $client->quit();
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($config_file, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($pid_file);
+
+  $self->assert_child_ok($pid);
+
+  if ($ex) {
+    test_append_logfile($log_file, $ex);
+    unlink($log_file);
+
+    die($ex);
+  }
+
+  my $query = "SELECT * FROM ftpsessions where user = '$user'";
+  $cmd = "sqlite3 $db_file \"$query\"";
+
+  if ($ENV{TEST_VERBOSE}) {
+    print STDERR "Executing sqlite3: $cmd\n";
+  }
+
+  my $output = `$cmd`;
+  my $res = join('', `$cmd`);
+  chomp($res);
+
+  my ($login, $ip_addr, $remote_port) = split(/\|/, $res);
 
   my $expected;
 


### PR DESCRIPTION
…te-port}

LogFormat variable.  Using session.c can lead to a null pointer deference on
e.g. session exit.