### PR TITLE
Bug#4299: TimeoutLogin no longer working for SFTP connections.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,7 +69,7 @@
   now supports a SortedNLST flag for such use cases.
 - Bug 4260 - Restarting server fails when using password-protected SSL
   certificates and no TLSPassPhraseProvider.
-- Bug 4126 - SSH rekeying causes invalid packet due to interrupting timer.
+- Bug 4216 - SSH rekeying causes invalid packet due to interrupting timer.
 - Bug 4278 - Memory leak when mod_facl is used.
 
 1.3.6rc2 - Released 10-Mar-2016

--- a/contrib/mod_sftp/mod_sftp.c
+++ b/contrib/mod_sftp/mod_sftp.c
@@ -1829,6 +1829,12 @@ static void sftp_shutdown_ev(const void *event_data, void *user_data) {
   }
 }
 
+static void sftp_timeoutlogin_ev(const void *event_data, void *user_data) {
+  if (sftp_sess_state & SFTP_SESS_STATE_HAVE_KEX) {
+    SFTP_DISCONNECT_CONN(SFTP_SSH2_DISCONNECT_BY_APPLICATION, NULL);
+  }
+}
+
 #ifdef PR_USE_DEVEL
 static void pool_printf(const char *fmt, ...) {
   char buf[PR_TUNABLE_BUFFER_SIZE];
@@ -1990,6 +1996,8 @@ static int sftp_init(void) {
   pr_event_register(&sftp_module, "core.postparse", sftp_postparse_ev, NULL);
   pr_event_register(&sftp_module, "core.restart", sftp_restart_ev, NULL);
   pr_event_register(&sftp_module, "core.shutdown", sftp_shutdown_ev, NULL);
+  pr_event_register(&sftp_module, "core.timeout-login", sftp_timeoutlogin_ev,
+    NULL);
 
   return 0;
 }

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -36048,9 +36048,9 @@ sub sftp_config_timeoutlogin {
 
       my ($err_code, $err_name, $err_str) = $ssh2->error();
 
-      my $expected = 'LIBSSH2_ERROR_TIMEOUT';
-      $self->assert($expected eq $err_name,
-        test_msg("Expected '$expected', got '$err_name'"));
+      my $expected = '(LIBSSH2_ERROR_SOCKET_DISCONNECT|LIBSSH2_ERROR_TIMEOUT)';
+      $self->assert(qr/$expected/, $err_name,
+        "Expected '$expected', got '$err_name'");
     };
 
     if ($@) {


### PR DESCRIPTION
The root cause was the blocking of alarms when reading/writing SFTP packets;
this was done to avoid corrupting packets during rekeying.  But it had the
unwanted side effect of blocking alarms like TimeoutLogin.  To balance the
TimeoutLogin need, we block alarms for packet IO only after the client has
authenticated.