### PR TITLE
tests: fix build failure on gcc-6.3 / glibc-2.25 (open)

### DIFF
--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -1056,7 +1056,7 @@ START_TEST (fsio_sys_access_file_test) {
   array_header *suppl_gids;
 
   /* Make the file to check; we want it to have perms 664.*/
-  fd = open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
+  fd = open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY, S_IRUSR|S_IWUSR);
   fail_if(fd < 0, "Unable to create file '%s': %s", fsio_test_path,
     strerror(errno));
 

--- a/tests/api/scoreboard.c
+++ b/tests/api/scoreboard.c
@@ -265,7 +265,7 @@ START_TEST (scoreboard_lock_test) {
   fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
-  fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR);
+  fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR, S_IRUSR|S_IWUSR);
   fail_unless(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
 
   res = pr_lock_scoreboard(fd, lock_type);
@@ -909,7 +909,7 @@ START_TEST (scoreboard_entry_lock_test) {
   fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
-  fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR);
+  fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR, S_IRUSR|S_IWUSR);
   fail_unless(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
 
   res = pr_scoreboard_entry_lock(fd, lock_type);


### PR DESCRIPTION
Recent gcc has a mechanism to detect some function misuses
at compile-time. In this case it's a case when open() is
likely to create new file but access permissions are not set
explicitly:

    $  LANG=C make -C tests api-tests
    gcc -g2 -O2 -Wall -fno-omit-frame-pointer -DHAVE_CONFIG_H  -DLINUX  -I.. -I../include   -c -o api/fsio.o api/fsio.c
    In file included from /usr/include/fcntl.h:313:0,
                     from /usr/include/sys/file.h:24,
                     from ../include/conf.h:93,
                     from api/tests.h:30,
                     from api/fsio.c:27:
    In function 'open',
        inlined from 'fsio_sys_access_file_test' at api/fsio.c:1059:6:
    /usr/include/bits/fcntl2.h:50:4: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
        __open_missing_mode ();
        ^~~~~~~~~~~~~~~~~~~~~~
    make: *** [<builtin>: api/fsio.o] Error 1

The change adds "u=rw" to all temp files.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>