### PR TITLE
Use absolute pathnames for executables in systemd unit files

### DIFF
--- a/contrib/dist/rpm/proftpd.service
+++ b/contrib/dist/rpm/proftpd.service
@@ -8,8 +8,8 @@ PIDFile = /run/proftpd/proftpd.pid
 Environment = PROFTPD_OPTIONS=
 EnvironmentFile = -/etc/sysconfig/proftpd
 ExecStart = /usr/sbin/proftpd $PROFTPD_OPTIONS
-ExecStartPost = touch /var/lock/subsys/proftpd
-ExecStopPost = rm -f /var/lock/subsys/proftpd
+ExecStartPost = /usr/bin/touch /var/lock/subsys/proftpd
+ExecStopPost = /bin/rm -f /var/lock/subsys/proftpd
 ExecReload = /bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Otherwise, systemd complains about them and ignores the commands.