### PR TITLE
Explain the function of the NoRootPrivs parameter to CreateHome

### DIFF
--- a/doc/howto/CreateHome.html
+++ b/doc/howto/CreateHome.html
@@ -109,6 +109,12 @@ of the target home directory itself.  By default, this home directory will
 be owned by the user's primary GID.
 
 <p>
+The <code>NoRootPrivs</code> parameter can be used to prevent proftpd from
+using root privileges when creating the home directory and parents. This can be
+useful for e.g. the case where home directories are on NFS with root squashing
+enabled.
+
+<p>
 Here are some examples (from the documentation) to help illustrate how one
 might use the <code>CreateHome</code> configuration directive:
 <pre>


### PR DESCRIPTION
The documentation mentions this parameter and shows an example of its usage but doesn't explain what it does, so here's a short explanation for the documentation, drawing from the explanation in [bug #3813](http://bugs.proftpd.org/show_bug.cgi?id=3813).