### PR TITLE
Switch to Type = simple and add configuration test

### DIFF
--- a/contrib/dist/rpm/proftpd.service
+++ b/contrib/dist/rpm/proftpd.service
@@ -3,14 +3,13 @@ Description = ProFTPD FTP Server
 After = network.target nss-lookup.target local-fs.target remote-fs.target
 
 [Service]
-Type = forking
-PIDFile = /run/proftpd/proftpd.pid
+Type = simple
 Environment = PROFTPD_OPTIONS=
 EnvironmentFile = -/etc/sysconfig/proftpd
-ExecStart = /usr/sbin/proftpd $PROFTPD_OPTIONS
-ExecStartPost = /usr/bin/touch /var/lock/subsys/proftpd
-ExecStopPost = /bin/rm -f /var/lock/subsys/proftpd
+ExecStartPre = /usr/sbin/proftpd --configtest
+ExecStart = /usr/sbin/proftpd --nodaemon $PROFTPD_OPTIONS
 ExecReload = /bin/kill -HUP $MAINPID
+PIDFile = /run/proftpd/proftpd.pid
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Upstream recommends Type = simple if possible rather than Type = forking:
http://0pointer.de/public/systemd-man/daemon.html#Integration%20with%20Systemd

Also add configuration test prior to starting the daemon, to help diagnose
start-up problems.