### PR TITLE
32 bit fixes

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -273,7 +273,13 @@ int pr_trace_parse_levels(char *str, int *min_level, int *max_level) {
   ptr = strchr(str, '-');
   if (ptr == NULL) {
     /* Just a single value. */
+    errno = 0;
     high = (int) strtol(str, &ptr, 10);
+    if (errno == ERANGE) {
+      errno = EINVAL;
+      return -1;
+    }
+
     if (ptr && *ptr) {
       errno = EINVAL;
       return -1;
@@ -302,6 +308,11 @@ int pr_trace_parse_levels(char *str, int *min_level, int *max_level) {
   *ptr = '\0';
 
   low = (int) strtol(str, &tmp, 10);
+  if (errno == ERANGE) {
+    errno = EINVAL;
+    return -1;
+  }
+
   if (tmp && *tmp) {
     *ptr = '-';
     errno = EINVAL;
@@ -316,6 +327,11 @@ int pr_trace_parse_levels(char *str, int *min_level, int *max_level) {
 
   tmp = NULL;
   high = (int) strtol(ptr + 1, &tmp, 10);
+  if (errno == ERANGE) {
+    errno = EINVAL;
+    return -1;
+  }
+
   if (tmp && *tmp) {
     errno = EINVAL;
     return -1;

--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -702,7 +702,7 @@ START_TEST (check_shutmsg_test) {
 
   (void) unlink(path);
   res = write_shutmsg(path,
-    "2340 1 1 0 0 0 0000 0000\nGoodbye, cruel world!\n");
+    "2037 1 1 0 0 0 0000 0000\nGoodbye, cruel world!\n");
   fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();


### PR DESCRIPTION
I thought it was all working but then I tried building for i686 and hit a couple of API test failures.

One of them is due to throwing a very large integer at strtol(3), which overflows the int type on 32-bit systems. The man page I looked at for strtol recommends setting errno to 0 prior to calling it and then checking for ERANGE in errno. Doing this resolves the test failure.

The second one looks to be a Y2038 issue. The test was checking to see if the year 2340 could be parsed in the `shutmsg` file, which works on 64-bit systems but not 32-bit. So I changed the year in the test to 2037 as a workaround for now. The last part of the same test appears to be checking what happens with a year of 0 in the `shutmsg` file, but doesn't actually test the return result, which is fortunate as again it "passes" on 64-bit systems and not on 32-systems, though I'm not sure why.