### PR TITLE
Issue #518: Provide a TLSStaplingOption for disabling the use of fake…

### DIFF
--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -1809,6 +1809,32 @@ behaviors of <code>mod_tls</code> when querying OCSP responders.
 <p>
 The currently implemented options are:
 <ul>
+  <li><code>NoFakeTryLater</code><br>
+    <p>
+    If the TLS client requests a stapled OCSP response, yet <code>mod_tls</code>
+    cannot provide one (<i>e.g.</i> due to inability to contact the OCSP
+    responder), the module will provide a fake <code>tryLater</code> OCSP
+    response.  Some client implementations, however, have trouble with such
+    fake OCSP responses; use this option to disable the use of such fake OCSP
+    response:
+    <pre>
+  # Skip using a fake tryLater OCSP response, if we cannot obtain one from
+  # an OCSP responder
+  TLSStaplingOptions NoFakeTryLater
+    </pre>
+    <b>However</b>, a fake <code>tryLater</code> OCSP response <b>might still
+    be emitted</b>, even if this option is used, if the server certificate
+    in question bears the "must staple" TLS feature; see
+    <a href="https://tools.ietf.org/html/rfc7633#section-3">RFC 7633</a>.  In
+    such cases, <code>mod_tls</code> is <em>required</em> to staple an OCSP
+    response.
+
+    <p>
+    <b>Note</b> that this option first appeared in
+    <code>proftpd-1.3.7rc1</code>.
+  </li>
+
+  <p>
   <li><code>NoNonce</code><br>
     <p>
     To defend against replay attacks of OCSP responses, the protocol allows


### PR DESCRIPTION
… tryLater

OCSP responses, unless otherwise required to do so via the "must staple"
X509v3 extension.