### PR TITLE
Bug#4314: When retrieving the appropriate <Anonymous> section for a c…

### DIFF
--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -982,6 +982,11 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
   origuser = user;
   c = pr_auth_get_anon_config(p, &user, &ourname, &anonname);
   if (c != NULL) {
+    pr_trace_msg("auth", 13,
+      "found <Anonymous> config: login user = %s, config user = %s, "
+      "anon name = %s", user != NULL ? user : "(null)",
+      ourname != NULL ? ourname : "(null)",
+      anonname != NULL ? anonname : "(null)");
     session.anon_config = c;
   }
 

--- a/src/auth.c
+++ b/src/auth.c
@@ -1784,6 +1784,14 @@ config_rec *pr_auth_get_anon_config(pool *p, const char **login_user,
     }
   }
 
+  if (anon_config != NULL) {
+    config_user_name = get_param_ptr(anon_config->subset, "UserName", FALSE);
+    if (config_user_name != NULL &&
+        real_user != NULL) {
+      *real_user = config_user_name;
+    }
+  }
+
   return anon_config;
 }
 


### PR DESCRIPTION
…lient,

the configured User/Group retrieved were from the parent section, not the
retrieved <Anonymous> section.  This appeared to cause regressions when
"AuthAliasOnly on" was used.  Let's hope that _this_ change does not itself
cause regressions.

The whole AuthAliasOnly is so buggy/fragile it should be removed entirely.