### PR TITLE
Issue #568: Make sure that if CreateHome NoRootPrivs is used, we DO use

### DIFF
--- a/doc/howto/CreateHome.html
+++ b/doc/howto/CreateHome.html
@@ -112,7 +112,9 @@ be owned by the user's primary GID.
 The <code>NoRootPrivs</code> parameter can be used to prevent ProFTPD from
 using root privileges when creating the home directory and parents. This can be
 useful for <i>e.g.</i> the case where home directories are on NFS mounts which
-have root squashing enabled.
+have root squashing enabled.  When the <code>NoRootPrivs</code> option is
+used, the home directory in question will be <i>created using the identity
+of the logging-in user</i>.
 
 <p>
 Here are some examples (from the documentation) to help illustrate how one

--- a/doc/modules/mod_auth.html
+++ b/doc/modules/mod_auth.html
@@ -340,7 +340,7 @@ See also: <a href="#AnonRequirePassword"><code>AnonRequirePassword</code></a>, <
 <p>
 <hr>
 <h3><a name="CreateHome">CreateHome</a></h3>
-<strong>Syntax:</strong> CreateHome <em>off|on [mode] [skel path] [dirmode mode]</em><br>
+<strong>Syntax:</strong> CreateHome <em>off|on [mode] [skel path] [dirmode mode]...</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_auth<br>

--- a/src/mkhome.c
+++ b/src/mkhome.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2003-2016 The ProFTPD Project team
+ * Copyright (c) 2003-2017 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -312,7 +312,15 @@ int create_home(pool *p, const char *home, const char *user, uid_t uid,
 
   dst_mode = *((mode_t *) c->argv[1]);
 
-  if (!(flags & PR_MKHOME_FL_USE_USER_PRIVS)) {
+  if (flags & PR_MKHOME_FL_USE_USER_PRIVS) {
+    /* Make sure we are the actual end user here (Issue#568).  Without this,
+     * we will not be using root privs, true, but we will not be creating
+     * the directory as the logging-in user; we will be creating the directory
+     * using the User/Group identity, which is not expected.
+     */
+    PRIVS_USER
+
+  } else {
     PRIVS_ROOT
   }
 


### PR DESCRIPTION
the identity of the logging-in user, not the enclosing context's User/Group
identity.