### PR TITLE
Fix false-positives in AIX function detection

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1439,6 +1439,8 @@ AC_TRY_LINK([
   #include <sys/types.h>
   #ifdef HAVE_USERSEC_H
   # include <usersec.h>
+  #else
+  # error "we are not on AIX"
   #endif
   ],
   [
@@ -1458,6 +1460,8 @@ AC_TRY_LINK([
   #include <sys/types.h>
   #ifdef HAVE_USERSEC_H
   # include <usersec.h>
+  #else
+  # error "we are not on AIX"
   #endif
   ],
   [
@@ -1476,6 +1480,8 @@ AC_TRY_LINK([
   #include <sys/types.h>
   #ifdef HAVE_USERSEC_H
   # include <usersec.h>
+  #else
+  # error "we are not on AIX"
   #endif
   ],
   [


### PR DESCRIPTION
Tested on Solaris 10/SPARC. Without this change the configure script
wrongly detects the authenticate() and friends AIX functions, yielding
scary compile errors later on (because those functions aren't available on Solaris 10).

The reason is that the configure test programs guards the usersec.h include
with an ifdef. On Solaris 10, the condition is false, thus the header
(that is not present on Solaris) isn't included such that the following
function call doesn't yield a compile error because the function is
implicitly declared.

For example, the GCC warns about this with:

    warning: implicit declaration of function 'authenticate' [-Wimplicit-function-declaration]
         (void) authenticate(NULL, NULL, NULL, NULL);

Thus, you can work-around this issue with current proftp via calling configure like this:

    $ ./configure ... CFLAGS='-Werror=implicit-function-declaration'
