### PR TITLE
Improve the performance when resolving a jotted buffer by invoking the

### DIFF
--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -1010,15 +1010,16 @@ static int sql_resolve_on_default(pool *p, pr_jot_ctx_t *jot_ctx,
 }
 
 static int sql_resolve_on_other(pool *p, pr_jot_ctx_t *jot_ctx,
-    unsigned char ch) {
+    unsigned char *text, size_t text_len) {
   struct sql_resolved *resolved;
 
   resolved = jot_ctx->log;
   if (resolved->buflen > 0) {
-    pr_trace_msg(trace_channel, 19, "appending text '%c' (1) to buffer", ch);
-    *(resolved->buf) = ch;
-    resolved->buf++;
-    resolved->buflen--;
+    pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
+      (int) text_len, text, (unsigned long) text_len);
+    memcpy(resolved->buf, text, text_len);
+    resolved->buf += text_len;
+    resolved->buflen -= text_len;
   }
 
   return 0;

--- a/include/jot.h
+++ b/include/jot.h
@@ -180,7 +180,7 @@ int pr_jot_resolve_logfmt(pool *p, cmd_rec *cmd, pr_jot_filters_t *filters,
   int (*on_meta)(pool *, pr_jot_ctx_t *, unsigned char, const char *,
     const void *),
   int (*on_default)(pool *, pr_jot_ctx_t *, unsigned char),
-  int (*on_other)(pool *, pr_jot_ctx_t *, unsigned char));
+  int (*on_other)(pool *, pr_jot_ctx_t *, unsigned char *, size_t));
 
 /* Canned `on_meta` callback to use when resolving LogFormat strings into
  * JSON objects.

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -609,15 +609,17 @@ static int resolve_on_default(pool *p, pr_jot_ctx_t *jot_ctx,
   return 0;
 }
 
-static int resolve_on_other(pool *p, pr_jot_ctx_t *jot_ctx, unsigned char ch) {
+static int resolve_on_other(pool *p, pr_jot_ctx_t *jot_ctx,
+    unsigned char *text, size_t text_len) {
   struct extlog_buffer *log;
 
   log = jot_ctx->log;
   if (log->buflen > 0) {
-    pr_trace_msg(trace_channel, 19, "appending text '%c' (1) to buffer", ch);
-    *(log->buf) = ch;
-    log->buf++;
-    log->buflen--;
+    pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
+      (int) text_len, text, (unsigned long) text_len);
+    memcpy(log->buf, text, text_len);
+    log->buf += text_len;
+    log->buflen -= text_len;
   }
 
   return 0;

--- a/tests/api/jot.c
+++ b/tests/api/jot.c
@@ -1060,7 +1060,7 @@ static int resolve_on_default(pool *jot_pool, pr_jot_ctx_t *jot_ctx,
 }
 
 static int resolve_on_other(pool *jot_pool, pr_jot_ctx_t *jot_ctx,
-    unsigned char ch) {
+    unsigned char *text, size_t text_len) {
   resolve_on_other_count++;
   return 0;
 }
@@ -1272,8 +1272,8 @@ START_TEST (jot_resolve_logfmt_on_other_test) {
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
   fail_unless(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 2,
-    "Expected on_other count 2, got %u", resolve_on_other_count);
+  fail_unless(resolve_on_other_count == 1,
+    "Expected on_other count 1, got %u", resolve_on_other_count);
 }
 END_TEST
 


### PR DESCRIPTION
`on_other` callback with larger segments of non-variable text, rather than
doing this character by character.