### PR TITLE
Issue #573: The RedisLogOnCommand and RedisLogOnEvent directives can now

### DIFF
--- a/doc/modules/mod_redis.html
+++ b/doc/modules/mod_redis.html
@@ -67,7 +67,7 @@ unless <code>AllowLogSymlinks</code> is explicitly set to <em>on</em>
 <h3><a name="RedisLogOnCommand">RedisLogOnCommand</a></h3>
 <strong>Syntax:</strong> RedisLogOnCommand <em>commands format-name</em><br>
 <strong>Default:</strong> None<br>
-<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code>, <code>&lt;Anonymous&gt;</code>, <code>&lt;Directory&gt;</code><br>
 <strong>Module:</strong> mod_redis<br>
 <strong>Compatibility:</strong> 1.3.6rc5 and later
 
@@ -91,7 +91,16 @@ More on the use of Redis logging, including a table showing how
 Example:
 <pre>
   LogFormat file-transfers "%h %l %u %t \"%r\" %s %b"
-  RedisLogOnCommand APPE,RETR,STOR,STOU file-transfers
+
+  # Only log to Redis for uploads in this directory
+  <Directory /path/to/inbox>
+    RedisLogOnCommand APPE,STOR,STOU file-transfers
+  </Directory>
+
+  # Only log to Redis for downloads from this directory
+  <Directory /path/to/pub>
+    RedisLogOnCommand RETR file-transfers
+  </Directory>
 </pre>
 
 <p>
@@ -104,7 +113,7 @@ supports.
 <h3><a name="RedisLogOnEvent">RedisLogOnEvent</a></h3>
 <strong>Syntax:</strong> RedisLogOnEvent <em>events format-name</em><br>
 <strong>Default:</strong> None<br>
-<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code>, <code>&lt;Anonymous&gt;</code>, <code>&lt;Directory&gt;</code><br>
 <strong>Module:</strong> mod_redis<br>
 <strong>Compatibility:</strong> 1.3.7rc1 and later
 

--- a/modules/mod_redis.c
+++ b/modules/mod_redis.c
@@ -118,7 +118,7 @@ static void log_events(cmd_rec *cmd) {
     return;
   }
 
-  c = find_config(main_server->conf, CONF_PARAM, "RedisLogOnCommand", FALSE);
+  c = find_config(CURRENT_CONF, CONF_PARAM, "RedisLogOnCommand", FALSE);
   while (c != NULL) {
     pr_signals_handle();
 
@@ -126,7 +126,7 @@ static void log_events(cmd_rec *cmd) {
     c = find_config_next(c, c->next, CONF_PARAM, "RedisLogOnCommand", FALSE);
   }
 
-  c = find_config(main_server->conf, CONF_PARAM, "RedisLogOnEvent", FALSE);
+  c = find_config(CURRENT_CONF, CONF_PARAM, "RedisLogOnEvent", FALSE);
   while (c != NULL) {
     pr_signals_handle();
 
@@ -180,7 +180,7 @@ MODRET set_redislogoncommand(cmd_rec *cmd) {
   pr_jot_filters_t *jot_filters;
 
   CHECK_ARGS(cmd, 2);
-  CHECK_CONF(cmd, CONF_ROOT|CONF_GLOBAL|CONF_VIRTUAL);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_GLOBAL|CONF_VIRTUAL|CONF_ANON|CONF_DIR);
 
   c = add_config_param(cmd->argv[0], 3, NULL, NULL, NULL);
 
@@ -218,6 +218,7 @@ MODRET set_redislogoncommand(cmd_rec *cmd) {
   c->argv[1] = pstrdup(c->pool, fmt_name);
   c->argv[2] = log_fmt;
 
+  c->flags |= CF_MERGEDOWN_MULTI;
   return PR_HANDLED(cmd);
 }
 
@@ -229,7 +230,7 @@ MODRET set_redislogonevent(cmd_rec *cmd) {
   pr_jot_filters_t *jot_filters;
 
   CHECK_ARGS(cmd, 2);
-  CHECK_CONF(cmd, CONF_ROOT|CONF_GLOBAL|CONF_VIRTUAL);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_GLOBAL|CONF_VIRTUAL|CONF_ANON|CONF_DIR);
 
   c = add_config_param(cmd->argv[0], 3, NULL, NULL, NULL);
 
@@ -268,6 +269,7 @@ MODRET set_redislogonevent(cmd_rec *cmd) {
   c->argv[1] = pstrdup(c->pool, fmt_name);
   c->argv[2] = log_fmt;
 
+  c->flags |= CF_MERGEDOWN_MULTI;
   return PR_HANDLED(cmd);
 }
 


### PR DESCRIPTION
be configured within <Directory> (and <Anonymous>) sections.

This allows Redis-based logging to be selectively done based on the
directory of the client.