### PR TITLE
Add autoconf detection of the pread(2) and pwrite(2) functions, and s…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -501,6 +501,9 @@
 /* Define if you have the Postgres PQinitOpenSSL function.  */
 #undef HAVE_POSTGRES_PQINITOPENSSL
 
+/* Define if you have the pread function.  */
+#undef HAVE_PREAD
+
 /* Define if you have the prctl function.  */
 #undef HAVE_PRCTL
 
@@ -509,6 +512,9 @@
 
 /* Define if you have the putenv function.  */
 #undef HAVE_PUTENV
+
+/* Define if you have the pwrite function.  */
+#undef HAVE_PWRITE
 
 /* Define if you have the random function.  */
 #undef HAVE_RANDOM

--- a/configure
+++ b/configure
@@ -34041,7 +34041,9 @@ done
 
 
 
-for ac_func in pathconf posix_fadvise prctl putenv random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror
+
+
+for ac_func in pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5

--- a/configure.in
+++ b/configure.in
@@ -2008,7 +2008,7 @@ AC_CHECK_FUNCS(getcwd getenv getgrouplist getgroups getgrset gethostbyname2 geth
 AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups)
 AC_CHECK_FUNCS(loginrestrictions)
 AC_CHECK_FUNCS(memcpy mempcpy memset_s mkdir mkstemp mlock mlockall munlock munlockall)
-AC_CHECK_FUNCS(pathconf posix_fadvise prctl putenv random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror)
+AC_CHECK_FUNCS(pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror)
 AC_CHECK_FUNCS(strlcat strlcpy strsep strtod strtof strtol strtoll strtoull setprotoent setspent endprotoent)
 # __snprintf and __vsnprintf are only on solaris and _really_ broken there.
 AC_CHECK_FUNCS(vsnprintf snprintf)


### PR DESCRIPTION
…tart

using them for e.g. writing scoreboard entries.  Saves on some lseek(2)
system calls.