### PR TITLE
systemd: use network-online.target

### DIFF
--- a/contrib/dist/rpm/proftpd.service
+++ b/contrib/dist/rpm/proftpd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description = ProFTPD FTP Server
-After = network.target nss-lookup.target local-fs.target remote-fs.target
+Wants=network-online.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target
 
 [Service]
 Type = simple


### PR DESCRIPTION
With systemd, wait for network-online.target (rather than network.target)
before starting.

If your network is slow coming up (say you're using DHCP and the server is
unavailable or rebooting after a power outage, etc.) then proftpd might
come up before the network is sufficiently configured.

Refs:
https://bugzilla.redhat.com/show_bug.cgi?id=1119787
https://bugzilla.redhat.com/show_bug.cgi?id=1506805
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/