### PR TITLE
Addresses a mod_vroot-caused issue, where TransferLog entries for files

### DIFF
--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -2998,7 +2998,7 @@ static int fxp_handle_abort(const void *key_data, size_t key_datasz,
   }
 
   /* Write an 'incomplete' TransferLog entry for this. */
-  abs_path = dir_abs_path(fxh->pool, real_path, TRUE);
+  abs_path = sftp_misc_vroot_abs_path(fxh->pool, real_path, TRUE);
 
   if (fxh->fh_flags == O_RDONLY) {
     direction = 'o';
@@ -4702,7 +4702,7 @@ static int fxp_handle_ext_copy_file(struct fxp_packet *fxp, char *src,
   fxp_cmd_dispatch(cmd);
 
   /* Write a TransferLog entry as well. */
-  abs_path = dir_abs_path(fxp->pool, dst, TRUE);
+  abs_path = sftp_misc_vroot_abs_path(fxp->pool, dst, TRUE);
   xferlog_write(0, session.c->remote_name, st.st_size, abs_path, 'b', 'i',
     'r', session.user, 'c', "_");
 
@@ -6637,6 +6637,8 @@ static int fxp_handle_close(struct fxp_packet *fxp) {
 
       } else {
         pr_response_add(R_226, "%s", "Transfer complete");
+        session.xfer.path = sftp_misc_vroot_abs_path(cmd2->pool,
+          session.xfer.path, FALSE);
         fxp_cmd_dispatch(cmd2);
       }
     }
@@ -11357,7 +11359,7 @@ static int fxp_handle_remove(struct fxp_packet *fxp) {
     /* The TransferLog format wants the full path to the deleted file,
      * regardless of a chroot.
      */
-    abs_path = dir_abs_path(fxp->pool, path, TRUE);
+    abs_path = sftp_misc_vroot_abs_path(fxp->pool, path, TRUE);
 
     xferlog_write(0, session.c->remote_name, st.st_size, abs_path,
       'b', 'd', 'r', session.user, 'c', "_");

--- a/contrib/mod_sftp/misc.h
+++ b/contrib/mod_sftp/misc.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp miscellaneous
- * Copyright (c) 2010-2016 TJ Saunders
+ * Copyright (c) 2010-2017 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,8 @@
 
 int sftp_misc_chown_file(pool *, pr_fh_t *);
 int sftp_misc_chown_path(pool *, const char *);
+const char *sftp_misc_get_chroot(pool *p);
 const char *sftp_misc_namelist_shared(pool *, const char *, const char *);
+char *sftp_misc_vroot_abs_path(pool *p, const char *, int);
 
 #endif /* MOD_SFTP_MISC_H */

--- a/contrib/mod_sftp/mod_sftp.c
+++ b/contrib/mod_sftp/mod_sftp.c
@@ -1604,6 +1604,10 @@ MODRET set_sftptrafficpolicy(cmd_rec *cmd) {
 /* Event handlers
  */
 
+static void sftp_chroot_ev(const void *event_data, void *user_data) {
+  (void) pr_table_add_dup(session.notes, "mod_sftp.chroot-path", event_data, 0);
+}
+
 extern pid_t mpid;
 
 static void sftp_exit_ev(const void *event_data, void *user_data) {
@@ -2008,13 +2012,15 @@ static int sftp_sess_init(void) {
   int times_gmt = TRUE;
 
   c = find_config(main_server->conf, CONF_PARAM, "SFTPEngine", FALSE);
-  if (c) {
+  if (c != NULL) {
     sftp_engine = *((int *) c->argv[0]);
   }
 
-  if (!sftp_engine)
+  if (sftp_engine == FALSE) {
     return 0;
+  }
 
+  pr_event_register(&sftp_module, "core.chroot", sftp_chroot_ev, NULL);
   pr_event_register(&sftp_module, "core.exit", sftp_exit_ev, NULL);
 #ifdef PR_USE_DEVEL
   pr_event_register(&sftp_module, "core.signal.USR2", sftp_sigusr2_ev, NULL);

--- a/contrib/mod_sftp/scp.c
+++ b/contrib/mod_sftp/scp.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp SCP
- * Copyright (c) 2008-2016 TJ Saunders
+ * Copyright (c) 2008-2017 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1643,6 +1643,8 @@ static int recv_path(pool *p, uint32_t channel_id, struct scp_path *sp,
       }
     }
 
+    session.xfer.path = sftp_misc_vroot_abs_path(session.xfer.p,
+      session.xfer.path, FALSE);
     (void) pr_cmd_dispatch_phase(cmd, POST_CMD, 0);
     (void) pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
 
@@ -2282,6 +2284,8 @@ static int send_path(pool *p, uint32_t channel_id, struct scp_path *sp) {
   pr_fsio_close(sp->fh);
   sp->fh = NULL;
 
+  session.xfer.path = sftp_misc_vroot_abs_path(session.xfer.p,
+    session.xfer.path, FALSE);
   (void) pr_cmd_dispatch_phase(cmd, POST_CMD, 0);
   (void) pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
 
@@ -2835,7 +2839,8 @@ int sftp_scp_close_session(uint32_t channel_id) {
                 curr_path = pstrdup(scp_pool, elt->fh->fh_path);
 
                 /* Write out an 'incomplete' TransferLog entry for this. */
-                abs_path = dir_abs_path(scp_pool, elt->best_path, TRUE);
+                abs_path = sftp_misc_vroot_abs_path(scp_pool, elt->best_path,
+                  TRUE);
             
                 if (elt->recvlen > 0) {
                   xferlog_write(0, pr_netaddr_get_sess_remote_name(),


### PR DESCRIPTION
uploaded/downloaded via SFTP or SCP, when mod_vroot is used, are not correct.