### PR TITLE
Issue #622: By using the SO_REUSEPORT socket option for the daemon li…

### DIFF
--- a/tests/api/stubs.c
+++ b/tests/api/stubs.c
@@ -30,6 +30,7 @@ session_t session;
 
 char ServerType = SERVER_STANDALONE;
 int ServerUseReverseDNS = 1;
+unsigned char is_master = FALSE;
 server_rec *main_server = NULL;
 pid_t mpid = 1;
 module *static_modules[] = { NULL };


### PR DESCRIPTION
…stening

socket, we inadvertently allowed multiple daemon processes to be running,
and listening on the same socket, at the same time.

This broke the previous behavior (and violates the principle of least surprise).
But we DO want this behavior for session processes.  So modify the setting
of SO_REUSEPORT to be done only for session processes.