### PR TITLE
Address the compiler warning about getgrouplist(3) on Mac OSX with some

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -339,6 +339,9 @@
 /* Define if you have the getgrouplist function.  */
 #undef HAVE_GETGROUPLIST
 
+/* Define if your getgrouplist(3) function takes ints. */
+#undef HAVE_GETGROUPLIST_TAKES_INTS
+
 /* Define if you have the getgroups function.  */
 #undef HAVE_GETGROUPS
 

--- a/configure
+++ b/configure
@@ -27162,6 +27162,69 @@ _ACEOF
 
 
 
+{ echo "$as_me:$LINENO: checking whether the getgrouplist(3) function takes ints" >&5
+echo $ECHO_N "checking whether the getgrouplist(3) function takes ints... $ECHO_C" >&6; }
+cat >conftest.$ac_ext <<_ACEOF
+/* confdefs.h.  */
+_ACEOF
+cat confdefs.h >>conftest.$ac_ext
+cat >>conftest.$ac_ext <<_ACEOF
+/* end confdefs.h.  */
+
+  #define _BSD_SOURCE
+  #include <grp.h>
+  #include <unistd.h>
+
+int
+main ()
+{
+
+  int (*f)(const char *, int, int *, int *) = getgrouplist;
+
+  ;
+  return 0;
+}
+_ACEOF
+rm -f conftest.$ac_objext conftest$ac_exeext
+if { (ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
+  (eval "$ac_link") 2>conftest.er1
+  ac_status=$?
+  grep -v '^ *+' conftest.er1 >conftest.err
+  rm -f conftest.er1
+  cat conftest.err >&5
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); } && {
+	 test -z "$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest$ac_exeext &&
+       $as_test_x conftest$ac_exeext; then
+
+  { echo "$as_me:$LINENO: result: yes" >&5
+echo "${ECHO_T}yes" >&6; }
+
+cat >>confdefs.h <<\_ACEOF
+#define HAVE_GETGROUPLIST_TAKES_INTS 1
+_ACEOF
+
+
+else
+  echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+
+  { echo "$as_me:$LINENO: result: no" >&5
+echo "${ECHO_T}no" >&6; }
+
+fi
+
+rm -f core conftest.err conftest.$ac_objext conftest_ipa8_conftest.oo \
+      conftest$ac_exeext conftest.$ac_ext
+
 { echo "$as_me:$LINENO: checking whether time.h and sys/time.h may both be included" >&5
 echo $ECHO_N "checking whether time.h and sys/time.h may both be included... $ECHO_C" >&6; }
 if test "${ac_cv_header_time+set}" = set; then

--- a/configure
+++ b/configure
@@ -27171,9 +27171,13 @@ cat confdefs.h >>conftest.$ac_ext
 cat >>conftest.$ac_ext <<_ACEOF
 /* end confdefs.h.  */
 
-  #define _BSD_SOURCE
-  #include <grp.h>
-  #include <unistd.h>
+  #define _GNU_SOURCE
+  #ifdef HAVE_GRP_H
+  # include <grp.h>
+  #endif
+  #ifdef HAVE_UNISTD_H
+  # include <unistd.h>
+  #endif
 
 int
 main ()

--- a/configure.in
+++ b/configure.in
@@ -1731,6 +1731,21 @@ AC_TYPE_MODE_T
 AC_TYPE_OFF_T
 AC_TYPE_GETGROUPS
 
+dnl Check the function signature of getgrouplist()
+AC_MSG_CHECKING([whether the getgrouplist(3) function takes ints])
+AC_TRY_LINK([
+  #define _BSD_SOURCE
+  #include <grp.h>
+  #include <unistd.h>
+], [
+  int (*f)(const char *, int, int *, int *) = getgrouplist;
+], [
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_GETGROUPLIST_TAKES_INTS, 1, [Define if getgrouplist3() takes ints as arguments])
+], [
+  AC_MSG_RESULT(no)
+])
+
 AC_HEADER_TIME
 AC_STRUCT_TM
 

--- a/configure.in
+++ b/configure.in
@@ -1734,9 +1734,13 @@ AC_TYPE_GETGROUPS
 dnl Check the function signature of getgrouplist()
 AC_MSG_CHECKING([whether the getgrouplist(3) function takes ints])
 AC_TRY_LINK([
-  #define _BSD_SOURCE
-  #include <grp.h>
-  #include <unistd.h>
+  #define _GNU_SOURCE
+  #ifdef HAVE_GRP_H
+  # include <grp.h>
+  #endif
+  #ifdef HAVE_UNISTD_H
+  # include <unistd.h>
+  #endif
 ], [
   int (*f)(const char *, int, int *, int *) = getgrouplist;
 ], [

--- a/modules/mod_auth_unix.c
+++ b/modules/mod_auth_unix.c
@@ -1253,7 +1253,12 @@ static int get_groups_by_getgrouplist(const char *user, gid_t primary_gid,
     "using getgrouplist(3) to look up group membership");
 
   memset(group_ids, 0, sizeof(group_ids));
-  if (getgrouplist(user, primary_gid, group_ids, &ngroups) < 0) {
+#ifdef HAVE_GETGROUPLIST_TAKES_INTS
+  res = getgrouplist(user, primary_gid, (int *) group_ids, &ngroups);
+#else
+  res = getgrouplist(user, primary_gid, group_ids, &ngroups);
+#endif
+  if (res < 0) {
     int xerrno = errno;
 
     pr_log_pri(PR_LOG_WARNING, "getgrouplist(3) error: %s", strerror(xerrno));


### PR DESCRIPTION
Autoconf detection magic.