### PR TITLE
Extend mod_exec to support additional backends and add IPC message queue module

### DIFF
--- a/contrib/mod_exec.h
+++ b/contrib/mod_exec.h
@@ -1,0 +1,40 @@
+/*
+ * ProFTPD: mod_exec.h -- header file for mod_exec and backends
+ * Copyright (c) 2018 The ProFTPD Project
+ *  
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, Andrew Houghton and other respective copyright
+ * holders give permission to link this program with OpenSSL, and distribute
+ * the resulting executable, without including the source code for OpenSSL in
+ * the source distribution.
+ *
+ * $Id: mod_exec.h $
+ */
+
+#ifndef MOD_EXEC_H
+#define MOD_EXEC_H
+
+const char *exec_subst_var(pool *, const char *, cmd_rec *);
+int exec_register_backend(const char *prefix, int (*exec_cmd)(cmd_rec *, config_rec *, int));
+extern int exec_engine;
+
+struct exec_event_data {
+  unsigned int flags;
+  config_rec *c;
+  const char *event;
+};
+
+#endif /* MOD_EXEC_H */

--- a/contrib/mod_exec_mqueue.c
+++ b/contrib/mod_exec_mqueue.c
@@ -1,0 +1,503 @@
+/*
+ * ProFTPD: mod_exec_mqueue -- a module for sending messages via IPC
+ * Copyright (c) 2018 Joshua Megerman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * This is mod_exec_mqueue, contrib software for proftpd 1.3.x and above.
+ * For more information contact TJ Saunders <tj@castaglia.org>.
+ */
+
+#include "conf.h"
+#include "privs.h"
+#include "mod_exec.h"
+
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+#define MOD_EXEC_MQUEUE_VERSION	"mod_exec_mqueue/0.9.0"
+
+/* Make sure the version of proftpd is as necessary. */
+#if PROFTPD_VERSION_NUMBER < 0x0001030402
+# error "ProFTPD 1.3.4rc2 or later required"
+#endif
+
+module exec_mqueue_module;
+extern xaset_t *server_list;
+
+static int exec_mqueue_logfd = -1;
+static char *exec_mqueue_logname = NULL;
+static const char *trace_channel = "exec";
+
+static int exec_mqueue_timeout_triggered = FALSE;
+
+/* Message defaults */
+#define DEFAULT_MSGTYPE 1L
+#define MAX_MESSAGE_SIZE (1024 - sizeof(long))
+
+/* This corresponds to a struct msgbuf from <sys/msg.h> */
+typedef struct EventMessage {
+  long mtype;
+  char buf[MAX_MESSAGE_SIZE];
+} EventMessage;
+
+
+/* End msg stuff */
+
+/* Prototypes */
+static int exec_mqueue_log(const char *, ...)
+#ifdef __GNUC__
+      __attribute__ ((format (printf, 1, 2)));
+#else
+      ;
+#endif
+static int exec_mqueue_sess_init(void);
+
+/* Support routines
+ */
+
+static int exec_mqueue_closelog(void) {
+  /* sanity check */
+  if (exec_mqueue_logfd != -1) {
+    close(exec_mqueue_logfd);
+    exec_mqueue_logfd = -1;
+    exec_mqueue_logname = NULL;
+  }
+
+  return 0;
+}
+
+static int exec_mqueue_log(const char *fmt, ...) {
+  va_list msg;
+  int res;
+
+  if (!exec_mqueue_logname)
+    return 0;
+
+  va_start(msg, fmt);
+  res = pr_log_vwritefile(exec_mqueue_logfd, MOD_EXEC_MQUEUE_VERSION, fmt, msg);
+  va_end(msg);
+  
+  return res;
+}
+
+static int exec_mqueue_openlog(void) {
+  int res = 0;
+
+  /* Sanity check */
+  exec_mqueue_logname = (char *) get_param_ptr(main_server->conf, "ExecLog", FALSE);
+  if (exec_mqueue_logname == NULL)
+    return 0;
+
+  /* Check for "none". */
+  if (strncasecmp(exec_mqueue_logname, "none", 5) == 0) {
+    exec_mqueue_logname = NULL;
+    return 0;
+  }
+
+  pr_signals_block();
+  PRIVS_ROOT
+  res = pr_log_openfile(exec_mqueue_logname, &exec_mqueue_logfd, PR_LOG_SYSTEM_MODE);
+  PRIVS_RELINQUISH
+  pr_signals_unblock();
+
+  return res;
+}
+
+static int exec_mqueue_timeout_cb(CALLBACK_FRAME) {
+  exec_mqueue_timeout_triggered = TRUE;
+  pr_trace_msg(trace_channel, 8, "msgsnd timed out");
+
+  return 0;
+}
+
+/* Send messages via IPC instead of executing commands to get around chroot(2)
+ * limitations.
+ */
+static int exec_mqueue_smessage(cmd_rec *cmd, config_rec *c, int flags) {
+  int status, i, j, mqid, xerrno, timerno;
+  int exec_mqueue_timeout = 0, format = 0;
+  EventMessage msgbuf;
+  char buf[MAX_MESSAGE_SIZE], *p, *endptr = NULL;
+  int c_remain = MAX_MESSAGE_SIZE-1;
+  void *ptr;
+
+  ptr = get_param_ptr(main_server->conf, "ExecMqueueKey", FALSE);
+  if (ptr == NULL) {
+    exec_mqueue_log("no message queue key specified");
+    return EINVAL;
+  }
+  if ((mqid = msgget(*((key_t *)ptr), IPC_CREAT | 0660)) == -1) {
+    xerrno = errno;
+    exec_mqueue_log("couldn't get message queue: %s", strerror(xerrno));
+    return xerrno;
+  }
+
+  msgbuf.mtype = 0;
+  *msgbuf.buf = *buf = 0;
+
+  p = (char *)(c->argv[2]) + 7; // after 'mqueue:'
+  if (*p != '\0') {
+    errno = 0;
+    i = strtoul(p, &endptr, 0);
+    xerrno = errno;
+    if ((*endptr == '\0') && !xerrno && (i > 0)) {
+      msgbuf.mtype = i;
+      exec_mqueue_log("message type %d specified in command", i);
+    }
+  }
+  if (msgbuf.mtype == 0) {
+    ptr = get_param_ptr(CURRENT_CONF, "ExecMqueueType", FALSE);
+    if (ptr == NULL) {
+      exec_mqueue_log("warning: no message type specified - defaulting to %ld", DEFAULT_MSGTYPE);
+      msgbuf.mtype = DEFAULT_MSGTYPE;
+    } else {
+      msgbuf.mtype = *((long *)ptr);
+    }
+  }
+
+  /* Determine the message format (and potentially maximum size) */
+  ptr = get_param_ptr(main_server->conf, "ExecMqueueFormat", FALSE);
+  if (ptr && (*((int *)ptr) == 1)) {
+    /* "ncftpd" format */
+    format = 1;
+    c_remain = 999;
+  }
+
+  /* Perform any required substitution on the command arguments. */
+  pool *tmp_pool = cmd ? cmd->tmp_pool : make_sub_pool(session.pool);
+  for (i = 3; i < c->argc; i++) {
+    pr_signals_handle();
+    if (!c->argv[i])
+      break;
+    c->argv[i] = (void *) exec_subst_var(tmp_pool, c->argv[i], cmd);
+    p = (char *) c->argv[i];
+    j = strlen(p);
+    if ((j+1) > c_remain) {
+      exec_mqueue_log("error: message is too big");
+      return(EMSGSIZE);
+    } else {
+      strncat(buf, p, c_remain);
+      c_remain -= j;
+      strncat(buf, "\n", c_remain--);
+    }
+  }
+  if (cmd == NULL) {
+    destroy_pool(tmp_pool);
+  }
+
+  /* finish generating the message */
+  if (format == 1) {
+    sprintf(msgbuf.buf, "STR\n%3d\n", (int)strlen(buf));
+  }
+  strncat(msgbuf.buf, buf, MAX_MESSAGE_SIZE-strlen(msgbuf.buf)-1);
+  
+  ptr = get_param_ptr(main_server->conf, "ExecMqueueTimeout", FALSE);
+  if (ptr) {
+    exec_mqueue_timeout = *((int *)ptr);
+  }
+
+  exec_mqueue_timeout_triggered = FALSE;
+  if (exec_mqueue_timeout) {
+    timerno = pr_timer_add(exec_mqueue_timeout, -1, &exec_mqueue_module, exec_mqueue_timeout_cb, "msgsnd");
+    if (timerno <= 0) {
+      xerrno = errno;
+      pr_trace_msg(trace_channel, 8, "error adding timer: %s", strerror(xerrno));
+      return xerrno;
+    }
+  }
+
+  status = msgsnd(mqid, &msgbuf, strlen(msgbuf.buf)+1, 0);
+  xerrno = errno;
+  pr_trace_msg(trace_channel, 10, "msgsnd returned: %s", strerror(xerrno));
+  if (exec_mqueue_timeout) {
+    pr_timer_remove(timerno, &exec_mqueue_module);
+  }
+  if (status == -1) {
+    status = xerrno;
+    if (exec_mqueue_timeout_triggered) {
+      exec_mqueue_log("message timed out: %s", strerror(status));
+    } else {
+      exec_mqueue_log("couldn't send message: %s", strerror(status));
+    }
+  } else {
+  }
+
+  return status;
+}
+
+/* usage: ExecMqueueKey <queue id> */
+MODRET set_execmqueuekey(cmd_rec *cmd) {
+  int xerrno;
+  config_rec *c;
+  long mqkey = 0;
+  char *endptr = NULL;
+
+  CHECK_ARGS(cmd, 1);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  errno = 0;
+  mqkey = strtol(cmd->argv[1], &endptr, 0);
+  xerrno = errno;
+
+  if (*endptr != '\0') {
+    CONF_ERROR(cmd, "requires a numeric argument");
+  }
+
+  if ((xerrno == ERANGE) || (mqkey > INT_MAX) || (mqkey < INT_MIN)) {
+    CONF_ERROR(cmd, "the value given is outside the legal range");
+  }
+
+  if (!mqkey) {
+    CONF_ERROR(cmd, "the value given must be non-zero");
+  }
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+  c->argv[0] = palloc(c->pool, sizeof(key_t));
+  *((key_t *) c->argv[0]) = (key_t)mqkey;
+
+  return PR_HANDLED(cmd);
+}
+
+/* usage: ExecMqueueType <message type> */
+MODRET set_execmqueuetype(cmd_rec *cmd) {
+  int xerrno;
+  config_rec *c;
+  long msgtype = 0;
+  char *endptr = NULL;
+
+  CHECK_ARGS(cmd, 1);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL|CONF_ANON|
+    CONF_DIR);
+
+  errno = 0;
+  msgtype = strtoul(cmd->argv[1], &endptr, 0);
+  xerrno = errno;
+
+  if (*endptr != '\0') {
+    CONF_ERROR(cmd, "requires a numeric argument");
+  }
+
+  if ((xerrno == ERANGE) || (msgtype > UINT_MAX)) {
+    CONF_ERROR(cmd, "the value given is outside the legal range");
+  }
+
+  if (!msgtype) {
+    CONF_ERROR(cmd, "the value given must be greater than zero");
+  }
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+  c->argv[0] = palloc(c->pool, sizeof(long));
+  *((long *) c->argv[0]) = (long)msgtype;
+  c->flags |= CF_MERGEDOWN;
+
+  return PR_HANDLED(cmd);
+}
+
+/* usage: ExecMqueueFormat <message type> */
+MODRET set_execmqueueformat(cmd_rec *cmd) {
+  config_rec *c;
+  int format = 0;
+
+  CHECK_ARGS(cmd, 1);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  if (!strcmp(cmd->argv[1], "ncftpd")) {
+    format = 1;
+  } else if (strcmp(cmd->argv[1], "raw")) {
+    CONF_ERROR(cmd, "invalid format - the supported formats are 'raw' and 'ncftpd'");
+  }
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+  c->argv[0] = palloc(c->pool, sizeof(int));
+  *((int *) c->argv[0]) = (int)format;
+
+  return PR_HANDLED(cmd);
+}
+
+/* usage: ExecMqueueTimeout <seconds> */
+MODRET set_execmqueuetimeout(cmd_rec *cmd) {
+  int timeout = -1;
+  config_rec *c = NULL;
+
+  CHECK_ARGS(cmd, 1);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  if (pr_str_get_duration(cmd->argv[1], &timeout) < 0) {
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error parsing timeout value '",
+      cmd->argv[1], "': ", strerror(errno), NULL));
+  }
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+  c->argv[0] = pcalloc(c->pool, sizeof(int));
+  *((int *) c->argv[0]) = timeout;
+
+  return PR_HANDLED(cmd);
+}
+
+/* usage: ExecMqueueCleanup on|off */
+MODRET set_execmqueuecleanup(cmd_rec *cmd) {
+  int cleanup = -1;
+  config_rec *c;
+
+  CHECK_ARGS(cmd, 1);
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  cleanup = get_boolean(cmd, 1);
+  if (cleanup == -1) {
+    CONF_ERROR(cmd, "expected Boolean parameter");
+  }
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+  c->argv[0] = palloc(c->pool, sizeof(int));
+  *((int *) c->argv[0]) = cleanup;
+
+  return PR_HANDLED(cmd);
+}
+
+/* Event handlers
+ */
+
+#if defined(PR_SHARED_MODULE)
+static void exec_mqueue_mod_unload_ev(const void *event_data, void *user_data) {
+  if (strncmp("mod_exec_mqueue.c", (const char *) event_data, 11) == 0) {
+
+    pr_event_unregister(&exec_mqueue_module, NULL, NULL);
+
+    exec_mqueue_closelog();
+  }
+}
+#endif /* PR_SHARED_MODULE */
+
+static void exec_mqueue_postparse_ev(const void *event_data, void *user_data) {
+  exec_mqueue_openlog();
+}
+
+static void exec_mqueue_shutdown_ev(const void *event_data, void *user_data) {
+  void *ptr;
+  int mqid;
+  server_rec *s;
+
+  for (s = (server_rec *) server_list->xas_list; s; s = s->next) {
+    ptr = get_param_ptr(s->conf, "ExecMqueueCleanup", FALSE);
+    if (ptr && !(*((int *)ptr))) // Don't cleanup this server
+      continue;
+
+    ptr = get_param_ptr(s->conf, "ExecMqueueKey", FALSE);
+    if (ptr) {
+      mqid = msgget(*((key_t *)ptr), 0);
+      if (mqid != -1) {
+        msgctl(mqid, IPC_RMID, NULL);
+        pr_trace_msg(trace_channel, 5, "removed queue %x", *((key_t *)ptr));
+      }
+    }
+  }
+
+}
+static void exec_mqueue_restart_ev(const void *event_data, void *user_data) {
+
+  /* Bounce the log file descriptor. */
+  exec_mqueue_closelog();
+  exec_mqueue_openlog();
+
+  return;
+}
+
+static void exec_mqueue_sess_reinit_ev(const void *event_data, void *user_data) {
+
+  /* A HOST command changed the main_server pointer, reinitialize ourselves. */
+
+  pr_event_unregister(&exec_mqueue_module, "core.session-reinit", exec_mqueue_sess_reinit_ev);
+
+  exec_mqueue_closelog();
+
+  exec_mqueue_sess_init();
+}
+
+/* Initialization routines
+ */
+
+static int exec_mqueue_sess_init(void) {
+
+  pr_event_register(&exec_mqueue_module, "core.session-reinit", exec_mqueue_sess_reinit_ev,
+    NULL);
+
+  if (!exec_engine) {
+    return 0;
+  }
+
+  exec_mqueue_closelog();
+  exec_mqueue_openlog();
+
+  return 0;
+}
+
+static int exec_mqueue_init(void) {
+  /* Register event handlers. */
+#if defined(PR_SHARED_MODULE)
+  pr_event_register(&exec_mqueue_module, "core.module-unload", exec_mqueue_mod_unload_ev,
+    NULL);
+#endif /* PR_SHARED_MODULE */
+  pr_event_register(&exec_mqueue_module, "core.postparse", exec_mqueue_postparse_ev, NULL);
+  pr_event_register(&exec_mqueue_module, "core.restart", exec_mqueue_restart_ev, NULL);
+  pr_event_register(&exec_mqueue_module, "core.shutdown", exec_mqueue_shutdown_ev, NULL);
+
+  /* Register the mqueue backend */
+  exec_register_backend("mqueue:", exec_mqueue_smessage);
+
+  return 0;
+}
+
+/* Module API tables
+ */
+
+static conftable exec_mqueue_conftab[] = {
+  { "ExecMqueueKey",		set_execmqueuekey,	NULL },
+  { "ExecMqueueType",		set_execmqueuetype,	NULL },
+  { "ExecMqueueFormat",		set_execmqueueformat,	NULL },
+  { "ExecMqueueTimeout",	set_execmqueuetimeout,	NULL },
+  { "ExecMqueueCleanup",	set_execmqueuecleanup,	NULL },
+  { NULL }
+};
+
+module exec_mqueue_module = {
+
+  /* Always NULL */
+  NULL, NULL,
+
+  /* Module API version */
+  0x20,
+
+  /* Module name */
+  "exec_mqueue",
+
+  /* Configuration handler table */
+  exec_mqueue_conftab,
+
+  /* Command handler table */
+  NULL,
+
+  /* Authentication handler table */
+  NULL,
+
+  /* Module initialization */
+  exec_mqueue_init,
+
+  /* Session initialization */
+  exec_mqueue_sess_init,
+
+  /* Module version */
+  MOD_EXEC_MQUEUE_VERSION
+};

--- a/doc/contrib/mod_exec.html
+++ b/doc/contrib/mod_exec.html
@@ -35,6 +35,14 @@ mentioned possibilities of compromise or disclosure via those programs.
 </center>
 
 <p>
+Additionally, <code>mod_exec</code> supports submodules that allow other
+methods of executing commands than simply running scripts:
+<a name="submodules"></a>
+<ul>
+  <li><a href="mod_exec_mqueue.html"><code>mod_exec_mqueue</code></a> for sending messages vi SysV IPC Message Queues<br>
+</ul>
+
+<p>
 Please read the <a href="#Usage">usage</a> section to know the other caveats
 with this module.
 
@@ -582,6 +590,11 @@ allows for any script you wish, and is not subject to the restrictions of a
 chroot, meaning that you can use <code>DefaultRoot</code> and still have
 arbitrary scripts executed.  If requested, I can provide help in writing a
 FIFO reader to execute the necessary scripts.
+
+<p>
+Another alternative is to use the <a href="mod_exec_mqueue.html"><code>
+mod_exec_mqueue</code></a> submodule, which uses SysV IPC Message Queues to
+bypass the filesystem paths altogether.
 
 <p>
 <hr>

--- a/doc/contrib/mod_exec_mqueue.html
+++ b/doc/contrib/mod_exec_mqueue.html
@@ -1,0 +1,242 @@
+<html>
+<head>
+<title>ProFTPD module mod_exec_mqueue</title>
+</head>
+
+<body bgcolor=white>
+
+<hr><br>
+<center>
+<h2><b>ProFTPD module <code>mod_exec_mqueue</code></b></h2>
+</center>
+<hr><br>
+
+This module is contained in the <code>mod_exec_mqueue.c</code> file for
+ProFTPD 1.3.<i>x</i>, found
+<a href="http://www.castaglia.org/proftpd/">here</a>, and is not compiled by
+default.  Installation instructions are discussed
+<a href="#Installation">here</a>.
+
+<p>
+The <code>mod_exec_mqueue</code> module extends the <code>mod_exec</code>
+module by allowing it to send messages via kernel IPC message queues instead
+of executing a script.  Unlike mod_exec running scripts, this module
+<em>will</em> work properly for <code>&lt;Anonymous&gt;</code> logins, or for
+logins that are affected by <code>DefaultRoot</code>.  This is because the SysV
+IPC does not depend on the filesystem at all, and only requires kernel
+syscalls.  Of course, it also requires a program to be listening for the
+messages on the other end, but that is beyond the scope of this module.
+
+<p>
+Please read the <a href="#Usage">usage</a> section to know the other caveats
+with this module.
+
+<p>
+The most current version of <code>mod_exec_mqueue</code> is distributed with the
+ProFTPD source code.
+
+<h2>Author</h2>
+<p>
+Please contact TJ Saunders &lt;tj <i>at</i> castaglia.org&gt; with any
+questions, concerns, or suggestions regarding this module.
+
+<h2>Directives</h2>
+<ul>
+  <li><a href="#ExecMqueueKey">ExecMqueueKey</a>
+  <li><a href="#ExecMqueueType">ExecMqueueType</a>
+  <li><a href="#ExecMqueueFormat">ExecMqueueFormat</a>
+  <li><a href="#ExecMqueueTimeout">ExecMqueueTimeout</a>
+  <li><a href="#ExecMqueueCleanup">ExecMqueueTimeout</a>
+  <li><a href="mod_exec.html#ExecLog">ExecLog</a> (from mod_exec)
+</ul>
+
+<p>
+It also modifies the syntax of the following commands from </code>mod_exec
+</code>.  Please read the <a href="#Sending Messages">Sending Messages</a>
+section for details.
+
+<p>
+<ul>
+  <li>ExecBeforeCommand
+  <li>ExecOnCommand
+  <li>ExecOnConnect
+  <li>ExecOnError
+  <li>ExecOnEvent
+  <li>ExecOnExit
+  <li>ExecOnRestart
+</ul>
+
+<p>
+<hr>
+<h2><a name="ExecMqueueKey">ExecMqueueKey</a></h2>
+<strong>Syntax:</strong> ExecMqueueKey <em>key value</em><br>
+<strong>Default:</strong> None<br>
+<strong>Context:</strong> &quot;server config&quot; <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_exec_mqueue<br>
+<strong>Compatibility:</strong> 1.3.4rc2 and later
+
+<p>
+The <code>ExecMqueueKey</code> directive is used to define the message queue
+used to send event messages.  Each server instance may use its own key, but the
+key is global to all messages send by that server instance.  The key is a
+signed 32-bit integer, and can be provided in either decimal or hexadecimal
+form (the latter prefixed with '0x').
+
+<p>
+<hr>
+<h2><a name="ExecMqueueType">ExecMqueueType</a></h2>
+<strong>Syntax:</strong> ExecMqueueType <em>message type</em><br>
+<strong>Default:</strong> 1<br>
+<strong>Context:</strong> &quot;server config&quot; <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code>, <code>&lt;Anonymous&gt;</code>, <code>&lt;Directory&gt;</code><br>
+<strong>Module:</strong> mod_exec_mqueue<br>
+<strong>Compatibility:</strong> 1.3.4rc2 and later
+
+<p>
+The <code>ExecMqueueType</code> directive is used to define the message type
+specified for messages sent in the listed context.  It is a positive long
+integer, and can be provided in either decimal or hexadecimal form (the latter
+prefixed with '0x').  If not provided, the message type of 1 is used.
+
+<p>
+<hr>
+<h2><a name="ExecMqueueFormat">ExecMqueueFormat</a></h2>
+<strong>Syntax:</strong> ExecMqueueFormat <em>"raw"|"ncftpd"</em><br>
+<strong>Default:</strong> "raw"<br>
+<strong>Context:</strong> &quot;server config&quot; <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_exec_mqueue<br>
+<strong>Compatibility:</strong> 1.3.4rc2 and later
+
+<p>
+The <code>ExecMqueueFormat</code> directive is used to specify the format of
+the messages sent.  The default format, "raw", simply inserts newlines after
+every argument and sends the concatenated string as is.  The "ncftpd" format
+uses the same message format as used by NcFTPd, which prepends a header that
+also includes the length of the message.  Please read the <a href="#Formats">
+Formats</a> section to know more about the message formats.
+
+<p>
+<hr>
+<h2><a name="ExecMqueueTimeout">ExecMqueueTimeout</a></h2>
+<strong>Syntax:</strong> ExecMqueueTimeout <em>seconds</em><br>
+<strong>Default:</strong> None<br>
+<strong>Context:</strong> &quot;server config&quot; <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_exec_mqueue<br>
+<strong>Compatibility:</strong> 1.3.4rc2 and later
+
+<p>
+The <code>ExecMqueueTimeout</code> directive is used to set a limit on how long
+the msgsnd syscall will block if the message queue is full before it is
+interrupted and the message send fails.  Messages that are not sent because of
+this are lost, and will not be re-attempted.  Please note that if the message
+does block, the user's FTP session will hang until this timeout is exceeded;
+if not set the session will hang forever until the server process is killed or
+the msgsnd syscall finally returns once the queue is cleared or removed.
+
+<p>
+<hr>
+<h2><a name="ExecMqueueCleanuop">ExecMqueueCleanuop</a></h2>
+<strong>Syntax:</strong> ExecMqueueCleanuop <em>on|off</em><br>
+<strong>Default:</strong> on<br>
+<strong>Context:</strong> &quot;server config&quot;, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_exec_mqueue<br>
+<strong>Compatibility:</strong> 1.3.4rc2 and later
+
+The <code>ExecMqueueCleanup</code> directive is used to indicate whether the
+IPC message queue should be removed when the server shuts down or not.  By
+default the queue will be remove; set this to off to leave the messsage queue
+in place.  Note that any unread messages will be lost when the queue is
+destroyed!
+
+<p>
+<hr>
+<h2><a name="Usage">Usage</a></h2>
+Example configuration:
+<pre>
+  &lt;IfModule mod_exec_mqueue.c&gt;
+    ExecMqueueKey 0xDEADBEEF
+    ExecMqueueType 3
+    ExecMqueueFormat ncftpd
+    ExecMqueueTimeout 30
+  &lt;/IfModule&gt;
+</pre>
+
+<p>
+<hr>
+<h2><a name="Formats">Formats</a></h2>
+To create the message, each argument will be parsed to replace any "cookies"
+(see the <a href="mod_exec.html#ExecEnviron">ExecEnviron</a> directive in
+<code>mod_exec</code>) and have a newline appended to it.  The resulting
+strings are concatenated in order to produce the raw message string.  If the
+format "ncftpd" is selected, the message is prepended with the string,
+"STR\n###\n", where "###" is the length of the raw message in bytes, with
+leading spaces if less than 100.  This means that ncftpd format messages can
+be no longer than 999 characters including the trailing newline.
+
+If you do not want a newline between parameters, instead of separate
+arguments you can use a single argument enclosed in quotes, which will only
+have a single newline appended at the end.
+
+<p>
+<hr>
+<h2><a name="Sending Messages">Sending Messages</a></h2>
+To use the message queue functionality within mod_exec, the script path
+parameter should be replaced by the string "mqueue:", with an optional message
+type (see <a href="#ExecMqueueType">ExecMqueueType</a>) immediately following
+the ':' character (no spaces in between).  All arguments after that will be
+formated as above and then sent via the configured message queue.  The default
+maximum message size is 1016 bytes, including the terminating NULL byte -
+changing this requires updating and recompiling the source.
+
+Additionally, the '*' and '~' flags to the <a href="mod_exec.html#ExecOnEvent">
+ExecOnEvent</a> directive are explicitly ignored, as they are not relevant to
+sending messages via IPC.  If these flags are relevant to how the messages are
+handled by the receiving software, you will need to incorporate them into the
+message itself.
+<p>
+<hr>
+<h2><a name="Installation">Installation</a></h2>
+To install <code>mod_exec_mqueue</code>, copy the <code>mod_exec_mqueue.c</code> file into
+<pre>
+  <i>proftpd-dir</i>/contrib/
+</pre>
+after unpacking the latest proftpd-1.3.<i>x</i> source code.  Then follow the
+usual steps for using third-party modules in proftpd:
+<pre>
+  ./configure --with-modules=mod_exec_mqueue
+</pre>
+To build <code>mod_exec_mqueue</code> as a DSO module:
+<pre>
+  ./configure --enable-dso --with-shared=mod_exec_mqueue
+</pre>
+Then follow the usual steps:
+<pre>
+  make
+  make install
+</pre>
+
+<p>
+Alternatively, if your proftpd was compiled with DSO support, you can
+use the <code>prxs</code> tool to build <code>mod_exec_mqueue</code> as a shared
+module:
+<pre>
+  prxs -c -i -d mod_exec_mqueue.c
+</pre>
+
+<p><a name="FAQ"></a>
+<b>Frequently Asked Questions</b><br>
+<font color=red>Question</font>: <br>
+<font color=blue>Answer</font>: 
+
+<p>
+<hr><br>
+
+<font size=2><b><i>
+&copy; Copyright 2018 Joshua Megerman<br>
+ All Rights Reserved<br>
+</i></b></font>
+
+<hr><br>
+
+</body>
+</html>
+


### PR DESCRIPTION
mod_exec doesn't work in a chroot environment, for various good reasons.  This patch extends mod_exec to support submodules (similar to mod_sql or mod_wrap), which can provide alternate methods of sending/executing commands.  It also add the mod_exec_mqueue module, which uses SysV IPC message queues to send messages to an external program and thus bypasses the chroot issue.  This was inspired by how NcFTPd handles it's events (as I am looking to replace NcFTPd with ProFTPd now that the former is no longer supported), and is configurable to send messages in the exact same format or raw without the NcFTPd-specific header.  Supports separate message queues per server instance, as well as separate message types based on both context and the command definition.

This was written against mod_exec 0.9.15 and ProFTPd 1.3.5e (running on CentOS 7), but the patch is clean against the latest mod_exec so it should work fine without any changes.