### PR TITLE
- ProFTPD dumps core with long env variable

### DIFF
--- a/src/proctitle.c
+++ b/src/proctitle.c
@@ -60,7 +60,7 @@ static unsigned int proc_flags = 0;
 #define PR_PROCTITLE_FL_USE_STATIC		0x001
 
 void pr_proctitle_init(int argc, char *argv[], char *envp[]) {
-  register int i;
+  register int i, j;
   register size_t envpsize;
   char **p;
 
@@ -69,10 +69,11 @@ void pr_proctitle_init(int argc, char *argv[], char *envp[]) {
     envpsize += strlen(envp[i]) + 1;
   }
 
-  p = (char **) malloc((i + 1) * sizeof(char *));
+  p = (char **) calloc((i + 1), sizeof(char *));
   if (p != NULL) {
     environ = p;
 
+    j = 0;
     for (i = 0; envp[i] != NULL; i++) {
       size_t envp_len = strlen(envp[i]);
 
@@ -81,13 +82,12 @@ void pr_proctitle_init(int argc, char *argv[], char *envp[]) {
         continue;
       }
 
-      environ[i] = malloc(envp_len + 1);
-      if (environ[i] != NULL) {
-        sstrncpy(environ[i], envp[i], envp_len + 1);
+      environ[j++] = malloc(envp_len + 1);
+      if (environ[j] != NULL) {
+        sstrncpy(environ[j], envp[i], envp_len + 1);
       }
     }
 
-    environ[i] = NULL;
   }
 
   prog_argv = argv;


### PR DESCRIPTION
```
  # LD_PRELOAD=libumem.so.1 UMEM_DEBUG=default FOO=`perl -e 'print"a"x2500'`
/usr/lib/inet/proftpd
    Segmentation Fault (core dumped)

> ::stack
  libc.so.1`findenv+0x3c(f90bff08, fa624260, 1, ffbfe614, f90bff08, 0)
  libc.so.1`getenv+0x34(0, 0, 1, f90b3bd8, 120e30, fa716248)
  libc.so.1`getopt_internal+0x44(1, ffbfe76c, 6b048, 120ee8, 0, e9)
  main+0xc4(1, ffbfe76c, 120c00, 558ad8bc, 0, 13a400)
  _start+0x108(0, 0, 0, 0, 0, 0)

> ::status
  debugging core file of proftpd (32-bit) from sst-t5220-06
  file: /usr/lib/inet/proftpd
  initial argv: /usr/lib/inet/proftpd
  threading model: native threads
  status: process terminated by SIGSEGV (Segmentation Fault), addr=baddcafe

baddcafe address suggests that the program is accessing uninitialized memory.
```
From the call stack it is evident that this access occurs during call of
findenv() function [1]. Loop in line 152 iterates through items of
environment table.
```
  getenv.c:
  ...
  139 findenv(const char **e, const char *string, int name_only, char
**value)
  ...
  152        for (; (s2 = *e) != NULL; e++) {
  153                s1 =  string;
  ...
```
Checking arguments of findenv() we can see that the first one contains
invalid address (baddcafe).
```
> f90bff08/10X
0xf90bff08:  baddcafe   f90bdfc0   f90bbfc8   f90bdf90   f90b9fc8   f90b9f90
             f90b7fe8   f90b5fc8   f90b9f58   f90bdf60
```
Now one may ask where does this entry in environment table comes from? Well,
ProFTPD is interacting with environment variables immediately after starting
up during pr_proctitle_init() [2].
```
  proctitle.c:
   66 void pr_proctitle_init(int argc, char *argv[], char *envp[]) {
  ...
   79    for (i = 0; envp[i] != NULL; i++) {
   80      size_t envp_len = strlen(envp[i]);
   81
   82      if (envp_len > PR_TUNABLE_ENV_MAX) {
   83        /* Skip any environ variables that are too long. */
   84        continue;
   85      }
  ...
```
In loop in line 79 it creates copy of environment table - but there is a
catch in condition in line 82. It just skips items of length greater than
PR_TUNABLE_ENV_MAX (2048 b). This effectively produces table with holes of
uninitialized data. Attempt of findenv() to access them results in observed
fault.

(issue found and analyzed by lukas.lipinsky@oracle.com)