### PR TITLE
- init_conn() on Solaris should treat EACCESS as EADDRINUSE

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -452,7 +452,11 @@ static conn_t *init_conn(pool *p, int fd, const pr_netaddr_t *bind_addr,
       }
 
       if (res != -1 ||
+#ifdef	SOLARIS2
+          (hold_errno != EADDRINUSE && hold_errno != EACCES) ||
+#else	/* !SOLARIS2 */
           hold_errno != EADDRINUSE ||
+#endif	/* SOLARIS2 */
           (port != INPORT_ANY && !retry_bind)) {
         break;
       }


### PR DESCRIPTION
    if proftpd in passive mode happens to pickup port numbers used by NFS,
    then bind fails with EACCESS. Such failure should be treated in the
    same way as proftpd treats EADDRINUSE. This is an excerpt from
    Solaris bind(2) manpage:

ERRORS
       The bind() function will fail if:

       EADDRINUSE       The specified address is already in use.

       EADDRNOTAVAIL    The  specified address is not available from the local
                        machine.

       EAFNOSUPPORT     The specified address is not a valid address  for  the
                        address family of the specified socket.