### PR TITLE
symlink("/tmp/prt-realink.lnk, "") creates 'empty' symlink

### DIFF
--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -309,6 +309,7 @@ START_TEST (dir_readlink_test) {
     res = dir_readlink(p, path, buf, bufsz, flags);
     fail_unless(res == 0, "Failed to handle empty symlink");
   }
+  (void) unlink(path);
 
   /* Not chrooted, absolute dst path */
   memset(buf, '\0', bufsz);


### PR DESCRIPTION
we must unlink() the '/tmp/prt-readlink.lnk' (empty symlink),
before proceeding further. Not doing so makes following test
to always fail with 'EEXIST'. 