### PR TITLE
/home/user* is unfortunate location

### DIFF
--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -312,7 +312,7 @@ START_TEST (dir_readlink_test) {
 
   /* Not chrooted, absolute dst path */
   memset(buf, '\0', bufsz);
-  dst_path = "/home/user/file.dat";
+  dst_path = "/tmp/home/user/file.dat";
   dst_pathlen = strlen(dst_path);
   res = symlink(dst_path, path);
   fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
@@ -423,7 +423,7 @@ START_TEST (dir_readlink_test) {
     dst_path, buf);
 
   /* Chrooted, absolute destination path shorter than chroot path */
-  session.chroot_path = "/home/user";
+  session.chroot_path = "/tmp/home/user";
   memset(buf, '\0', bufsz);
   dst_path = "/foo";
   dst_pathlen = strlen(dst_path);
@@ -442,7 +442,7 @@ START_TEST (dir_readlink_test) {
 
   /* Chrooted, overlapping chroot to non-dir */
   memset(buf, '\0', bufsz);
-  dst_path = "/home/user2";
+  dst_path = "/tmp/home/user2";
   dst_pathlen = strlen(dst_path);
 
   (void) unlink(path);
@@ -459,7 +459,7 @@ START_TEST (dir_readlink_test) {
 
   /* Chrooted, absolute destination within chroot */
   memset(buf, '\0', bufsz);
-  dst_path = "/home/user/file.txt";
+  dst_path = "/tmp/home/user/file.txt";
   dst_pathlen = strlen(dst_path);
   expected_path = "/file.txt";
   expected_pathlen = strlen(expected_path);
@@ -478,9 +478,9 @@ START_TEST (dir_readlink_test) {
 
   /* Chrooted, absolute destination outside of chroot */
   memset(buf, '\0', bufsz);
-  dst_path = "/home/user/../file.txt";
+  dst_path = "/tmp/home/user/../file.txt";
   dst_pathlen = strlen(dst_path);
-  expected_path = "/home/file.txt";
+  expected_path = "/tmp/home/file.txt";
   expected_pathlen = strlen(expected_path);
 
   (void) unlink(path);
@@ -1315,8 +1315,8 @@ START_TEST (path_subst_uservar_test) {
     res);
 
   session.user = "user";
-  original = "/home/%u";
-  expected = "/home/user";
+  original = "/tmp/home/%u";
+  expected = "/tmp/home/user";
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
@@ -1326,8 +1326,8 @@ START_TEST (path_subst_uservar_test) {
     res);
 
   session.user = "user";
-  original = "/home/%u[";
-  expected = "/home/user[";
+  original = "/tmp/home/%u[";
+  expected = "/tmp/home/user[";
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
@@ -1337,8 +1337,8 @@ START_TEST (path_subst_uservar_test) {
     res);
 
   session.user = "user";
-  original = "/home/%u[]";
-  expected = "/home/user[]";
+  original = "/tmp/home/%u[]";
+  expected = "/tmp/home/user[]";
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
@@ -1348,8 +1348,8 @@ START_TEST (path_subst_uservar_test) {
     res);
 
   session.user = "user";
-  original = "/home/users/%u[0]/%u[0]%u[1]/%u";
-  expected = "/home/users/u/us/user";
+  original = "/tmp/home/users/%u[0]/%u[0]%u[1]/%u";
+  expected = "/tmp/home/users/u/us/user";
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
@@ -1360,7 +1360,7 @@ START_TEST (path_subst_uservar_test) {
 
   /* Attempt to use an invalid index */
   session.user = "user";
-  original = "/home/users/%u[a]/%u[b]%u[c]/%u";
+  original = "/tmp/home/users/%u[a]/%u[b]%u[c]/%u";
   expected = original;
   path = pstrdup(p, original);
   mark_point();
@@ -1372,7 +1372,7 @@ START_TEST (path_subst_uservar_test) {
 
   /* Attempt to use an out-of-bounds index */
   session.user = "user";
-  original = "/home/users/%u[0]/%u[-1]%u[1]/%u";
+  original = "/tmp/home/users/%u[0]/%u[-1]%u[1]/%u";
   expected = original;
   path = pstrdup(p, original);
   mark_point();
@@ -1384,7 +1384,7 @@ START_TEST (path_subst_uservar_test) {
 
   /* Attempt to use an out-of-bounds index */
   session.user = "user";
-  original = "/home/users/%u[0]/%u[0]%u[4]/%u";
+  original = "/tmp/home/users/%u[0]/%u[0]%u[4]/%u";
   expected = original;
   path = pstrdup(p, original);
   mark_point();


### PR DESCRIPTION
/home/user is reserved to mount NFS homes on Oracle Soalris,
unit tests should not use this path. doing simple s/home/tmp\/home
solves it. The ultimate solution would be to let autoconf configure
the environment for unit tests or use environement variable.