### PR TITLE
Offsides maxloginfix

### DIFF
--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -2668,7 +2668,7 @@ MODRET auth_pass(cmd_rec *cmd) {
       /* Set auth_tries to -1 so that the session is disconnected after
        * POST_CMD_ERR and LOG_CMD_ERR events are processed.
        */
-      auth_retries = -1;
+      auth_tries = -1;
     }
 
     return PR_ERROR_MSG(cmd, R_530, denymsg ? denymsg : _("Login incorrect."));

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -383,6 +383,14 @@ MODRET auth_err_pass(cmd_rec *cmd) {
    */
   pr_table_remove(session.notes, "mod_auth.orig-user", NULL);
 
+  /* If auth_tries = -1, that means we reached the max login attempts and
+   * should disconnect the session.
+   */
+  if (auth_tries == -1) {
+    pr_session_disconnect(&auth_module, PR_SESS_DISCONNECT_CONFIG_ACL,
+      "Denied by MaxLoginAttempts");
+  }
+  
   return PR_HANDLED(cmd);
 }
 
@@ -2657,8 +2665,10 @@ MODRET auth_pass(cmd_rec *cmd) {
       /* Generate an event about this limit being exceeded. */
       pr_event_generate("mod_auth.max-login-attempts", session.c);
 
-      pr_session_disconnect(&auth_module, PR_SESS_DISCONNECT_CONFIG_ACL,
-        "Denied by MaxLoginAttempts");
+      /* Set auth_tries to -1 so that the session is disconnected after
+       * POST_CMD_ERR and LOG_CMD_ERR events are processed.
+       */
+      auth_retries = -1;
     }
 
     return PR_ERROR_MSG(cmd, R_530, denymsg ? denymsg : _("Login incorrect."));


### PR DESCRIPTION
After a failed login exceeds MaxLoginAttempts, don't disconnect the session until after the POST_CMD_ERR and LOG_CMD_ERR events have been processed.  This fixes a security issue where failed logins won't be logged properly if they exceed MaxLoginAttempts, and also allows things like ExecOnError to work as they are called by POST_CMD_ERR.

This is a slightly cleaner patch than the one I proposed in issue #718.