### PR TITLE
Guard against ENOATTR being undefined in API tests

### DIFF
--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -26,6 +26,12 @@
 
 #include "tests.h"
 
+#ifdef PR_USE_XATTR
+#ifndef ENOATTR
+# define ENOATTR ENODATA
+#endif
+#endif
+
 static pool *p = NULL;
 
 static char *fsio_cwd = NULL;


### PR DESCRIPTION
Since updating libattr in Fedora Rawhide last week, ENOATTR was undefined and caused a compilation error in tests/api/fsio.c.