### PR TITLE
- pam_exchange() panics when msg[] == NULL.

### DIFF
--- a/modules/mod_auth_pam.c
+++ b/modules/mod_auth_pam.c
@@ -106,7 +106,7 @@ static int pam_exchange(int num_msg, PR_PAM_CONST struct pam_message **msg,
   for (i = 0; i < num_msg; i++) {
     response[i].resp_retcode = 0; /* PAM_SUCCESS; */
 
-    switch (msg[i]->msg_style) {
+    switch (msg[0][i].msg_style) {
     case PAM_PROMPT_ECHO_ON:
       pr_trace_msg(trace_channel, 9, "received PAM_PROMPT_ECHO_ON message");
 
@@ -131,9 +131,9 @@ static int pam_exchange(int num_msg, PR_PAM_CONST struct pam_message **msg,
     case PAM_RADIO_TYPE:
 #endif /* PAM_RADIO_TYPE */
       pr_trace_msg(trace_channel, 9, "received %s response: %s",
-        msg[i]->msg_style == PAM_TEXT_INFO ? "PAM_TEXT_INFO" :
-          msg[i]->msg_style == PAM_ERROR_MSG ? "PAM_ERROR_MSG" :
-          "PAM_RADIO_TYPE", msg[i]->msg);
+        msg[0][i].msg_style == PAM_TEXT_INFO ? "PAM_TEXT_INFO" :
+          msg[0][i].msg_style == PAM_ERROR_MSG ? "PAM_ERROR_MSG" :
+          "PAM_RADIO_TYPE", msg[0][i].msg);
 
       /* Ignore it, but pam still wants a NULL response... */
       response[i].resp = NULL;


### PR DESCRIPTION
The patch fixes panic with stack as follows:
```
018-07-26 12:55:49,134 ST025 proftpd[2319] ST025 (ST025[::1]): -----BEGIN STACK TRACE-----
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [0] /usr/lib/inet/proftpd'pam_exchange+0x64 [0x5450d4]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [1] /lib/amd64/libc.so.1'call_user_handler+0x2f1 [0x7fb992640b51]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [2] /usr/lib/inet/proftpd'pam_exchange+0x64 [0x5450d4]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [3] /lib/amd64/libpam.so.1'do_conv+0x10c [0x7fb992a0983c]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [4] /lib/amd64/libpam.so.1'__pam_display_msg+0x1f [0x7fb992a099ff]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [5] /usr/lib/security/amd64/pam_dhkeys.so.1'remove_key+0x119 [0x7fb98da03029]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [6] /usr/lib/security/amd64/pam_dhkeys.so.1'pam_sm_setcred+0x1b3 [0x7fb98da03363]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [7] /lib/amd64/libpam.so.1'run_stack+0x670 [0x7fb992a06720]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [8] /lib/amd64/libpam.so.1'pam_setcred+0x37 [0x7fb992a06a67]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [9] /usr/lib/inet/proftpd'auth_pam_exit_ev+0x53 [0x545303]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [10] /usr/lib/inet/proftpd'pr_event_generate+0x1c7 [0x4ed6f7]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [11] /usr/lib/inet/proftpd'sess_cleanup+0x118 [0x4eea58]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [12] /usr/lib/inet/proftpd'pr_session_disconnect+0x61 [0x4eecb1]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [13] /usr/lib/inet/proftpd'core_log_quit+0x20 [0x501dd0]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [14] /usr/lib/inet/proftpd'pr_module_call+0x5f [0x4ceabf]
2018-07-26 12:55:49,135 ST025 proftpd[2319] ST025 (ST025[::1]): [15] /usr/lib/inet/proftpd'_dispatch+0x493 [0x496a73]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [16] /usr/lib/inet/proftpd'pr_cmd_dispatch_phase+0x49f [0x49772f]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [17] /usr/lib/inet/proftpd'cmd_loop+0x77f [0x49800f]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [18] /usr/lib/inet/proftpd'fork_server+0x632 [0x498a92]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [19] /usr/lib/inet/proftpd'daemon_loop+0x4e7 [0x499677]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [20] /usr/lib/inet/proftpd'main+0x716 [0x49a5b6]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): [21] /usr/lib/inet/proftpd'0x95ff4 [0x495ff4]
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): -----END STACK TRACE-----
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): ProFTPD terminating (signal 11)
2018-07-26 12:55:49,136 ST025 proftpd[2319] ST025 (ST025[::1]): FTP session closed.
```
The client session dies at `pam_exchange()` function at line 109:
```
103     return PAM_CONV_ERR;
104   }
105 
106   for (i = 0; i < num_msg; i++) {
107     response[i].resp_retcode = 0; /* PAM_SUCCESS; */
108 
109     switch (msg[i]->msg_style) {
110     case PAM_PROMPT_ECHO_ON:
111       pr_trace_msg(trace_channel, 9, "received PAM_PROMPT_ECHO_ON message");
112 
113       /* PAM frees response and resp.  If you don't believe this, please read
114        * the actual PAM RFCs as well as have a good look at libpam.
115        */
116       response[i].resp = pam_user ? strdup(pam_user) : NULL;
117       break;
118 
119     case PAM_PROMPT_ECHO_OFF:
```
The panic happens when root user logs off. The proftpd.conf is as follows:
```
ServerName                      "FTP server"
ServerIdent                     off
ServerType                      standalone
DefaultServer                   on
Port                            21

Umask                           022

# To prevent DoS attacks, set the maximum number of child processes
# to 30.  If you need to allow more than 30 concurrent connections
# at once, simply increase this value.  Note that this ONLY works
# in standalone mode, in inetd mode you should use an inetd server
# that allows you to limit maximum number of processes per service
# (such as xinetd).
MaxInstances                    30

# Set the user and group under which the server will run.
User                            ftp
Group                           ftp

# Normally, we want files to be overwriteable.
AllowOverwrite          on

# Bar use of SITE CHMOD by default.
<Limit SITE_CHMOD>
  DenyAll
</Limit>

# Make PAM the final authority on what gets authenticated.
AuthOrder mod_auth_pam.c* mod_auth_unix.c

# Use system libraries for user lookups.
PersistentPasswd off

# Root login must be enabled explicitly. It is not permitted by default.
# Allow it only if you know what you are doing.
#RootLogin on

DisplayConnect          /etc/issue

SyslogLevel     debug
DebugLevel      10
ExtendedLog     /var/tmp/ftp.logs/ftp.log
ServerLog       /var/tmp/ftp.logs/ftp.foo

RootLogin       on
```
It's 1.3.6 server with configuration as follows:
```
root@ST025:/usr/lib/inet# /usr/lib/inet/proftpd -V                                                                                                                                                                       [16/1930]
Compile-time Settings:
  Version: 1.3.6 (stable)
  Platform: SOLARIS2 (SOLARIS2_11) [SunOS 5.11 i86pc]
  Built: Thu Jul 26 2018 08:54:26 PDT
  Built With:
    configure  '--prefix=/usr' '--mandir=/usr/share/man' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--libdir=/usr/lib/amd64' 'install_user=anedvedi' 'install_group=staff' '--sysconfdir=/etc' '--localstatedir=/var/run' '--libe$
ecdir=/usr/lib/proftpd/amd64' '--enable-ipv6' '--enable-ctrls' '--enable-facl' '--enable-nls' '--enable-dso' '--enable-openssl' '--enable-tests' '--disable-static' '--with-modules=mod_solaris_audit:mod_solaris_priv' '--with-s$
ared=mod_facl:mod_wrap:mod_tls:mod_tls-fips-140:mod_auth_gss:mod_gss' '--enable-buffer-size=16384' 'FIPS_CPPFLAGS=-I/usr/include/openssl/fips-140' 'FIPS_LDFLAGS=-R/lib/openssl/fips-140/64' 'CC=/opt/solarisstudio12.4/bin/cc' '$
FLAGS=-m64 -xO4 -xchip=generic -Ui386 -U__i386 -xregs=no%frameptr -mt -I/usr/include/kerberosv5 -DHAVE_KRB5_H=1 -DKRB5_DLLIMP= -DHAVE__GETGRPSBYMEMBER -D_SOLARIS_DTRACE' 'LDFLAGS=-m64 -z now -z guidance=nolazyload -z nolazylo$
d -lbsm' 'CPPFLAGS=-m64' 'CXX=/opt/solarisstudio12.4/bin/CC' 'CXXFLAGS=-norunpath -m64 -xO4 -xchip=generic -Ui386 -U__i386 -xregs=no%frameptr'

  CFLAGS: -m64 -xO4 -xchip=generic -Ui386 -U__i386 -xregs=no%frameptr -mt -I/usr/include/kerberosv5 -DHAVE_KRB5_H=1 -DKRB5_DLLIMP= -DHAVE__GETGRPSBYMEMBER -D_SOLARIS_DTRACE
  LDFLAGS: -L$(top_srcdir)/lib -m64 -z now -z guidance=nolazyload -z nolazyload -lbsm 
  LIBS: -lsec -lintl  -lssl -lcrypto -lpam -lsupp 

  Files:
    Configuration File:
      /etc/proftpd.conf
    Pid File:
      /var/run/proftpd.pid
    Scoreboard File:
      /var/run/proftpd.scoreboard
    Header Directory:
      /usr/include/proftpd
    Shared Module Directory:
      /usr/lib/proftpd/amd64

  Info:
    + Max supported UID: 4294967295
    + Max supported GID: 4294967295

  Features:
    - Autoshadow support
    + Controls support
    + curses support
    - Developer support
    + DSO support
    + IPv6 support
    + Largefile support
    - Lastlog support
    - Memcache support
    - ncurses support
    + NLS support
    - Redis support
    - Sodium support
    + OpenSSL support
    - PCRE support
    + POSIX ACL support
    + Shadow file support
    + Sendfile support
    + Trace support
    - xattr support

  Tunable Options:
    PR_TUNABLE_BUFFER_SIZE = 16384
    PR_TUNABLE_DEFAULT_RCVBUFSZ = 8192
    PR_TUNABLE_DEFAULT_SNDBUFSZ = 8192
    PR_TUNABLE_ENV_MAX = 2048
    PR_TUNABLE_GLOBBING_MAX_MATCHES = 100000
    PR_TUNABLE_GLOBBING_MAX_RECURSION = 8
    PR_TUNABLE_HASH_TABLE_SIZE = 40
    PR_TUNABLE_LOGIN_MAX = 256
    PR_TUNABLE_NEW_POOL_SIZE = 512
    PR_TUNABLE_PATH_MAX = 1024
    PR_TUNABLE_SCOREBOARD_BUFFER_SIZE = 80
    PR_TUNABLE_SCOREBOARD_SCRUB_TIMER = 30
    PR_TUNABLE_SELECT_TIMEOUT = 30
    PR_TUNABLE_TIMEOUTIDENT = 10
    PR_TUNABLE_TIMEOUTIDLE = 600
    PR_TUNABLE_TIMEOUTLINGER = 10
    PR_TUNABLE_TIMEOUTLOGIN = 300
    PR_TUNABLE_TIMEOUTNOXFER = 300
    PR_TUNABLE_TIMEOUTSTALLED = 3600
    PR_TUNABLE_XFER_SCOREBOARD_UPDATES = 10
```

I'm still investigating a true culprit of this, which sent the
malformed message down the pam-stack. But I think it never
hurts to make code a fault resistant.