### PR TITLE
- introducing session.priv_aware, a SOALRIS2 specific flag

### DIFF
--- a/include/proftpd.h
+++ b/include/proftpd.h
@@ -100,6 +100,9 @@ typedef struct {
    */
 
   int disable_id_switching;		/* Disable UID/GID switching */
+#ifdef SOLARIS2
+  int priv_aware;			/* process posses all privs it needs */
+#endif /* SOLARIS2 */
   uid_t uid, ouid;                      /* Current and original UIDs */
   gid_t gid;                            /* Current GID */
 

--- a/src/privs.c
+++ b/src/privs.c
@@ -185,7 +185,11 @@ int pr_privs_root(const char *file, int lineno) {
 
   pr_signals_block();
 
+#ifdef SOLARIS2
+  if (!session.disable_id_switching && !session.priv_aware) {
+#else
   if (!session.disable_id_switching) {
+#endif
 
 #if defined(HAVE_SETEUID)
     if (seteuid(PR_ROOT_UID) < 0) {
@@ -247,7 +251,12 @@ int pr_privs_user(const char *file, int lineno) {
 
   pr_signals_block();
 
+#ifdef SOLARIS2
+  if (!session.disable_id_switching && !session.priv_aware) {
+#else
   if (!session.disable_id_switching) {
+#endif
+
 #if defined(HAVE_SETEUID)
     if (seteuid(PR_ROOT_UID) < 0) {
       int priority = (errno == EPERM ? PR_LOG_NOTICE : PR_LOG_ERR);
@@ -335,7 +344,12 @@ int pr_privs_relinquish(const char *file, int lineno) {
 
   pr_signals_block();
 
+#ifdef SOLARIS2
+  if (!session.disable_id_switching && !session.priv_aware) {
+#else
   if (!session.disable_id_switching) {
+#endif
+
 #if defined(HAVE_SETEUID)
     if (geteuid() != PR_ROOT_UID) {
       if (seteuid(PR_ROOT_UID) < 0) {


### PR DESCRIPTION
Proftpd always runs as [privilege aware process](http://www.oracle.com/technetwork/server-storage/solaris/program-privileges-136378.html). Our custom [mod_solaris_priv.c ](https://github.com/syoyo/oi-build/blob/master/components/proftpd/mod_solaris_priv.c) [always drops](http://www.oracle.com/technetwork/server-storage/solaris/program-privileges-136378.html) 'traditional' unix privileges for every session process. The link goes to indiana, but module is same for recent solaris. It might be possible to download it from Oracle either [here](http://download.oracle.com/otn-pub/oss/solaris/sol-11_4-beta-opensource_1.zip) or [here](http://download.oracle.com/otn-pub/oss/solaris/sol-11_4-beta-opensource_2.zip). Both are large files. To be honest I don't know which .zip contains proftpd.

Anyway as soon as mod_solaris_priv.c drops privs by calling `setreuid(session.uid, session.uid)` there is no way for process to gain a `root` back on Solaris, although
we set `session.disable_id_switching` to TRUE, the [mod_auth_pam](https://github.com/proftpd/proftpd/blob/bb43bb9cac4cac06517e61eb777b4c2c766ca70c/modules/mod_auth_pam.c#L189) plugin overrides our setting. In case of Solaris it creates extra noise in logs, which is annoying:
```
Jul 20 09:01:21 ... proftpd[4382]: ... (localhost[::1]) - ROOT PRIVS:
unable to seteuid(): Not owner
Jul 20 09:01:21 ... proftpd[4382]: ... (localhost[::1]) - ROOT PRIVS:
unable to setegid(): Not owner
Jul 20 09:01:21 ... proftpd[4382]: ... (localhost[::1]) - RELINQUISH PRIVS:
unable to seteuid(PR_ROOT_UID): Not owner
``` 

The proposed a fix introduces yet another flag to `session`. The flag `priv_aware` is specific for Solaris and has the same effect as the existing flag `disable_id_switching`. The pull request is just suggestion. I will be glad for any other alternative approach we might take on Solaris.