### PR TITLE
let proftpd to drop core, when it dies because of segfault

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -113,7 +113,7 @@ void pr_session_disconnect(module *m, int reason_code,
   }
 
   if (reason_code == PR_SESS_DISCONNECT_SEGFAULT) {
-    flags |= PR_SESS_END_FL_ERROR;
+    flags |= PR_SESS_END_FL_NOEXIT;
   }
 
   pr_session_end(flags);


### PR DESCRIPTION
The Stack Trace we get from customers is not that helpful sometimes.
We would like our customers to send us also a core file from dying
process. Unfortunately the proftpd is not allwed to drop the core.
Not sure if it is a bug or intention, hence I'm sending a patch,
which prevents proftpd dying on SigSegv to call exit(3C).