### PR TITLE
Support for masquerade ip for data connections and set client ip for ignore masquerade.

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -3827,7 +3827,6 @@ MODRET core_pasv(cmd_rec *cmd) {
         }
       }
     }
-
   } else {
     c = find_config(main_server->conf, CONF_PARAM, "MasqueradeAddress", FALSE);
     if (c != NULL) {
@@ -3838,9 +3837,11 @@ MODRET core_pasv(cmd_rec *cmd) {
   }
 
   /* Fixup the address string for the PASV response. */
-  tmp = strrchr(addrstr, ':');
-  if (tmp) {
-    addrstr = tmp + 1;
+  if (addrstr != NULL) {
+    tmp = strrchr(addrstr, ':');
+    if (tmp) {
+      addrstr = tmp + 1;
+    }
   }
 
   /* If we already have a passive listen data connection open, kill it. */
@@ -3967,9 +3968,14 @@ MODRET core_pasv(cmd_rec *cmd) {
 
   if (addrstr == NULL) {
     addrstr = (char *) pr_netaddr_get_ipstr(session.d->local_addr);
+
+    /* Fixup the address string for the PASV response. */
+    tmp = strrchr(addrstr, ':');
+    if (tmp) {
+      addrstr = tmp + 1;
+    }
   }
 
-  /* Fixup the address string for the PASV response. */
   for (tmp = addrstr; *tmp; tmp++) {
     if (*tmp == '.') {
       *tmp = ',';


### PR DESCRIPTION
This PR wrote for allow you to change the LISTEN IP for actual data access when setting masquerade.

For example, if the proftpd server has more than two IPs(public / private), the data channel may be waiting in same IP about communication channel connected.

This is true even if you have set MasqueradeAddress.
So if servers has several IPs, you will need a separate settings(DNAT or something).

Also, some clients need to ignore the MasqeradeAddress setting due to internal requirements.

Therefore, this PR allows to modify the Data LISTEN IP to MasqeradeAddress and set the client IP(or CIDR band) to ignore MasqeradeAddress.