### PR TITLE
Generate an event when clients disconnect explicitly

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -3634,6 +3634,11 @@ MODRET core_quit(cmd_rec *cmd) {
    * the session.
    */
 
+  /* This event allows modules to distinguish between a client
+   * using QUIT, and one being disconnected for any reason whatsoever.
+   */
+  pr_event_generate("core.quit", NULL);
+
   return PR_HANDLED(cmd);
 }
 


### PR DESCRIPTION
This allows to distinguish clients exiting normally from all other
disconnections. This can be useful for external modules.

Fixes #777