### PR TITLE
fstat cache prevents proper symlink resolution

### DIFF
--- a/src/fsio.c
+++ b/src/fsio.c
@@ -3045,7 +3045,8 @@ int pr_fs_resolve_path(const char *path, char *buf, size_t buflen, int op) {
 
       fs = lookup_dir_fs(namebuf, op);
 
-      if (fs_cache_lstat(fs, namebuf, &sbuf) == -1) {
+      if ((fs_cache_lstat(fs, namebuf, &sbuf) == -1) ||
+        (fs_cache_stat(fs, namebuf, &sbuf) == -1)) {
         errno = ENOENT;
         return -1;
       }


### PR DESCRIPTION
one of our customer hit strange behavior when it comes to symlinks.
the steps to reproduce the issue are as follows:

	mkdir /foo
	ln -s /foo /foo2
	chmod 0777 /foo
	svcadm enable ftp

now let's connect to ftp server (e.g. 'ftp localhost') and issue commands
as follows:
	Connected to _IP_SERVER_A.
	220 ::ffff:_IP_SERVER_A FTP server ready
	Name (_IP_SERVER_A:userfoo): userfoo
	331 Password required for userfoo
	Password:
	230 User userfoo logged in
	Remote system type is UNIX.
	Using binary mode to transfer files.
	ftp> mkdir /foo2/foofoofoo
	257 "/foo2/foofoofoo" - Directory successfully created
	ftp> cd /foo2/foofoofoo
	550 /foo2/foofoofoo: No such file or directory
	ftp> quit

however re-connecting to server, everything seems to work as
expected:
	root@atenea:~# ftp _IP_SERVER_A
	Connected to _IP_SERVER_A.
	220 ::ffff:_IP_SERVER_A FTP server ready
	Name (_IP_SERVER_A:userfoo):
	331 Password required for userfoo
	Password:
	230 User userfoo logged in
	Remote system type is UNIX.
	Using binary mode to transfer files.
	ftp> cd /foo2/foofoofoo
	250 CWD command successful
	ftp> quit
	221 Goodbye.

The issue impacts symbolic links only ('/foo2') in this case.
Applying similar steps to '/foo' directory always works.

The oneliner in this pull request fixes the issue, however I'm
not sure whether the fix is correct.