### PR TITLE
Bug #4350: Implement a variant of the SFTP Message API for reading da…

### DIFF
--- a/contrib/mod_sftp/keys.c
+++ b/contrib/mod_sftp/keys.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp key mgmt (keys)
- * Copyright (c) 2008-2018 TJ Saunders
+ * Copyright (c) 2008-2019 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -837,9 +837,15 @@ static int has_req_perms(int fd, const char *path) {
 static EVP_PKEY *get_pkey_from_data(pool *p, unsigned char *pkey_data,
     uint32_t pkey_datalen) {
   EVP_PKEY *pkey = NULL;
-  char *pkey_type;
+  char *pkey_type = NULL;
+  uint32_t len;
 
-  pkey_type = sftp_msg_read_string(p, &pkey_data, &pkey_datalen);
+  len = sftp_msg_read_string2(p, &pkey_data, &pkey_datalen, &pkey_type);
+  if (len == 0) {
+    (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+      "error reading key: invalid/unsupported key format");
+    return NULL;
+  }
 
   if (strncmp(pkey_type, "ssh-rsa", 8) == 0) {
     RSA *rsa;
@@ -860,8 +866,23 @@ static EVP_PKEY *get_pkey_from_data(pool *p, unsigned char *pkey_data,
       return NULL;
     }
 
-    rsa_e = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
-    rsa_n = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &rsa_e);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      RSA_free(rsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
+
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &rsa_n);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      RSA_free(rsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
@@ -899,10 +920,41 @@ static EVP_PKEY *get_pkey_from_data(pool *p, unsigned char *pkey_data,
       return NULL;
     }
 
-    dsa_p = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
-    dsa_q = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
-    dsa_g = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
-    dsa_pub_key = sftp_msg_read_mpint(p, &pkey_data, &pkey_datalen);
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &dsa_p);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      DSA_free(dsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
+
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &dsa_q);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      DSA_free(dsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
+
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &dsa_g);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      DSA_free(dsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
+
+    len = sftp_msg_read_mpint2(p, &pkey_data, &pkey_datalen, &dsa_pub_key);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      DSA_free(dsa);
+      EVP_PKEY_free(pkey);
+      return NULL;
+    }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
@@ -938,8 +990,16 @@ static EVP_PKEY *get_pkey_from_data(pool *p, unsigned char *pkey_data,
     const EC_GROUP *curve;
     EC_POINT *point;
     int ec_nid;
+    char *ptr = NULL;
 
-    curve_name = sftp_msg_read_string(p, &pkey_data, &pkey_datalen);
+    len = sftp_msg_read_string2(p, &pkey_data, &pkey_datalen, &ptr);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      return NULL;
+    }
+
+    curve_name = (const char *) ptr;
 
     /* If the curve name does not match the last 8 characters of the
      * public key type (which, in the case of ECDSA keys, contains the
@@ -984,7 +1044,14 @@ static EVP_PKEY *get_pkey_from_data(pool *p, unsigned char *pkey_data,
       return NULL;
     }
 
-    point = sftp_msg_read_ecpoint(p, &pkey_data, &pkey_datalen, curve, point);
+    len = sftp_msg_read_ecpoint2(p, &pkey_data, &pkey_datalen, curve, &point);
+    if (len == 0) {
+      (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
+        "error reading key: invalid/unsupported key format");
+      EC_KEY_free(ec);
+      return NULL;
+    }
+
     if (point == NULL) {
       (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
         "error reading EC_POINT from public key data: %s", strerror(errno));
@@ -3134,7 +3201,7 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
 #endif /* prior to OpenSSL-1.1.0 */
   EVP_MD_CTX *pctx;
   unsigned char *sig;
-  uint32_t sig_len;
+  uint32_t len, sig_len;
   unsigned char digest[EVP_MAX_MD_SIZE];
   char *sig_type;
   unsigned int digestlen = 0;
@@ -3156,7 +3223,11 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
 
   if (strncmp(pubkey_algo, "ssh-dss", 8) == 0) {
     if (sftp_interop_supports_feature(SFTP_SSH2_FEAT_HAVE_PUBKEY_ALGO_IN_DSA_SIG)) {
-      sig_type = sftp_msg_read_string(p, &signature, &signaturelen);
+      len = sftp_msg_read_string2(p, &signature, &signaturelen, &sig_type);
+      if (len == 0) {
+        errno = EINVAL;
+        return -1;
+      }
 
     } else {
       /* The client did not prepend the public key algorithm name to their
@@ -3170,13 +3241,26 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
     }
 
   } else {
-    sig_type = sftp_msg_read_string(p, &signature, &signaturelen);
+    len = sftp_msg_read_string2(p, &signature, &signaturelen, &sig_type);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
   }
 
   if (strncmp(sig_type, "ssh-rsa", 8) == 0) {
-    sig_len = sftp_msg_read_int(p, &signature, &signaturelen);
-    sig = (unsigned char *) sftp_msg_read_data(p, &signature, &signaturelen,
-      sig_len);
+    len = sftp_msg_read_int2(p, &signature, &signaturelen, &sig_len);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
+    len = sftp_msg_read_data2(p, &signature, &signaturelen, sig_len, &sig);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
     if (sig != NULL) {
       RSA *rsa;
       unsigned int modulus_len;
@@ -3271,7 +3355,11 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
 
 #if !defined(OPENSSL_NO_DSA)
   } else if (strncmp(sig_type, "ssh-dss", 8) == 0) {
-    sig_len = sftp_msg_read_int(p, &signature, &signaturelen);
+    len = sftp_msg_read_int2(p, &signature, &signaturelen, &sig_len);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
 
     /* A DSA signature string is composed of 2 20 character parts. */
     if (sig_len != 40) {
@@ -3279,8 +3367,12 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
         "bad DSA signature len (%lu)", (unsigned long) sig_len);
     }
 
-    sig = (unsigned char *) sftp_msg_read_data(p, &signature, &signaturelen,
-      sig_len);
+    len = sftp_msg_read_data2(p, &signature, &signaturelen, sig_len, &sig);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
     if (sig != NULL) {
       DSA *dsa;
       DSA_SIG *dsa_sig;
@@ -3407,9 +3499,18 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
       }
     }
 
-    sig_len = sftp_msg_read_int(p, &signature, &signaturelen);
-    sig = (unsigned char *) sftp_msg_read_data(p, &signature, &signaturelen,
-      sig_len);
+    len = sftp_msg_read_int2(p, &signature, &signaturelen, &sig_len);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
+    len = sftp_msg_read_data2(p, &signature, &signaturelen, sig_len, &sig);
+    if (len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
     if (sig != NULL) {
       EC_KEY *ec;
       ECDSA_SIG *ecdsa_sig;
@@ -3432,7 +3533,13 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
       sig_s = ecdsa_sig->s;
 #endif /* prior to OpenSSL-1.1.0 */
 
-      sig_r = sftp_msg_read_mpint(p, &sig, &sig_len);
+      len = sftp_msg_read_mpint2(p, &sig, &sig_len, &sig_r);
+      if (len == 0) {
+        ECDSA_SIG_free(ecdsa_sig);
+        errno = EINVAL;
+        return -1;
+      }
+
       if (sig_r == NULL) {
         (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
           "error reading 'r' ECDSA signature component: %s",
@@ -3441,7 +3548,13 @@ int sftp_keys_verify_signed_data(pool *p, const char *pubkey_algo,
         return -1;
       }
 
-      sig_s = sftp_msg_read_mpint(p, &sig, &sig_len);
+      len = sftp_msg_read_mpint2(p, &sig, &sig_len, &sig_s);
+      if (len == 0) {
+        ECDSA_SIG_free(ecdsa_sig);
+        errno = EINVAL;
+        return -1;
+      }
+
       if (sig_s == NULL) {
         (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
           "error reading 's' ECDSA signature component: %s",

--- a/contrib/mod_sftp/msg.h
+++ b/contrib/mod_sftp/msg.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp message format
- * Copyright (c) 2008-2016 TJ Saunders
+ * Copyright (c) 2008-2019 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +38,22 @@ uint32_t sftp_msg_read_int(pool *, unsigned char **, uint32_t *);
 uint64_t sftp_msg_read_long(pool *, unsigned char **, uint32_t *);
 BIGNUM *sftp_msg_read_mpint(pool *, unsigned char **, uint32_t *);
 char *sftp_msg_read_string(pool *, unsigned char **, uint32_t *);
+
+/* Variant of the Message Read API whose return value indicates the number
+ * of bytes of the message actually read.  A zero-length return value indicates
+ * failure to read the requested data type.
+ */
+uint32_t sftp_msg_read_byte2(pool *, unsigned char **, uint32_t *, char *);
+uint32_t sftp_msg_read_bool2(pool *, unsigned char **, uint32_t *, int *);
+uint32_t sftp_msg_read_data2(pool *, unsigned char **, uint32_t *, size_t, unsigned char **);
+#ifdef PR_USE_OPENSSL_ECC
+uint32_t sftp_msg_read_ecpoint2(pool *, unsigned char **, uint32_t *,
+  const EC_GROUP *, EC_POINT **);
+#endif /* PR_USE_OPENSSL_ECC */
+uint32_t sftp_msg_read_int2(pool *, unsigned char **, uint32_t *, uint32_t *);
+uint32_t sftp_msg_read_long2(pool *, unsigned char **, uint32_t *, uint64_t *);
+uint32_t sftp_msg_read_mpint2(pool *, unsigned char **, uint32_t *, BIGNUM **);
+uint32_t sftp_msg_read_string2(pool *, unsigned char **, uint32_t *, char **);
 
 uint32_t sftp_msg_write_byte(unsigned char **, uint32_t *, char);
 uint32_t sftp_msg_write_bool(unsigned char **, uint32_t *, char);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
@@ -77,6 +77,11 @@ my $TESTS = {
     test_class => [qw(bug forking ssh2)],
   },
 
+  ssh2_auth_publickey_rsa_sql_invalid_format_bug4350 => {
+    order => ++$order,
+    test_class => [qw(bug forking ssh2)],
+  },
+
 };
 
 sub new {
@@ -107,7 +112,10 @@ sub list_tests {
     }
   }
 
-  return testsuite_get_runnable_tests($TESTS);
+#  return testsuite_get_runnable_tests($TESTS);
+  return qw(
+    ssh2_auth_publickey_rsa_sql_invalid_format_bug4350
+  );
 }
 
 sub set_up {
@@ -2373,6 +2381,179 @@ EOS
       unless ($ssh2->auth_publickey($user, $rsa_pub_key, $rsa_priv_key)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("RSA publickey authentication failed: [$err_name] ($err_code) $err_str");
+      }
+
+      $ssh2->disconnect();
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($config_file, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($pid_file);
+
+  $self->assert_child_ok($pid);
+
+  if ($ex) {
+    test_append_logfile($log_file, $ex);
+    unlink($log_file);
+
+    die($ex);
+  }
+
+  unlink($log_file, $db_file);
+}
+
+sub ssh2_auth_publickey_rsa_sql_invalid_format_bug4350 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  my $config_file = "$tmpdir/sftp.conf";
+  my $pid_file = File::Spec->rel2abs("$tmpdir/sftp.pid");
+  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/sftp.scoreboard");
+
+  my $log_file = test_get_logfile();
+
+  my $auth_user_file = File::Spec->rel2abs("$tmpdir/sftp.passwd");
+  my $auth_group_file = File::Spec->rel2abs("$tmpdir/sftp.group");
+
+  my $user = 'proftpd';
+  my $passwd = 'test';
+  my $group = 'ftpd';
+  my $home_dir = File::Spec->rel2abs($tmpdir);
+  my $uid = 500;
+  my $gid = 500;
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/sftp.db");
+
+  my $rsa_data = 'foobar';
+  my $db_script = File::Spec->rel2abs("$tmpdir/sftp.sql");
+
+  my $fh;
+  if (open($fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE sftpuserkeys (
+  name TEXT NOT NULL PRIMARY KEY,
+  key BLOB NOT NULL
+);
+
+INSERT INTO sftpuserkeys (name, key) VALUES ('$user', '$rsa_data');
+EOS
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  if ($ENV{TEST_VERBOSE}) {
+    print STDERR "Executing sqlite3: $cmd\n";
+  }
+
+  my @output = `$cmd`;
+
+  unlink($db_script);
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $home_dir)) {
+      die("Can't set perms on $home_dir to 0755: $!");
+    }
+
+    unless (chown($uid, $gid, $home_dir)) {
+      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    }
+  }
+
+  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
+    '/bin/bash');
+  auth_group_write($auth_group_file, $group, $gid, $user);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
+
+  my $rsa_priv_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key_bug4155');
+  my $rsa_pub_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key_bug4155.pub');
+
+  my $config = {
+    PidFile => $pid_file,
+    ScoreboardFile => $scoreboard_file,
+    SystemLog => $log_file,
+    TraceLog => $log_file,
+    Trace => 'DEFAULT:10 ssh2:20 sftp:20 scp:20',
+
+    AuthUserFile => $auth_user_file,
+    AuthGroupFile => $auth_group_file,
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sql_sqlite.c' => {
+        SQLAuthenticate => 'off',
+        SQLConnectInfo => $db_file,
+        SQLLogFile => $log_file,
+        SQLNamedQuery => 'get-user-authorized-keys SELECT "key FROM sftpuserkeys WHERE name = \'%{0}\'"',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $log_file",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+        "SFTPAuthorizedUserKeys sql:/get-user-authorized-keys",
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::SSH2;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $ssh2 = Net::SSH2->new();
+
+      sleep(1);
+
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      if ($ssh2->auth_publickey($user, $rsa_pub_key, $rsa_priv_key)) {
+        die("RSA publickey authentication succeeded unexpectedly");
       }
 
       $ssh2->disconnect();


### PR DESCRIPTION
…ta types

with better error reporting.

This API variant is then used when reading public key data, as during user
publickey authentication, for better logging and error handling when the
provided key data are invalid.