### PR TITLE
Fix -- AIX mod_sftp unsuccessful login count problems #693

### DIFF
--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -1433,7 +1433,9 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
 
     pr_response_add_err(R_530, "Login incorrect.");
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
-    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+    if (res < 0) {
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+    }
     pr_response_clear(&resp_err_list);
 
     pr_cmd_dispatch_phase(cmd, res == 0 ? POST_CMD : POST_CMD_ERR, 0);

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -344,7 +344,7 @@ static int do_auth(pool *p, xaset_t *conf, const char *u, char *pw) {
 /* Command handlers
  */
 
-static void login_failed(pool *p, const char *user) {
+void login_failed(pool *p, const char *user) {
 #ifdef HAVE_LOGINFAILED
   const char *host, *sess_ttyname;
   int res, xerrno;
@@ -407,7 +407,7 @@ MODRET auth_log_pass(cmd_rec *cmd) {
   return PR_DECLINED(cmd);
 }
 
-static void login_succeeded(pool *p, const char *user) {
+void login_succeeded(pool *p, const char *user) {
 #ifdef HAVE_LOGINSUCCESS
   const char *host, *sess_ttyname;
   char *msg = NULL;


### PR DESCRIPTION
This is a proposed fix for  [Issue #693](https://github.com/proftpd/proftpd/issues/693)   
mod_auth_unix.c is modified to call login_succeeded() or login_failed() right after the call to authenticate(), before PRIVS_ROOT.

mod_sftp/auth.c is modified to make call of pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0) conditional, so that it is not called for each attempt to find a client identity file.