### PR TITLE
Fix -- AIX mod_sftp unsuccessful login count problems #693

### DIFF
--- a/contrib/mod_sftp/auth-password.c
+++ b/contrib/mod_sftp/auth-password.c
@@ -173,6 +173,9 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         user);
       *send_userauth_fail = TRUE;
       errno = EINVAL;
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
       return 0;
 
     case PR_AUTH_AGEPWD:

--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -1433,7 +1433,9 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
 
     pr_response_add_err(R_530, "Login incorrect.");
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
-    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+    if (res < 0) {
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+    }
     pr_response_clear(&resp_err_list);
 
     pr_cmd_dispatch_phase(cmd, res == 0 ? POST_CMD : POST_CMD_ERR, 0);

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -344,7 +344,7 @@ static int do_auth(pool *p, xaset_t *conf, const char *u, char *pw) {
 /* Command handlers
  */
 
-static void login_failed(pool *p, const char *user) {
+void login_failed(pool *p, const char *user) {
 #ifdef HAVE_LOGINFAILED
   const char *host, *sess_ttyname;
   int res, xerrno;
@@ -407,7 +407,7 @@ MODRET auth_log_pass(cmd_rec *cmd) {
   return PR_DECLINED(cmd);
 }
 
-static void login_succeeded(pool *p, const char *user) {
+void login_succeeded(pool *p, const char *user) {
 #ifdef HAVE_LOGINSUCCESS
   const char *host, *sess_ttyname;
   char *msg = NULL;

--- a/modules/mod_auth_unix.c
+++ b/modules/mod_auth_unix.c
@@ -114,7 +114,6 @@ static FILE *grpf = NULL;
 static int unix_persistent_passwd = FALSE;
 static const char *trace_channel = "auth.unix";
 
-void login_failed(pool *, const char *);
 void login_succeded(pool *, const char *);
 
 #undef PASSWD
@@ -1011,8 +1010,6 @@ MODRET pw_check(cmd_rec *cmd) {
     } while (reenter != 0);
     if (res == 0) {
       login_succeeded(cmd->tmp_pool, user);
-    } else {
-      login_failed(cmd->tmp_pool, user);
     }
     PRIVS_RELINQUISH
 

--- a/modules/mod_auth_unix.c
+++ b/modules/mod_auth_unix.c
@@ -35,10 +35,6 @@
 # include <crypt.h>
 #endif
 
-#ifdef HAVE_SYS_AUDIT_H
-# include <sys/audit.h>
-#endif
-
 #ifdef PR_USE_SHADOW
 # ifdef HAVE_SHADOW_H
 #   include <shadow.h>


### PR DESCRIPTION
This is a proposed fix for [Issue #693](https://github.com/proftpd/proftpd/issues/693)
mod_auth_unix.c is modified to call login_succeeded() right after the call to authenticate(), before PRIVS_ROOT.

mod_sftp/auth.c is modified to make call of pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0) conditional, so that it is not called for each attempt to find a client identity file.

mod_sftp/auth-passwd.c is modified to add calls when the password is bad to:

      pr_response_add_err(R_501, "Login incorrect.");
      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);

Now, the AIX unsuccessful_login_count is correctly incremented for failed logins using ftps or sftp, and correctly reset to 0 on a successful login using ftps and sftp.