### PR TITLE
mod_sql_mysql: tweak build for mysql-8 ('my_bool' removal)

### DIFF
--- a/contrib/mod_sql_mysql.c
+++ b/contrib/mod_sql_mysql.c
@@ -132,6 +132,7 @@
 #include "../contrib/mod_sql.h"
 
 #include <mysql.h>
+#include <stdbool.h>
 
 /* The my_make_scrambled_password{,_323} functions are not part of the public
  * MySQL API and are not declared in any of the MySQL header files. But the
@@ -496,7 +497,11 @@ MODRET cmd_open(cmd_rec *cmd) {
    *  http://dev.mysql.com/doc/refman/5.0/en/auto-reconnect.html
    */
   if (!(pr_sql_opts & SQL_OPT_NO_RECONNECT)) {
+#if MYSQL_VERSION_ID >= 80000
+    bool reconnect = true;
+#else
     my_bool reconnect = TRUE;
+#endif
     mysql_options(conn->mysql, MYSQL_OPT_RECONNECT, &reconnect);
   }
 #endif


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=85131 removed 'my_bool'
in favour of 'bool' from <stdbool.h> or c++'s 'bool'.

That causes build failure like:

```
mod_sql_mysql.c: In function ‘cmd_open’:
mod_sql_mysql.c:498:5: error: unknown type name ‘my_bool’; did you mean ‘bool’?
  498 |     my_bool reconnect = TRUE;
      |     ^~~~~~~
      |     bool
```

The change adds conditional use of 'bool'/'my_bool' based on 'MYSQL_VERSION_ID'.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/692434
Closes: https://github.com/proftpd/proftpd/issues/824