### PR TITLE
- mod_gss does not compile with IPv6 support. The issue has been

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -50,4 +50,11 @@
 /* The following macros first appeared in 1.3.6rc2. */
 #define _sql_make_cmd			sql_make_cmd
 
+/*
+ * USE_IPV6 is required by mod_gss.
+ */
+#ifdef PR_USE_IPV6
+#define USE_IPV6			1
+#endif
+
 #endif /* PR_COMPAT_H */


### PR DESCRIPTION
  introduced in 1.3.6 release.
another option to fix it is to change mod_gss module, so it will use PR_USE_IPV6
instead of its USE_INET6 guard.