### PR TITLE
configure.in: fix --disable-tests handling

### DIFF
--- a/configure
+++ b/configure
@@ -20860,7 +20860,7 @@ ENABLE_TESTS="\"\""
 # Check whether --enable-tests was given.
 if test "${enable_tests+set}" = set; then
   enableval=$enable_tests;
-    if test "$enableval" != xno ; then
+    if test x"$enableval" != xno ; then
 
 for ac_header in check.h
 do

--- a/configure.in
+++ b/configure.in
@@ -1036,7 +1036,7 @@ AC_ARG_ENABLE(tests,
     [enable unit tests (default=no)])
   ],
   [
-    if test "$enableval" != xno ; then
+    if test x"$enableval" != xno ; then
       AC_CHECK_HEADERS(check.h)
 
       AC_CHECK_LIB(check, tcase_create,


### PR DESCRIPTION
Toralf found out that `./configure --disable-tests` fails configure
phase in an attempt to find `libcheck`:

```
...
checking for check.h... no
checking for tcase_create in -lcheck... no
configure: error: libcheck support, required for tests, not present -- aborting
```

This happens because the condition lost a `x` guard at test site:
    `if test "$enableval" != xno ; then`

The fix is to add missing guard:
    `if test x"$enableval" != xno ; then`

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/697782