### PR TITLE
Issue #750: Fix mod_digest's handling of the `POST_CMD` phase for the…

### DIFF
--- a/contrib/mod_digest.c
+++ b/contrib/mod_digest.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_digest - File hashing/checksumming module
  * Copyright (c) Mathias Berchtold <mb@smartftp.com>
- * Copyright (c) 2016-2018 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2019 TJ Saunders <tj@castaglia.org>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2951,7 +2951,7 @@ static cmdtable digest_cmdtab[] = {
   { CMD, C_XSHA256,	G_READ, digest_xsha256,	TRUE, FALSE, CL_READ|CL_INFO },
   { CMD, C_XSHA512,	G_READ, digest_xsha512,	TRUE, FALSE, CL_READ|CL_INFO },
 
-  { POST_CMD,	C_PASS, G_NONE,	digest_post_pass, TRUE, FALSE },
+  { POST_CMD,	C_PASS, G_NONE,	digest_post_pass, FALSE, FALSE },
 
   /* Command handlers for opportunistic digest computation/caching.
    * Note that we use C_ANY for better interoperability with e.g.


### PR DESCRIPTION
… `PASS`

command.

The command table entry inadvertently had the "requires authentication" flag
set to `TRUE`, which does not make sense for a `POST_CMD` phase handler for
the `PASS` command, at least in the context of an SFTP login.  This would cause
`mod_digest` to effectively short-circuit the further dispatching of the `PASS`
command for that phase.  Due to module load ordering, this means that the
`mod_auth` module would not be called, and thus would not be able to enforce
limits.