### PR TITLE
- PassivePorts option needs same treatment as we got in PR#703

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -633,7 +633,11 @@ conn_t *pr_inet_create_conn_portrange(pool *p, const pr_netaddr_t *bind_addr,
       c = init_conn(p, -1, bind_addr, ports[i], FALSE, FALSE);
 
       if (!c &&
+#ifdef	SOLARIS2
+          (inet_errno != EADDRINUSE && inet_errno != EACCES)) {
+#else	/* !SOLARIS2 */
           inet_errno != EADDRINUSE) {
+#endif	/* SOLARIS2 */
         pr_log_pri(PR_LOG_WARNING, "error initializing connection: %s",
           strerror(inet_errno));
         pr_session_disconnect(NULL, PR_SESS_DISCONNECT_BY_APPLICATION, NULL);


### PR DESCRIPTION
This is a kind of follow up push to earlier change, we shipped in #703 
(EACCESS should be treated as EADDRINUSE on Solaris).