### PR TITLE
Bug #870: Release PAM handler after unsuccessful authentication

### DIFF
--- a/modules/mod_auth_pam.c
+++ b/modules/mod_auth_pam.c
@@ -218,7 +218,7 @@ static void auth_pam_exit_ev(const void *event_data, void *user_data) {
   }
 
   pr_trace_msg(trace_channel, 17, "freeing PAM handle");
-  res = pam_end(pamh, 0);
+  res = pam_end(pamh, PAM_SUCCESS);
   if (res != PAM_SUCCESS) {
     pr_trace_msg(trace_channel, 1, "error freeing PAM handle: %s",
       pam_strerror(pamh, res));
@@ -565,6 +565,18 @@ MODRET pam_auth(cmd_rec *cmd) {
     free(pam_pass);
     pam_pass = NULL;
     pam_pass_len = 0;
+  }
+
+  if (!success) {
+    /* Free pam handle since we will not start user session.  */
+    pr_trace_msg(trace_channel, 17, "freeing PAM handle");
+    res = pam_end(pamh, PAM_AUTH_ERR);
+    if (res != PAM_SUCCESS) {
+      pr_trace_msg(trace_channel, 1, "error freeing PAM handle: %s",
+        pam_strerror(pamh, res));
+    }
+
+    pamh = NULL;
   }
 
   PRIVS_RELINQUISH


### PR DESCRIPTION
Fixes bug #870

- Added mandatory PAM handler releasing after unsuccessful transaction
- Set PAM_SUCCESS and PAM_AUTH_ERR arguments for corresponding `pam_end()` calls instead of magic numbers.