### PR TITLE
- change makes proftpd to comply with RFC 640.

### DIFF
--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -1512,7 +1512,7 @@ MODRET facts_mlsd(cmd_rec *cmd) {
 
     pr_fsio_closedir(dirh);
 
-    pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[0],
+    pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
       strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -1960,7 +1960,7 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
 
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+        pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
           strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
@@ -2203,7 +2203,7 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
 
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0], 
+        pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
           strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
@@ -3104,7 +3104,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
             if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
               int xerrno = errno;
 
-              pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0], 
+              pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
                 strerror(xerrno));
 
               pr_cmd_set_errno(cmd, xerrno);
@@ -3131,7 +3131,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
           if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
             int xerrno = errno;
 
-            pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+            pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
               strerror(xerrno));
 
             pr_cmd_set_errno(cmd, xerrno);
@@ -3157,7 +3157,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
     if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
       int xerrno = errno;
 
-      pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+      pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
         strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
@@ -3250,7 +3250,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
         if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
           xerrno = errno;
 
-          pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+          pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
             strerror(xerrno));
 
           pr_cmd_set_errno(cmd, xerrno);
@@ -3287,7 +3287,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
             if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
               xerrno = errno;
 
-              pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+              pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
                 strerror(xerrno));
 
               pr_cmd_set_errno(cmd, xerrno);
@@ -3328,7 +3328,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
         if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
           xerrno = errno;
 
-          pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+          pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
             strerror(xerrno));
 
           pr_cmd_set_errno(cmd, xerrno);
@@ -3353,7 +3353,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
 
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
+        pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
           strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
@@ -3367,6 +3367,9 @@ MODRET ls_nlst(cmd_rec *cmd) {
     } else if (S_ISDIR(st.st_mode)) {
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
+
+        pr_response_add_err(R_425, "%s: %s", (char *) cmd->argv[0],
+          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;


### PR DESCRIPTION
RFC 640 defines format of multi-line responses. All the foundation
to produce proper multi-line error codes exists already in proftpd
code. The change allows proftpd the right thing.

The RFC 640 defines multi-line responses as follows
'''
       Thus the format for multi-line replies is that the first line
       will begin with the exact required reply code, followed
       immediately by a Hyphen, "-" (also known as Minus), followed
       by text.  The last line will begin with the same code,
       followed immediately by Space <SP>, optionally some text, and
       TELNET <eol>.                                                     10a
    
          For example:
                               123-First line
                               Second line
                                 234 A line beginning with numbers
                               123 The last line                        10a1
    
       The user-process then simply needs to search for the second
       occurrence of the same reply code, followed by <SP> (Space),
       at the beginning of a line, and ignore all intermediary lines.
       If an intermediary line begins with a 3-digit number, the
       Server must pad the front to avoid confusion.                     10b
'''

`proftpd` server deviates from standard, when it fails to open
data connection back to client, when handling `LIST` command.
In this case the command gets dispatched to `mod_ls` module,
which calls `pr_data_open()`. If function fails it puts `425` error
code to the list and returning back to caller. The caller handles
the same error, however with different error code (`450`). The
mod_ls module puts its own error message to the list. Since
list contains two different error messages the code dispatches
back to client on control connection. The legacy ftp client bundled
with `Solaris`/`Illumos` fails to recover from such situation (for
example `lftp` seems to be immune).

The fix is straightforward make sure the caller of `pr_data_open()`
adds it's own message with `425` error code, so proftpd server
can construct multi-line message properly.