### PR TITLE
Issue #808: When started as a nonroot user, ignore the supplemental g…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,8 +43,10 @@
   Alpine.
 - Issue 968 - Require TLSv1.3 data connection sessions to reuse same session as
   control connection for TLSv1.3 session tickets.
-- Issue 366 - ftptop should support batch mode.  ftptop now supports -b and
-  -n command-line options, like top(1).
+- Issue 366 - ftptop should support batch mode.  ftptop now supports -b and -n
+  command-line options, like top(1).
+- Issue 808 - ProFTPD should ignore supplemental groups when run as a non-root
+  user.
 
 1.3.7rc3 - Released 20-Feb-2020
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -18,6 +18,8 @@ ChangeLog files.
 
   + Added -b and -n command-line options to ftptop.
 
+  + Ignore supplemental groups when run as non-root user (Issue #808).
+
   + New Configuration Directives
 
     LDAPUseSASL

--- a/src/main.c
+++ b/src/main.c
@@ -2571,20 +2571,8 @@ int main(int argc, char *argv[], char **envp) {
   }
 
   if (daemon_uid != PR_ROOT_UID) {
-    /* Allocate space for daemon supplemental groups. */
-    daemon_gids = make_array(permanent_pool, 2, sizeof(gid_t));
-
-    if (pr_auth_getgroups(permanent_pool, (const char *) get_param_ptr(
-        main_server->conf, "UserName", FALSE), &daemon_gids, NULL) < 0) {
-      pr_log_debug(DEBUG2, "unable to retrieve daemon supplemental groups");
-    }
-
-    if (set_groups(permanent_pool, daemon_gid, daemon_gids) < 0) {
-      if (errno != ENOSYS) {
-        pr_log_pri(PR_LOG_WARNING, "unable to set daemon groups: %s",
-          strerror(errno));
-      }
-    }
+    pr_log_debug(DEBUG9, "ignoring supplemental groups for non-root UID %lu",
+      (unsigned long) daemon_uid);
   }
 
   /* After configuration is complete, make sure that passwd, group


### PR DESCRIPTION
…roups.

This helps preserve the principle of least surprise later, when e.g. virtual
users are used.