### PR TITLE
Move definition of recvd_signal_flags for API tests

### DIFF
--- a/contrib/mod_auth_otp/t/api/tests.h
+++ b/contrib/mod_auth_otp/t/api/tests.h
@@ -45,10 +45,10 @@ Suite *tests_get_base32_suite(void);
 Suite *tests_get_hotp_suite(void);
 Suite *tests_get_totp_suite(void);
 
-/* Temporary hack/placement for this variable, until we get to testing
- * the Signals API.
+/* Temporary hack/placement (in stubs.c) for this variable,
+ * until we get to testing the Signals API.
  */
-unsigned int recvd_signal_flags;
+extern volatile unsigned int recvd_signal_flags;
 
 extern pool *auth_otp_pool;
 extern int auth_otp_logfd;

--- a/tests/api/stubs.c
+++ b/tests/api/stubs.c
@@ -39,6 +39,8 @@ xaset_t *server_list = NULL;
 
 static cmd_rec *next_cmd = NULL;
 
+volatile unsigned int recvd_signal_flags = 0;
+
 int tests_stubs_set_next_cmd(cmd_rec *cmd) {
   next_cmd = cmd;
   return 0;

--- a/tests/api/tests.h
+++ b/tests/api/tests.h
@@ -83,10 +83,10 @@ Suite *tests_get_jot_suite(void);
 Suite *tests_get_redis_suite(void);
 Suite *tests_get_error_suite(void);
 
-/* Temporary hack/placement for this variable, until we get to testing
- * the Signals API.
+/* Temporary hack/placement (in stubs.c) for this variable,
+ * until we get to testing the Signals API.
  */
-unsigned int recvd_signal_flags;
+extern volatile unsigned int recvd_signal_flags;
 
 extern char ServerType;
 extern int ServerUseReverseDNS;


### PR DESCRIPTION
Defining it in tests/api/tests.h results in compile failures with gcc 10 due to there being multiple definitions of the object (see https://www.gnu.org/software/gcc/gcc-10/porting_to.html).

Moving it to the stubs.c file along with all of the other stub objects/functions resolves this issue.