### PR TITLE
Automatically tag cmd_recs, and provide an API for getting the tags o…

### DIFF
--- a/include/pool.h
+++ b/include/pool.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2015 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,6 +50,7 @@ void *pallocsz(struct pool_rec *, size_t);
 void *pcalloc(struct pool_rec *, size_t);
 void *pcallocsz(struct pool_rec *, size_t);
 void pr_pool_tag(struct pool_rec *, const char *);
+const char *pr_pool_get_tag(struct pool_rec *);
 
 #ifdef PR_USE_DEVEL
 void pr_pool_debug_memory(void (*)(const char *, ...));

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -726,7 +726,6 @@ static void log_exit_ev(const void *event_data, void *user_data) {
 
   tmp_pool = make_sub_pool(session.pool);
   cmd = pr_cmd_alloc(tmp_pool, 1, pstrdup(tmp_pool, "EXIT"));
-  pr_pool_tag(cmd->pool, "EXIT");
   cmd->cmd_class |= CL_DISCONNECT;
 
   responses_blocked = pr_response_blocked();
@@ -1214,7 +1213,6 @@ static int log_sess_init(void) {
 
     tmp_pool = make_sub_pool(session.pool);
     cmd = pr_cmd_alloc(tmp_pool, 1, pstrdup(tmp_pool, "CONNECT"));
-    pr_pool_tag(cmd->pool, "CONNECT");
     cmd->cmd_class |= CL_CONNECT;
 
     responses_blocked = pr_response_blocked();

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -4082,6 +4082,7 @@ static void xfer_exit_ev(const void *event_data, void *user_data) {
 
   if (session.sf_flags & SF_XFER) {
     cmd_rec *cmd;
+
     pr_data_abort(0, FALSE);
 
     cmd = session.curr_cmd_rec;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2009-2017 The ProFTPD Project team
+ * Copyright (c) 2009-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -180,6 +180,8 @@ cmd_rec *pr_cmd_alloc(pool *p, unsigned int argc, ...) {
 
     va_end(args);
     cmd->argv[argc] = NULL;
+
+    pr_pool_tag(cmd->pool, cmd->argv[0]);
   }
 
   /* This table will not contain that many entries, so a low number

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2019 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -877,11 +877,13 @@ static cmd_rec *make_ftp_cmd(pool *p, char *buf, size_t buflen, int flags) {
 
   *((char **) push_array(tarr)) = NULL;
   cmd->argv = tarr->elts;
+  pr_pool_tag(cmd->pool, cmd->argv[0]);
 
   /* This table will not contain that many entries, so a low number
    * of chains should suffice.
    */
   cmd->notes = pr_table_nalloc(cmd->pool, 0, 8);
+
   return cmd;
 }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -397,6 +397,15 @@ void pr_pool_tag(pool *p, const char *tag) {
   p->tag = tag;
 }
 
+const char *pr_pool_get_tag(pool *p) {
+  if (p == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  return p->tag;
+}
+
 /* Release the entire free block list */
 static void pool_release_free_block_list(void) {
   union block_hdr *blok = NULL, *next = NULL;
@@ -514,6 +523,7 @@ static void clear_pool(struct pool_rec *p) {
   p->last = p->first;
   p->first->h.first_avail = p->free_first_avail;
 
+  p->tag = NULL;
   pr_alarms_unblock();
 }
 

--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2008-2015 The ProFTPD Project team
+ * Copyright (c) 2008-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -301,6 +301,30 @@ START_TEST (pool_tag_test) {
 }
 END_TEST
 
+START_TEST (pool_get_tag_test) {
+  pool *p;
+  const char *res;
+
+  res = pr_pool_get_tag(NULL);
+  fail_unless(res == NULL, "Failed to handle null pool");
+
+  p = make_sub_pool(permanent_pool);
+
+  mark_point();
+  res = pr_pool_get_tag(p);
+  fail_unless(res == NULL, "Failed to handle untagged pool");
+
+  mark_point();
+  pr_pool_tag(p, "foo");
+  res = pr_pool_get_tag(p);
+  fail_unless(res != NULL, "Failed to get pool tag: %s", strerror(errno));
+  fail_unless(strcmp(res, "foo") == 0, "Expected tag 'foo', got '%s'", res);
+
+  destroy_pool(p);
+
+}
+END_TEST
+
 #if defined(PR_USE_DEVEL)
 START_TEST (pool_debug_memory_test) {
   pool *p, *sub_pool;
@@ -429,6 +453,7 @@ Suite *tests_get_pool_suite(void) {
   tcase_add_test(testcase, pool_pcalloc_test);
   tcase_add_test(testcase, pool_pcallocsz_test);
   tcase_add_test(testcase, pool_tag_test);
+  tcase_add_test(testcase, pool_get_tag_test);
 #if defined(PR_USE_DEVEL)
   tcase_add_test(testcase, pool_debug_memory_test);
   tcase_add_test(testcase, pool_debug_flags_test);


### PR DESCRIPTION
…n pools.

Useful for debugging.