### PR TITLE
Issue #908: Add autoconf detection of the `timingsafe_bcmp(3)` functi…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -618,6 +618,9 @@
 /* Define if you have the strtoull function.  */
 #undef HAVE_STRTOULL
 
+/* Define if you have the timingsafe_bcmp function.  */
+#undef HAVE_TIMINGSAFE_BCMP
+
 /* Define if you have the tzset function.  */
 #undef HAVE_TZSET
 

--- a/configure
+++ b/configure
@@ -34326,7 +34326,8 @@ done
 
 
 
-for ac_func in pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror
+
+for ac_func in pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror timingsafe_bcmp
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5

--- a/configure.in
+++ b/configure.in
@@ -2032,7 +2032,7 @@ AC_CHECK_FUNCS(getcwd getenv getgrouplist getgroups getgrset gethostbyname2 geth
 AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups)
 AC_CHECK_FUNCS(loginrestrictions)
 AC_CHECK_FUNCS(explicit_bzero memcpy mempcpy memset_s mkdir mkstemp mlock mlockall munlock munlockall)
-AC_CHECK_FUNCS(pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror)
+AC_CHECK_FUNCS(pathconf posix_fadvise pread prctl putenv pwrite random regcomp rmdir select setgroups socket srandom statfs strchr strcoll strerror timingsafe_bcmp)
 AC_CHECK_FUNCS(strlcat strlcpy strsep strtod strtof strtol strtoll strtoull setprotoent setspent endprotoent)
 # __snprintf and __vsnprintf are only on solaris and _really_ broken there.
 AC_CHECK_FUNCS(vsnprintf snprintf)

--- a/contrib/mod_sql_passwd.c
+++ b/contrib/mod_sql_passwd.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_sql_passwd -- Various SQL password handlers
- * Copyright (c) 2009-2019 TJ Saunders
+ * Copyright (c) 2009-2020 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -481,6 +481,7 @@ static unsigned char *sql_passwd_hash(pool *p, const EVP_MD *md,
   return hash;
 }
 
+#if !defined(HAVE_TIMINGSAFE_BCMP)
 static int timingsafe_bcmp(const void *b1, const void *b2, size_t n) {
   const unsigned char *p1 = b1, *p2 = b2;
   int ret = 0;
@@ -491,6 +492,7 @@ static int timingsafe_bcmp(const void *b1, const void *b2, size_t n) {
 
   return (ret != 0);
 }
+#endif /* HAVE_TIMINGSAFE_BCMP */
 
 static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
     const char *ciphertext, const char *digest) {


### PR DESCRIPTION
…on, present

on e.g. FreeBSD, to avoid compilation errors.