### PR TITLE
mod_quotatab: fix build failure against gcc-10

### DIFF
--- a/contrib/mod_quotatab.c
+++ b/contrib/mod_quotatab.c
@@ -50,6 +50,7 @@ typedef struct regtab_obj {
 module quotatab_module;
 
 /* Quota objects for the current session */
+quota_deltas_t quotatab_deltas;
 static quota_table_t *limit_tab = NULL;
 static quota_limit_t sess_limit;
 

--- a/contrib/mod_quotatab.h
+++ b/contrib/mod_quotatab.h
@@ -188,7 +188,7 @@ typedef struct table_obj {
 #define QUOTATAB_TALLY_SRC      0x0002
 
 /* Quota objects for the current session. */
-quota_deltas_t quotatab_deltas;
+extern quota_deltas_t quotatab_deltas;
 
 /* Function prototypes necessary for quotatab sub-modules */
 int quotatab_log(const char *, ...)


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
$ ./configure --with-modules=mod_quotatab && make
...
ld: modules/module_glue.o:(.data.rel+0x68):
  undefined reference to `quotatab_file_module'
collect2: error: ld returned 1 exit status
make: *** [Makefile:56: proftpd] Error 1
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.