### PR TITLE
It's unlikely that the session ticket-oriented TLSv1.3 sessions will be

### DIFF
--- a/contrib/mod_tls_memcache.c
+++ b/contrib/mod_tls_memcache.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_tls_memcache -- a module which provides shared SSL session
  *                              and OCSP response caches using memcached servers
- * Copyright (c) 2011-2017 TJ Saunders
+ * Copyright (c) 2011-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1204,15 +1204,23 @@ static int sess_cache_status(tls_sess_cache_t *cache,
             statusf(arg, "    Protocol: %s", "TLSv1");
             break;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+#if defined(TLS1_1_VERSION)
           case TLS1_1_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.1");
             break;
+#endif /* TLS1_1_VERSION */
 
+#if defined(TLS1_2_VERSION)
           case TLS1_2_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.2");
             break;
-#endif
+#endif /* TLS1_2_VERSION */
+
+#if defined(TLS1_3_VERSION)
+          case TLS1_3_VERSION:
+            statusf(arg, "    Protocol: %s", "TLSv1.3");
+            break;
+#endif /* TLS1_3_VERSION */
 
           default:
             statusf(arg, "    Protocol: %s", "unknown");

--- a/contrib/mod_tls_redis.c
+++ b/contrib/mod_tls_redis.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_tls_redis -- a module which provides shared SSL session
  *                           and OCSP response caches using Redis servers
- * Copyright (c) 2017 TJ Saunders
+ * Copyright (c) 2017-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1058,15 +1058,23 @@ static int sess_cache_status(tls_sess_cache_t *cache,
             statusf(arg, "    Protocol: %s", "TLSv1");
             break;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+#if defined(TLS1_1_VERSION)
           case TLS1_1_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.1");
             break;
+#endif /* TLS1_1_VERSION */
 
+#if defined(TLS1_2_VERSION)
           case TLS1_2_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.2");
             break;
-#endif
+#endif /* TLS1_2_VERSION */
+
+#if defined(TLS1_3_VERSION)
+          case TLS1_3_VERSION:
+            statusf(arg, "    Protocol: %s", "TLSv1.3");
+            break;
+#endif /* TLS1_3_VERSION */
 
           default:
             statusf(arg, "    Protocol: %s", "unknown");

--- a/contrib/mod_tls_shmcache.c
+++ b/contrib/mod_tls_shmcache.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_tls_shmcache -- a module which provides shared SSL session
  *                              and OCSP response caches using SysV shared
  *                              memory segments
- * Copyright (c) 2009-2017 TJ Saunders
+ * Copyright (c) 2009-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1603,15 +1603,23 @@ static int sess_cache_status(tls_sess_cache_t *cache,
             statusf(arg, "    Protocol: %s", "TLSv1");
             break;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+#if defined(TLS1_1_VERSION)
           case TLS1_1_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.1");
             break;
+#endif /* TLS1_1_VERSION */
 
+#if defined(TLS1_2_VERSION)
           case TLS1_2_VERSION:
             statusf(arg, "    Protocol: %s", "TLSv1.2");
             break;
-#endif
+#endif /* TLS1_2_VERSION */
+
+#ifdef TLS1_3_VERSION
+          case TLS1_3_VERSION:
+            statusf(arg, "    Protocol: %s", "TLSv1.3");
+            break;
+#endif /* TLS1_3_VERSION */
 
           default:
             statusf(arg, "    Protocol: %s", "unknown");


### PR DESCRIPTION
cached externally.  If they are, though, we should be prepared.