### PR TITLE
Issue #857: If no value is found for the specified `%{env:...}` envir…

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -139,7 +139,9 @@ static char *get_config_word(pool *p, char *word) {
          */
         pr_trace_msg(trace_channel, 17, "no value found for environment "
           "variable '%s' for word '%s', ignoring", key, word);
-        ptr = strstr(ptr2, "%{env:");
+
+        word = (char *) sreplace(p, word, var, "", NULL);
+        ptr = strstr(word, "%{env:");
         continue;
       }
 

--- a/tests/api/parser.c
+++ b/tests/api/parser.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2014-2017 The ProFTPD Project team
+ * Copyright (c) 2014-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -333,6 +333,22 @@ START_TEST (parser_parse_line_test) {
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
   fail_unless(strcmp(cmd->arg, "Foo@baR") == 0,
     "Expected 'Foo@baR', got '%s'", cmd->arg);
+  lineno = pr_parser_get_lineno();
+  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+
+  /* This time, with a single word containing multiple environment variables
+   * where one of the variables is NOT present (Issue #857).
+   */
+  pr_env_set(p, "FOO_TEST", "Foo");
+  text = pstrdup(p, "BarBaz %{env:FOO_TEST}@%{env:BAZ_TEST}");
+  cmd = pr_parser_parse_line(p, text, 0);
+  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+    strerror(errno));
+  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+    "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
+  fail_unless(strcmp(cmd->arg, "Foo@") == 0,
+    "Expected 'Foo@', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
   fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
 


### PR DESCRIPTION
…onment

variable, replace the value with the empty string.

This addresses the regression introduced by the changes for Issue #507.