### PR TITLE
Issue #932: When handling `ServerAlias` directives, we need to ensure…

### DIFF
--- a/tests/t/lib/ProFTPD/TestSuite/Utils.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/Utils.pm
@@ -377,9 +377,12 @@ sub config_write {
     unless (defined($config->{Port})) {
       my $dynport = get_high_numbered_port();
       $config->{Port} = $dynport;
-    }
+      $port = $dynport;
 
-    $port = $config->{Port};
+    } elsif ($config->{Port} == 0 || $config->{Port} eq '0') {
+      my $dynport = get_high_numbered_port();
+      $port = $dynport;
+   }
 
     unless (defined($config->{User})) {
       # Handle User names that may contain embedded backslashes and spaces


### PR DESCRIPTION
… that

the internal IP-based bindings are created _before_ handling `ServerAlias`.