### PR TITLE
Remove the unnecessary calls to add more lines to the FTP responses f…

### DIFF
--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -1512,9 +1512,6 @@ MODRET facts_mlsd(cmd_rec *cmd) {
 
     pr_fsio_closedir(dirh);
 
-    pr_response_add_err(R_550, "%s: %s", (char *) cmd->argv[0],
-      strerror(xerrno));
-
     pr_cmd_set_errno(cmd, xerrno);
     errno = xerrno;
     return PR_ERROR(cmd);

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -1959,9 +1959,6 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
 
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-          strerror(xerrno));
-
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;
         return -1;
@@ -2204,9 +2201,6 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
     if (!opt_STAT) {
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
-
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0], 
-          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;
@@ -3106,9 +3100,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
             if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
               int xerrno = errno;
 
-              pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0], 
-                strerror(xerrno));
-
               pr_cmd_set_errno(cmd, xerrno);
               errno = xerrno;
               return PR_ERROR(cmd);
@@ -3133,9 +3124,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
           if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
             int xerrno = errno;
 
-            pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-              strerror(xerrno));
-
             pr_cmd_set_errno(cmd, xerrno);
             errno = xerrno;
             return PR_ERROR(cmd);
@@ -3158,9 +3146,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
 
     if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
       int xerrno = errno;
-
-      pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-        strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);
       errno = xerrno;
@@ -3252,9 +3237,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
         if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
           xerrno = errno;
 
-          pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-            strerror(xerrno));
-
           pr_cmd_set_errno(cmd, xerrno);
           errno = xerrno;
           return PR_ERROR(cmd);
@@ -3288,9 +3270,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
           if (list_flags & LS_FL_NO_ERROR_IF_ABSENT) {
             if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
               xerrno = errno;
-
-              pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-                strerror(xerrno));
 
               pr_cmd_set_errno(cmd, xerrno);
               errno = xerrno;
@@ -3330,9 +3309,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
         if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
           xerrno = errno;
 
-          pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-            strerror(xerrno));
-
           pr_cmd_set_errno(cmd, xerrno);
           errno = xerrno;
           return PR_ERROR(cmd);
@@ -3354,9 +3330,6 @@ MODRET ls_nlst(cmd_rec *cmd) {
     if (S_ISREG(st.st_mode)) {
       if (pr_data_open(NULL, "file list", PR_NETIO_IO_WR, 0) < 0) {
         int xerrno = errno;
-
-        pr_response_add_err(R_450, "%s: %s", (char *) cmd->argv[0],
-          strerror(xerrno));
 
         pr_cmd_set_errno(cmd, xerrno);
         errno = xerrno;


### PR DESCRIPTION
…or failed

data transfers.

These calls were not providing useful information, and were using different
respones codes, leading to unexpectedly mixed responses.