### PR TITLE
Issue #82: Implement support for configuring SSL-related settings via…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,8 @@
 - Bug 4394 - LogFormat %a gives local server IP address instead of remote
   client IP address.
 - Issue 946 - Improve handling of ldaps URLs, LDAPUseTLS directive in mod_ldap.
+- Issue 82 - Support configurable certificate settings in LDAP SSL/TLS
+  connections.
 
 1.3.7rc3 - Released 20-Feb-2020
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,6 +6,21 @@ This file contains a description of the major changes to ProFTPD for the
 releases.  More information on these changes can be found in the NEWS and
 ChangeLog files.
 
+1.3.7rc4
+---------
+
+  + Implemented support for configuring certificate options for LDAP
+    connections using SSL/TLS.
+
+  + Changed Configuration Directives
+
+    LDAPServer
+      The LDAPServer directive now supports configuring the trusted CA
+      file, client certificate and key files, SSL ciphers, and verification
+      policies for LDAP connections.  See doc/contrib/mod_ldap.html#LDAPServer
+      for more details.
+
+
 1.3.7rc3
 ---------
 
@@ -32,9 +47,15 @@ ChangeLog files.
 
   + Changed Configuration Directives
 
-    LogFormat %{transfer-port} (Issue #912)
+    LogFormat %{transfer-port}
+      The LogFormat directive supports a %{transfer-port} variable for
+      logging the selected data transfer port.
 
-    SFTPOptions NoExtensionNegotiation (Issue #907)
+    SFTPOptions NoExtensionNegotiation
+      The mod_sftp module now supports SSH extension negotations (RFC 8332).
+      If there any issues with this support, it can be disabled using:
+
+        SFTPOptions NoExtensionNegotiation
 
     SQLAuthTypes bcrypt
       The mod_sql_passwd module now supports bcrypt-encrypted passwords.

--- a/doc/contrib/mod_ldap.html
+++ b/doc/contrib/mod_ldap.html
@@ -607,7 +607,7 @@ optional parameters <b>is required</b>.
 <p>
 <hr>
 <h3><a name="LDAPServer">LDAPServer</a></h3>
-<strong>Syntax:</strong> LDAPServer <em>&quot;url1|host1:port1 url2|host2:port2&quot;</em><br>
+<strong>Syntax:</strong> LDAPServer <em>url1|host1:port1 url2|host2:port2 [ssl-ca:&lt;path&gt;] [ssl-cert:&lt;path&gt;] [ssl-key:&lt;path&gt;] [ssl-ciphers:&lt;list&gt;] [ssl-verify:boolean]</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_ldap<br>
@@ -621,33 +621,84 @@ servers specified by your LDAP library will be used.  Note that the LDAP
 URL syntax may also be used.
 
 <p>
-To specify multiple LDAP servers, enclose the entire list of servers in
-quotation marks.  For example:
+To specify multiple LDAP servers, you can configure the entire list of servers
+on one line:
 <pre>
-  LDAPServer &quot;host1:port1 host2:port2&quot;
+  # Using just hostname/port
+  LDAPServer host1:port1 host2:port2
 </pre>
 or:
 <pre>
-  LDAPServer &quot;url1 url2&quot;
+  # Using the URL syntax
+  LDAPServer url1 url2
 </pre>
-Th default search scope for LDAP URLs is "base" (unless a scope is explicitly
+In ProFTPD 1.3.7rc4 and later, you can also use multiple <code>LDAPServer</code>
+directives as well, <i>e.g.</i>:
+<pre>
+  LDAPServer host1:port1
+  LDAPServer url1
+  LDAPServer host2
+  LDAPServer url2
+</pre>
+
+<p>
+The default search scope for LDAP URLs is "base" (unless a scope is explicitly
 provided in the URL). This behavior differs from the
 <a href="#LDAPSearchScope"><code>LDAPSearchScope</code></a> directive, which
 defaults to "subtree".
 
 <p>
-<b>Note</b> that to use LDAPS (LDAP over SSL), use the <em>URL</em> format,
-<i>e.g.</i>:
+<b>Note</b> that to use LDAPS (LDAP over SSL), you <b>must</b> use the
+<em>URL</em> format, <i>e.g.</i>:
 <pre>
   LDAPServer ldaps://host1:port1 ldaps://host2:port2
 </pre>
-Alternatively, you can use the <a href="#LDAPUseTLS"><code>LDAPUseTLS</code></a>
-directive, <i>e.g.</i>:
+
+<p>
+However, LDAPS is deprecated.  Instead, LDAP prefers the
+<a href="https://en.wikipedia.org/wiki/STARTTLS">STARTTLS</a> mechanism. To
+enable use of STARTTLS for your LDAP connections, use the
+<a href="#LDAPUseTLS"><code>LDAPUseTLS</code></a> directive, <i>e.g.</i>:
 <pre>
   LDAPServer ldap://host1:port1 ldap://host2:port2
   LDAPUseTLS on
 </pre>
-to tell <code>mod_ldap</code> to use LDAP's <a href="https://en.wikipedia.org/wiki/STARTTLS">STARTTLS</a> mechanism.
+
+<p>
+In ProFTPD 1.3.7rc4 and later, it is possible to configure SSL/TLS parameters
+for a given connection.  Most of the time, all that is needed for the SSL
+session is the CA (Certificate Authority) to use, for verifying the
+certificate presented by the LDAP server, using the <em>ssl-ca:</em> parameter.
+Thus:
+<pre>
+  LDAPServer ... ssl-ca:/path/to/cacert.pem
+</pre>
+If your LDAP server is configured to require SSL/TLS mutual authentication
+(also called "client auth"), you may need the <em>ssl-cert:</em> and
+<em>ssl-key:</em> parameters as well:
+<pre>
+  LDAPServer ... ssl-ca:/path/to/cacert.pem \
+    ssl-cert:/path/to/client-cert.pem \
+    ssl-key:/path/to/client-key.pem
+</pre>
+Finally, you may want to configure the specific SSL/TLS ciphersuites that
+should be used; the <em>ssl-ciphers:</em> parameter can be used for this:
+<pre>
+  LDAPServer ... ssl-ca:/path/to/cacert.pem \
+    ssl-cert:/path/to/client-cert.pem \
+    ssl-key:/path/to/client-key.pem \
+    ssl-ciphers:DEFAULT:!EXPORT:!DES
+</pre>
+
+<p>
+If there is an issue with the server certificate presented by your LDAP
+server, <b>but</b> you need to create the SSL/TLS session anyway, you can
+relax the certificate verification requirements using the <em>ssl-verify:</em>
+parameter, <i>e.g.</i>:
+<pre>
+  LDAPServer ... ssl-ca:/path/to/cacert.pem \
+    ssl-verify:off
+</pre>
 
 <p>
 <hr>


### PR DESCRIPTION
… the

`LDAPServer` directive, as opposed to the ldap.conf(5) file.