### PR TITLE
Issue #953: By using just `pr_regexp_compile`, and not the POSIX-spec…

### DIFF
--- a/contrib/mod_rewrite.c
+++ b/contrib/mod_rewrite.c
@@ -2567,7 +2567,7 @@ MODRET set_rewriterule(cmd_rec *cmd) {
     pattern++;
   }
 
-  res = pr_regexp_compile_posix(pre, pattern, regex_flags);
+  res = pr_regexp_compile(pre, pattern, regex_flags);
   if (res != 0) {
     char errstr[200] = {'\0'};
 


### PR DESCRIPTION
…ific

variant, we ensure that `RewriteRule` expressions can take advantage of PCRE
when it is available.