### PR TITLE
Issue #964: Modules that use the bcrypt code in the `libsupp` library…

### DIFF
--- a/include/auth.h
+++ b/include/auth.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2004-2016 The ProFTPD Project team
+ * Copyright (c) 2004-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -170,6 +170,10 @@ const char *pr_auth_get_home(pool *, const char *pw_dir);
  * crypt(3) function.
  */
 size_t pr_auth_set_max_password_len(pool *p, size_t len);
+
+/* Pool-using convenience wrapper for the bcrypt() function. */
+char *pr_auth_bcrypt(pool *p, const char *key, const char *salt,
+  size_t *hashed_len);
 
 /* For internal use only. */
 int init_auth(void);

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -22,7 +22,7 @@ Makefile: Makefile.in ../config.status
 	cd ../ && ./config.status
 
 .c.o:
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
+	$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 libltdl: dummy
 	cd libltdl/ && $(MAKE)

--- a/src/auth.c
+++ b/src/auth.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2017 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,7 @@
 #include "conf.h"
 #include "privs.h"
 #include "error.h"
+#include "openbsd-blowfish.h"
 
 static pool *auth_pool = NULL;
 static size_t auth_max_passwd_len = PR_TUNABLE_PASSWORD_MAX;
@@ -2431,6 +2432,29 @@ size_t pr_auth_set_max_password_len(pool *p, size_t len) {
   }
 
   return prev_len;
+}
+
+char *pr_auth_bcrypt(pool *p, const char *key, const char *salt,
+    size_t *hashed_len) {
+  char hashed[128], *res;
+
+  if (p == NULL ||
+      key == NULL ||
+      salt == NULL ||
+      hashed_len == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  if (bcrypt_hashpass(key, salt, hashed, sizeof(hashed)) != 0) {
+    return NULL;
+  }
+
+  res = palloc(p, sizeof(hashed));
+  memcpy(res, hashed, sizeof(hashed));
+  *hashed_len = sizeof(hashed);
+
+  return res;
 }
 
 /* Internal use only.  To be called in the session process. */


### PR DESCRIPTION
… need

to properly declare that usage for the linker.

Otherwise, strict platforms like Alpine will not be able to properly
resolve all of the symbols, and will fail to load such shared modules.