### PR TITLE
Issue #693: Move the logging (via LOG_CMD_ERR handlers) of true failu…

### DIFF
--- a/contrib/mod_sftp/auth-hostbased.c
+++ b/contrib/mod_sftp/auth-hostbased.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp 'hostbased' user authentication
- * Copyright (c) 2008-2016 TJ Saunders
+ * Copyright (c) 2008-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -221,6 +221,10 @@ int sftp_auth_hostbased(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
     pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): authentication "
       "via '%s' host key failed", user, hostkey_algo);
 
+    pr_response_add_err(R_501, "Login incorrect.");
+    pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
     *send_userauth_fail = TRUE;
     errno = EACCES;
     return 0;
@@ -261,6 +265,10 @@ int sftp_auth_hostbased(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
     pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): signature "
       "verification of '%s' host key failed", user, hostkey_algo);
 
+    pr_response_add_err(R_501, "Login incorrect.");
+    pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
     *send_userauth_fail = TRUE;
     errno = EACCES;
     return 0;
@@ -276,6 +284,11 @@ int sftp_auth_hostbased(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       "authentication for user '%s' failed: User not authorized", user);
     pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): User not authorized "
       "for login", user);
+
+    pr_response_add_err(R_501, "Login incorrect.");
+    pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
     *send_userauth_fail = TRUE;
     errno = EACCES;
     return 0;

--- a/contrib/mod_sftp/auth-password.c
+++ b/contrib/mod_sftp/auth-password.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp 'password' user authentication
- * Copyright (c) 2008-2017 TJ Saunders
+ * Copyright (c) 2008-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -171,6 +171,11 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         user);
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): Incorrect password",
         user);
+
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
       *send_userauth_fail = TRUE;
       errno = EINVAL;
       return 0;
@@ -181,6 +186,11 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         user);
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): Password expired",
         user);
+
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
       *send_userauth_fail = TRUE;
       errno = EINVAL;
       return 0;
@@ -191,6 +201,11 @@ int sftp_auth_password(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
         user);
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): Account disabled",
         user);
+
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
       *send_userauth_fail = TRUE;
       errno = EINVAL;
       return 0;

--- a/contrib/mod_sftp/auth-publickey.c
+++ b/contrib/mod_sftp/auth-publickey.c
@@ -340,6 +340,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): authentication "
         "via '%s' public key failed", user, pubkey_algo);
 
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
       *send_userauth_fail = TRUE;
       errno = EACCES;
       return 0;
@@ -387,6 +391,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): signature "
         "verification of '%s' public key failed", user, pubkey_algo);
 
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
       *send_userauth_fail = TRUE;
       errno = EACCES;
       return 0;
@@ -403,6 +411,11 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
       "authentication for user '%s' failed: User not authorized", user);
     pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): User not authorized "
       "for login", user);
+
+    pr_response_add_err(R_501, "Login incorrect.");
+    pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
     *send_userauth_fail = TRUE;
     errno = EACCES;
     return 0;
@@ -422,6 +435,10 @@ int sftp_auth_publickey(struct ssh2_packet *pkt, cmd_rec *pass_cmd,
 
       pr_log_auth(PR_LOG_NOTICE, "USER %s (Login failed): public key request "
        "reused previously verified public key (fingerprint %s)", user, fp);
+
+      pr_response_add_err(R_501, "Login incorrect.");
+      pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
 
       *send_userauth_fail = TRUE;
       errno = EACCES;

--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -1433,7 +1433,16 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
 
     pr_response_add_err(R_530, "Login incorrect.");
     pr_cmd_dispatch_phase(pass_cmd, POST_CMD_ERR, 0);
-    pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+
+    /* True login failures are recorded (via PASS LOG_CMD_ERR handler) by the
+     * specific authentication mechanism implementations, to be more accurate.
+     * See Issue #693.  Thus we only dispatched this PASS command to
+     * LOG_CMD_ERR handlers if there was some other error condition.
+     */
+    if (res < 0) {
+      pr_cmd_dispatch_phase(pass_cmd, LOG_CMD_ERR, 0);
+    }
+
     pr_response_clear(&resp_err_list);
 
     pr_cmd_dispatch_phase(cmd, res == 0 ? POST_CMD : POST_CMD_ERR, 0);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -36426,38 +36426,7 @@ EOC
 sub sftp_config_max_login_attempts_via_password {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/sftp.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/sftp.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/sftp.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/sftp.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/sftp.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'sftp');
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -36466,14 +36435,14 @@ sub sftp_config_max_login_attempts_via_password {
   my $rsa_pub_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key.pub');
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
     Trace => 'DEFAULT:10 ssh2:20 sftp:20 scp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     MaxLoginAttempts => 1,
 
     IfModules => {
@@ -36483,14 +36452,15 @@ sub sftp_config_max_login_attempts_via_password {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
       ],
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -36512,16 +36482,15 @@ sub sftp_config_max_login_attempts_via_password {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
-      my $ssh2 = Net::SSH2->new();
-
       sleep(1);
 
+      my $ssh2 = Net::SSH2->new();
       unless ($ssh2->connect('127.0.0.1', $port)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      unless ($ssh2->auth_password($user, $passwd)) {
+      unless ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
@@ -36538,16 +36507,16 @@ sub sftp_config_max_login_attempts_via_password {
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      if ($ssh2->auth_publickey($user, $rsa_pub_key, $rsa_priv_key)) {
-        die("Publickey auth succeeded unexpectedly");
-      }
-
-      if ($ssh2->auth_password($user, $passwd)) {
+      if ($ssh2->auth_password($setup->{user}, 'foobar')) {
         die("Password auth succeeded unexpectedly");
       }
 
-    };
+      if ($ssh2->auth_publickey($setup->{user}, $rsa_pub_key, $rsa_priv_key)) {
+        die("Publickey auth succeeded unexpectedly");
+      }
 
+      $ssh2->disconnect();
+    };
     if ($@) {
       $ex = $@;
     }
@@ -36556,7 +36525,7 @@ sub sftp_config_max_login_attempts_via_password {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -36566,55 +36535,48 @@ sub sftp_config_max_login_attempts_via_password {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
+  # Make sure we do see LOG_CMD_ERR log messages for the PASS command
+  # (Issue #693).
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $seen = 0;
 
-    die($ex);
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /LOG_CMD_ERR .*PASS/) {
+          $seen = 1;
+          last;
+        }
+      }
+
+      close($fh);
+
+      $self->assert($seen == 1,
+        test_msg("Did not see LOG_CMD_ERR PASS messages as expected"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
   }
 
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub sftp_config_max_login_attempts_via_publickey {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/sftp.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/sftp.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/sftp.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/sftp.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/sftp.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'sftp');
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -36629,14 +36591,14 @@ sub sftp_config_max_login_attempts_via_publickey {
   }
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
     Trace => 'DEFAULT:10 ssh2:20 sftp:20 scp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     MaxLoginAttempts => 1,
 
     IfModules => {
@@ -36646,7 +36608,7 @@ sub sftp_config_max_login_attempts_via_publickey {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
         "SFTPAuthorizedUserKeys file:~/.authorized_keys",
@@ -36654,7 +36616,8 @@ sub sftp_config_max_login_attempts_via_publickey {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -36685,7 +36648,7 @@ sub sftp_config_max_login_attempts_via_publickey {
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      unless ($ssh2->auth_publickey($user, $rsa_pub_key, $rsa_priv_key)) {
+      unless ($ssh2->auth_publickey($setup->{user}, $rsa_pub_key, $rsa_priv_key)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
@@ -36702,15 +36665,16 @@ sub sftp_config_max_login_attempts_via_publickey {
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      if ($ssh2->auth_password($user, 'foobar')) {
+      if ($ssh2->auth_password($setup->{user}, 'foobar')) {
         die("Password auth succeeded unexpectedly");
       }
 
-      if ($ssh2->auth_publickey($user, $rsa_pub_key, $rsa_priv_key)) {
+      if ($ssh2->auth_publickey($setup->{user}, $rsa_pub_key, $rsa_priv_key)) {
         die("Publickey auth succeeded unexpectedly");
       }
-    };
 
+      $ssh2->disconnect();
+    };
     if ($@) {
       $ex = $@;
     }
@@ -36719,7 +36683,7 @@ sub sftp_config_max_login_attempts_via_publickey {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -36729,18 +36693,42 @@ sub sftp_config_max_login_attempts_via_publickey {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
+  # Make sure we don't see any LOG_CMD_ERR log messages for the PASS
+  # command (Issue #693).
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $seen = 0;
 
-    die($ex);
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /LOG_CMD_ERR .* PASS/) {
+          $seen = 1;
+          last;
+        }
+      }
+
+      close($fh);
+
+      $self->assert($seen == 0,
+        test_msg("Saw LOG_CMD_ERR PASS messages unexpectedly"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
   }
 
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub sftp_config_max_login_attempts_none_bug4087 {


### PR DESCRIPTION
…res,

where clients send bad authentication data, into the mechanism-specific
implementations.

This helps weed out the _attempted_ authentications, as an SSH agent trying
multiple keys, from e.g. wrong passwords and bad (vs unknown) keys.