### PR TITLE
Issue #984: Only send an SSH EXT_INFO message if the client indicated…

### DIFF
--- a/contrib/mod_sftp/misc.c
+++ b/contrib/mod_sftp/misc.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp miscellaneous
- * Copyright (c) 2010-2017 TJ Saunders
+ * Copyright (c) 2010-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -289,6 +289,31 @@ int sftp_misc_chown_path(pool *p, const char *path) {
 
 const char *sftp_misc_get_chroot(pool *p) {
   return pr_table_get(session.notes, "mod_sftp.chroot-path", NULL);
+}
+
+int sftp_misc_namelist_contains(pool *p, const char *namelist,
+    const char *name) {
+  register unsigned int i;
+  int res = FALSE;
+  pool *tmp_pool;
+  array_header *list;
+  const char **elts;
+
+  tmp_pool = make_sub_pool(p);
+  pr_pool_tag(tmp_pool, "Contains name pool");
+
+  list = pr_str_text_to_array(tmp_pool, namelist, ',');
+  elts = (const char **) list->elts;
+
+  for (i = 0; i < list->nelts; i++) {
+    if (strcmp(elts[i], name) == 0) {
+      res = TRUE;
+      break;
+    }
+  }
+
+  destroy_pool(tmp_pool);
+  return res;
 }
 
 const char *sftp_misc_namelist_shared(pool *p, const char *c2s_names,

--- a/contrib/mod_sftp/misc.h
+++ b/contrib/mod_sftp/misc.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp miscellaneous
- * Copyright (c) 2010-2017 TJ Saunders
+ * Copyright (c) 2010-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,8 +29,9 @@
 
 int sftp_misc_chown_file(pool *, pr_fh_t *);
 int sftp_misc_chown_path(pool *, const char *);
-const char *sftp_misc_get_chroot(pool *p);
+const char *sftp_misc_get_chroot(pool *);
+int sftp_misc_namelist_contains(pool *, const char *, const char *);
 const char *sftp_misc_namelist_shared(pool *, const char *, const char *);
-char *sftp_misc_vroot_abs_path(pool *p, const char *, int);
+char *sftp_misc_vroot_abs_path(pool *, const char *, int);
 
 #endif /* MOD_SFTP_MISC_H */

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -4180,6 +4180,8 @@ sub ssh2_ext_hostkey_rsa_sha256 {
   if (open(my $fh, "> $ssh_config")) {
     print $fh <<EOC;
 HostKeyAlgorithms rsa-sha2-256
+IdentityAgent none
+PubkeyAcceptedKeyTypes rsa-sha2-256
 EOC
     unless (close($fh)) {
       die("Can't write $ssh_config: $!");
@@ -4249,6 +4251,10 @@ EOC
       # libssh2, and thus Net::SSH2, don't support rsa-sha256 yet.  So we
       # use the external sftp(1) client (e.g. OpenSSH-7.9p1) to test.
       my $sftp = '/Users/tj/local/openssh-7.9p1/bin/sftp';
+
+      # Since we are using a non-standard sftp(1), make sure the system
+      # ssh-agent, which may not support SHA-2 signatures, is not involved.
+      $ENV{SSH_AUTH_SOCK} = '';
 
       my @cmd = (
         $sftp,
@@ -4358,6 +4364,7 @@ sub ssh2_ext_hostkey_rsa_sha512 {
     print $fh <<EOC;
 HostKeyAlgorithms rsa-sha2-512
 IdentityAgent none
+PubkeyAcceptedKeyTypes rsa-sha2-256
 EOC
     unless (close($fh)) {
       die("Can't write $ssh_config: $!");
@@ -4427,6 +4434,10 @@ EOC
       # libssh2, and thus Net::SSH2, don't support rsa-sha512 yet.  So we
       # use the external sftp(1) client (e.g. OpenSSH-7.9p1) to test.
       my $sftp = '/Users/tj/local/openssh-7.9p1/bin/sftp';
+
+      # Since we are using a non-standard sftp(1), make sure the system
+      # ssh-agent, which may not support SHA-2 signatures, is not involved.
+      $ENV{SSH_AUTH_SOCK} = '';
 
       my @cmd = (
         $sftp,


### PR DESCRIPTION
… support

for extension negotiations via the signaling "ext-info-c" key exchange
algorithm.

Otherwise we might send EXT_INFO messages to clients which do not support them,
causing interoperability problems.