### PR TITLE
Issue #983: Use the re-entrant versions of `ctime(3)`, `gmtime(3)`, and

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -273,6 +273,9 @@
 /* Define if you have the crypt function.  */
 #undef HAVE_CRYPT
 
+/* Define if you have the ctime_r function.  */
+#undef HAVE_CTIME_R
+
 /* Define if you have the dirfd function.  */
 #undef HAVE_DIRFD
 
@@ -387,6 +390,9 @@
 /* Define if you have the gettimeofday function.  */
 #undef HAVE_GETTIMEOFDAY
 
+/* Define if you have the gmtime_r function.  */
+#undef HAVE_GMTIME_R
+
 /* Define if you have the Hiredis redisReconnect function.  */
 #undef HAVE_HIREDIS_REDISRECONNECT
 
@@ -416,6 +422,9 @@
 
 /* Define if you have the llistxattr function.  */
 #undef HAVE_LLISTXATTR
+
+/* Define if you have the localtime_r function.  */
+#undef HAVE_LOCALTIME_R
 
 /* Define if you have the loginfailed function.  */
 #undef HAVE_LOGINFAILED

--- a/configure
+++ b/configure
@@ -33431,7 +33431,10 @@ done
 
 
 
-for ac_func in bcopy crypt fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp mkdtemp nl_langinfo
+
+
+
+for ac_func in bcopy crypt ctime_r fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo
 do
 as_ac_var=`echo "ac_cv_func_$ac_func" | $as_tr_sh`
 { echo "$as_me:$LINENO: checking for $ac_func" >&5
@@ -33523,6 +33526,7 @@ _ACEOF
 
 fi
 done
+
 
 { echo "$as_me:$LINENO: checking for gai_strerror" >&5
 echo $ECHO_N "checking for gai_strerror... $ECHO_C" >&6; }

--- a/configure.in
+++ b/configure.in
@@ -1901,7 +1901,8 @@ AC_PROG_GCC_TRADITIONAL
 AC_TYPE_SIGNAL
 AC_FUNC_VPRINTF
 
-AC_CHECK_FUNCS(bcopy crypt fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp mkdtemp nl_langinfo)
+AC_CHECK_FUNCS(bcopy crypt ctime_r fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo)
+
 AC_CHECK_FUNC(gai_strerror,
   AC_DEFINE(HAVE_GAI_STRERROR, 1,
     [Define if you have the gai_strerror() function]),

--- a/contrib/mod_exec.c
+++ b/contrib/mod_exec.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_exec -- a module for executing external scripts
- * Copyright (c) 2002-2017 TJ Saunders
+ * Copyright (c) 2002-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1140,7 +1140,7 @@ static const char *exec_subst_var(pool *tmp_pool, const char *varstr,
       now = time(NULL);
       memset(time_str, 0, sizeof(time_str));
 
-      tm = pr_localtime(NULL, &now);
+      tm = pr_localtime(tmp_pool, &now);
       if (tm != NULL) {
         strftime(time_str, sizeof(time_str), fmt, tm);
       }

--- a/contrib/mod_readme.c
+++ b/contrib/mod_readme.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2017 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,7 +67,12 @@ static void readme_add_path(pool *p, const char *path) {
       }
 
       memset(time_str, '\0', sizeof(time_str));
+#if defined(HAVE_CTIME_R)
+      pr_snprintf(time_str, sizeof(time_str)-1, "%.26s",
+        ctime_r(&st.st_mtime, time_str));
+#else
       pr_snprintf(time_str, sizeof(time_str)-1, "%.26s", ctime(&st.st_mtime));
+#endif /* HAVE_CTIME_R */
     
       ptr = strchr(time_str, '\n');
       if (ptr != NULL) {

--- a/contrib/mod_sftp/date.c
+++ b/contrib/mod_sftp/date.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp date(1) simulation
- * Copyright (c) 2012-2016 TJ Saunders
+ * Copyright (c) 2012-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -151,13 +151,13 @@ int sftp_date_postopen_session(uint32_t channel_id) {
   }
 
   time(&now);
-  date_str = pr_strtime2(now, sess->use_gmt);
+  date_str = pr_strtime3(sess->pool, now, sess->use_gmt);
 
   /* XXX Is this big enough?  Too big? */
   buflen = bufsz = 128;
   buf = ptr = palloc(sess->pool, bufsz);
 
-  /* pr_strtime() trims off the trailing newline, so add it back in. */
+  /* pr_strtime3() trims off the trailing newline, so add it back in. */
   sftp_msg_write_string(&buf, &buflen,
     pstrcat(sess->pool, date_str, "\n", NULL));
 
@@ -178,7 +178,7 @@ int sftp_date_open_session(uint32_t channel_id) {
    * channel ID.
    */
   sess = last = date_sessions;
-  while (sess) {
+  while (sess != NULL) {
     pr_signals_handle();
 
     if (sess->channel_id == channel_id) {

--- a/contrib/mod_sftp/display.c
+++ b/contrib/mod_sftp/display.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp Display files
- * Copyright (c) 2010-2017 TJ Saunders
+ * Copyright (c) 2010-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -93,7 +93,7 @@ const char *sftp_display_fh_get_msg(pool *p, pr_fh_t *fh) {
   pr_snprintf(mg_size, sizeof(mg_size), "%" PR_LU, (pr_off_t) fs_size);
   format_size_str(mg_size_units, sizeof(mg_size_units), fs_size);
 
-  mg_time = pr_strtime(time(NULL));
+  mg_time = pr_strtime3(p, time(NULL), FALSE);
 
   max_clients = get_param_ptr(main_server->conf, "MaxClients", FALSE);
 
@@ -222,7 +222,7 @@ const char *sftp_display_fh_get_msg(pool *p, pr_fh_t *fh) {
         now = time(NULL);
         memset(time_str, 0, sizeof(time_str));
 
-        tm = pr_localtime(NULL, &now);
+        tm = pr_localtime(p, &now);
         if (tm != NULL) {
           strftime(time_str, sizeof(time_str), fmt, tm);
         }

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -1011,30 +1011,8 @@ static int fxp_get_v5_open_flags(uint32_t desired_access, uint32_t flags) {
   return res;
 }
 
-/* Like pr_strtime(), except that it uses pr_gmtime() rather than
- * pr_localtime().
- */
 static const char *fxp_strtime(pool *p, time_t t) {
-  static char buf[64];
-  static char *mons[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-    "Aug", "Sep", "Oct", "Nov", "Dec" };
-  static char *days[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-  struct tm *tm;
-
-  memset(buf, '\0', sizeof(buf));
-
-  tm = pr_gmtime(p, &t);
-  if (tm != NULL) {
-    pr_snprintf(buf, sizeof(buf), "%s %s %2d %02d:%02d:%02d %d",
-      days[tm->tm_wday], mons[tm->tm_mon], tm->tm_mday, tm->tm_hour,
-      tm->tm_min, tm->tm_sec, tm->tm_year + 1900);
-
-  } else {
-    buf[0] = '\0';
-  }
-
-  buf[sizeof(buf)-1] = '\0';
-  return buf;
+  return pr_strtime3(p, t, TRUE);
 }
 
 static void fxp_cmd_dispatch(cmd_rec *cmd) {

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -881,7 +881,7 @@ static int sql_resolve_on_meta(pool *p, pr_jot_ctx_t *jot_ctx,
         time_t now;
 
         now = time(NULL);
-        tm = pr_localtime(NULL, &now);
+        tm = pr_localtime(p, &now);
 
         if (jot_hint != NULL) {
           time_fmt = jot_hint;

--- a/contrib/mod_tls_memcache.c
+++ b/contrib/mod_tls_memcache.c
@@ -1227,10 +1227,10 @@ static int sess_cache_status(tls_sess_cache_t *cache,
         }
 
         ts = SSL_SESSION_get_time(sess);
-        statusf(arg, "    Started: %s", pr_strtime(ts));
+        statusf(arg, "    Started: %s", pr_strtime3(tmp_pool, ts, FALSE));
         ts = entry->expires;
-        statusf(arg, "    Expires: %s (%u secs)", pr_strtime(ts),
-          SSL_SESSION_get_timeout(sess));
+        statusf(arg, "    Expires: %s (%u secs)",
+          pr_strtime3(tmp_pool, ts, FALSE), SSL_SESSION_get_timeout(sess));
 
         SSL_SESSION_free(sess);
         statusf(arg, "%s", "  -----END SSL SESSION PARAMETERS-----");

--- a/contrib/mod_tls_redis.c
+++ b/contrib/mod_tls_redis.c
@@ -1081,10 +1081,10 @@ static int sess_cache_status(tls_sess_cache_t *cache,
         }
 
         ts = SSL_SESSION_get_time(sess);
-        statusf(arg, "    Started: %s", pr_strtime(ts));
+        statusf(arg, "    Started: %s", pr_strtime3(tmp_pool, ts, FALSE));
         ts = entry->expires;
-        statusf(arg, "    Expires: %s (%u secs)", pr_strtime(ts),
-          SSL_SESSION_get_timeout(sess));
+        statusf(arg, "    Expires: %s (%u secs)",
+          pr_strtime3(tmp_pool, ts, FALSE), SSL_SESSION_get_timeout(sess));
 
         SSL_SESSION_free(sess);
         statusf(arg, "%s", "  -----END SSL SESSION PARAMETERS-----");

--- a/contrib/mod_tls_shmcache.c
+++ b/contrib/mod_tls_shmcache.c
@@ -1492,7 +1492,7 @@ static int sess_cache_status(tls_sess_cache_t *cache,
     statusf(arg, "Shared memory segment size: %u bytes",
       (unsigned int) ds.shm_segsz);
     statusf(arg, "Shared memory cache created on: %s",
-      pr_strtime(ds.shm_ctime));
+      pr_strtime3(tmp_pool, ds.shm_ctime, FALSE));
     statusf(arg, "Shared memory attach count: %u",
       (unsigned int) ds.shm_nattch);
 
@@ -1626,10 +1626,10 @@ static int sess_cache_status(tls_sess_cache_t *cache,
         }
 
         ts = SSL_SESSION_get_time(sess);
-        statusf(arg, "    Started: %s", pr_strtime(ts));
+        statusf(arg, "    Started: %s", pr_strtime3(tmp_pool, ts, FALSE));
         ts = entry->expires;
-        statusf(arg, "    Expires: %s (%u secs)", pr_strtime(ts),
-          SSL_SESSION_get_timeout(sess));
+        statusf(arg, "    Expires: %s (%u secs)",
+          pr_strtime3(tmp_pool, ts, FALSE), SSL_SESSION_get_timeout(sess));
 
         SSL_SESSION_free(sess);
         statusf(arg, "%s", "  -----END SSL SESSION PARAMETERS-----");
@@ -2515,7 +2515,7 @@ static int ocsp_cache_status(tls_ocsp_cache_t *cache,
     statusf(arg, "Shared memory segment size: %u bytes",
       (unsigned int) ds.shm_segsz);
     statusf(arg, "Shared memory cache created on: %s",
-      pr_strtime(ds.shm_ctime));
+      pr_strtime3(tmp_pool, ds.shm_ctime, FALSE));
     statusf(arg, "Shared memory attach count: %u",
       (unsigned int) ds.shm_nattch);
 

--- a/include/support.h
+++ b/include/support.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2017 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,7 +96,8 @@ int exists(const char *);
 int exists2(pool *, const char *);
 
 char *safe_token(char **);
-int check_shutmsg(const char *, time_t *, time_t *, time_t *, char *, size_t);
+int check_shutmsg(pool *, const char *, time_t *, time_t *, time_t *, char *,
+  size_t);
 
 void pr_memscrub(void *, size_t);
 
@@ -105,6 +106,9 @@ struct tm *pr_gmtime(pool *, const time_t *);
 struct tm *pr_localtime(pool *, const time_t *);
 const char *pr_strtime(time_t);
 const char *pr_strtime2(time_t, int);
+
+/* Preferred version.  Allocates the returned string out of the given pool. */
+const char *pr_strtime3(pool *, time_t, int);
 
 int pr_gettimeofday_millis(uint64_t *);
 int pr_timeval2millis(struct timeval *, uint64_t *);

--- a/lib/pr-syslog.c
+++ b/lib/pr-syslog.c
@@ -112,6 +112,9 @@ static void pr_vsyslog(int sockfd, int pri, register const char *fmt,
   struct strbuf ctl, dat;
   struct log_ctl lc;
 #else
+# ifdef HAVE_CTIME_R
+  char timebuf[32];
+# endif /* HAVE_CTIME_R */
   char *timestr = NULL;
 
 # ifdef HAVE_TZNAME
@@ -148,7 +151,12 @@ static void pr_vsyslog(int sockfd, int pri, register const char *fmt,
 # endif /* HAVE_TZNAME */
 
   time(&now);
+# ifdef HAVE_CTIME_R
+  memset(timebuf, '\0', sizeof(timebuf));
+  timestr = ctime_r(&now, timebuf);
+# else
   timestr = ctime(&now);
+# endif /* HAVE_CTIME_R */
 
 # ifdef HAVE_TZNAME
   /* Restore the old tzname setting, to prevent ctime(3) from inadvertently

--- a/modules/mod_dso.c
+++ b/modules/mod_dso.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_dso -- support for loading/unloading modules at run-time
- * Copyright (c) 2004-2017 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2004-2020 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +65,7 @@ static int dso_load_file(char *path) {
   return 0;
 }
 
-static int dso_load_module(char *name) {
+static int dso_load_module(pool *p, char *name) {
   int module_load_errno = 0, res;
   char *symbol_name, *path, *ptr;
   size_t namelen;
@@ -176,7 +176,7 @@ static int dso_load_module(char *name) {
     if (res == 0) {
       pr_log_debug(DEBUG7, MOD_DSO_VERSION
         ": loaded module '%s' (from '%s', last modified on %s)", info->name,
-        info->filename, pr_strtime(st.st_mtime));
+        info->filename, pr_strtime3(p, st.st_mtime, FALSE));
     }
   }
 
@@ -350,7 +350,7 @@ static int dso_handle_insmod(pr_ctrls_t *ctrl, int reqargc,
   }
 
   for (i = 0; i < reqargc; i++) {
-    if (dso_load_module(reqargv[i]) < 0) {
+    if (dso_load_module(ctrl->ctrls_tmp_pool, reqargv[i]) < 0) {
       int xerrno = errno;
 
       /* Make the error messages a little more relevant. */
@@ -481,7 +481,7 @@ MODRET set_loadmodule(cmd_rec *cmd) {
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT);
 
-  if (dso_load_module(cmd->argv[1]) < 0) {
+  if (dso_load_module(cmd->tmp_pool, cmd->argv[1]) < 0) {
     int xerrno = errno;
 
     if (xerrno != EEXIST) {

--- a/src/auth.c
+++ b/src/auth.c
@@ -1946,7 +1946,7 @@ int pr_auth_chroot(const char *path) {
    */
   tmp_pool = make_sub_pool(session.pool);
   now = time(NULL);
-  (void) pr_localtime(NULL, &now);
+  (void) pr_localtime(tmp_pool, &now);
 
   pr_event_generate("core.chroot", path);
 

--- a/src/display.c
+++ b/src/display.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2004-2017 The ProFTPD Project team
+ * Copyright (c) 2004-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -181,7 +181,7 @@ static int display_fh(pr_fh_t *fh, const char *fs, const char *resp_code,
 
   s = (session.anon_config ? session.anon_config->subset : main_server->conf);
 
-  mg_time = pr_strtime(time(NULL));
+  mg_time = pr_strtime3(p, time(NULL), FALSE);
 
   max_clients = get_param_ptr(s, "MaxClients", FALSE);
 
@@ -349,7 +349,7 @@ static int display_fh(pr_fh_t *fh, const char *fs, const char *resp_code,
         time(&now);
         memset(time_str, 0, sizeof(time_str));
 
-        tm = pr_localtime(NULL, &now);
+        tm = pr_localtime(p, &now);
         if (tm != NULL) {
           strftime(time_str, sizeof(time_str), fmt, tm);
         }

--- a/src/ftpdctl.c
+++ b/src/ftpdctl.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2001-2017 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -73,7 +73,20 @@ int pr_fs_get_usable_fd(int fd) {
 }
 
 struct tm *pr_localtime(pool *p, const time_t *t) {
-  return localtime(t);
+  struct tm *tm;
+
+#if defined(HAVE_LOCALTIME_R)
+  if (p == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  tm = localtime_r(t, pcalloc(p, sizeof(struct tm)));
+#else
+  tm = localtime(t);
+#endif /* HAVE_LOCALTIME_R */
+
+  return tm;
 }
 
 int pr_privs_root(const char *file, int lineno) {

--- a/src/support.c
+++ b/src/support.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2019 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -857,12 +857,13 @@ char *safe_token(char **s) {
  * filled with the times to deny new connections and disconnect
  * existing ones.
  */
-int check_shutmsg(const char *path, time_t *shut, time_t *deny, time_t *disc,
-    char *msg, size_t msg_size) {
+int check_shutmsg(pool *p, const char *path, time_t *shut, time_t *deny,
+    time_t *disc, char *msg, size_t msg_size) {
   FILE *fp;
   char *deny_str, *disc_str, *cp, buf[PR_TUNABLE_BUFFER_SIZE+1] = {'\0'};
   char hr[3] = {'\0'}, mn[3] = {'\0'};
   time_t now, shuttime = (time_t) 0;
+  struct stat st;
   struct tm *tm;
 
   if (path == NULL) {
@@ -871,85 +872,92 @@ int check_shutmsg(const char *path, time_t *shut, time_t *deny, time_t *disc,
   }
 
   fp = fopen(path, "r");
-  if (fp != NULL) {
-    struct stat st;
-
-    if (fstat(fileno(fp), &st) == 0) {
-      if (S_ISDIR(st.st_mode)) {
-        fclose(fp);
-        errno = EISDIR;
-        return -1;
-      }
-    }
-
-    cp = fgets(buf, sizeof(buf), fp);
-    if (cp != NULL) {
-      buf[sizeof(buf)-1] = '\0'; CHOP(cp);
-
-      /* We use this to fill in dst, timezone, etc */
-      time(&now);
-      tm = pr_localtime(NULL, &now);
-      if (tm == NULL) {
-        fclose(fp);
-        return 0;
-      }
-
-      tm->tm_year = atoi(safe_token(&cp)) - 1900;
-      tm->tm_mon = atoi(safe_token(&cp)) - 1;
-      tm->tm_mday = atoi(safe_token(&cp));
-      tm->tm_hour = atoi(safe_token(&cp));
-      tm->tm_min = atoi(safe_token(&cp));
-      tm->tm_sec = atoi(safe_token(&cp));
-
-      deny_str = safe_token(&cp);
-      disc_str = safe_token(&cp);
-
-      shuttime = mktime(tm);
-      if (shuttime == (time_t) -1) {
-        fclose(fp);
-        return 0;
-      }
-
-      if (deny != NULL) {
-        if (strlen(deny_str) == 4) {
-          sstrncpy(hr, deny_str, sizeof(hr)); hr[2] = '\0'; deny_str += 2;
-          sstrncpy(mn, deny_str, sizeof(mn)); mn[2] = '\0';
-
-          *deny = shuttime - ((atoi(hr) * 3600) + (atoi(mn) * 60));
-
-        } else {
-          *deny = shuttime;
-        }
-      }
-
-      if (disc != NULL) {
-        if (strlen(disc_str) == 4) {
-          sstrncpy(hr, disc_str, sizeof(hr)); hr[2] = '\0'; disc_str += 2;
-          sstrncpy(mn, disc_str, sizeof(mn)); mn[2] = '\0';
-
-          *disc = shuttime - ((atoi(hr) * 3600) + (atoi(mn) * 60));
-
-        } else {
-          *disc = shuttime;
-        }
-      }
-
-      if (fgets(buf, sizeof(buf), fp) && msg) {
-        buf[sizeof(buf)-1] = '\0';
-	CHOP(buf);
-        sstrncpy(msg, buf, msg_size-1);
-      }
-    }
-
-    fclose(fp);
-    if (shut != NULL) {
-      *shut = shuttime;
-    }
-
-    return 1;
+  if (fp == NULL) {
+    return -1;
   }
 
-  return -1;
+  if (fstat(fileno(fp), &st) == 0) {
+    if (S_ISDIR(st.st_mode)) {
+      fclose(fp);
+      errno = EISDIR;
+      return -1;
+    }
+  }
+
+  cp = fgets(buf, sizeof(buf), fp);
+  if (cp != NULL) {
+    buf[sizeof(buf)-1] = '\0'; CHOP(cp);
+
+    /* We use this to fill in dst, timezone, etc */
+    time(&now);
+    tm = pr_localtime(p, &now);
+    if (tm == NULL) {
+      fclose(fp);
+      return 0;
+    }
+
+    tm->tm_year = atoi(safe_token(&cp)) - 1900;
+    tm->tm_mon = atoi(safe_token(&cp)) - 1;
+    tm->tm_mday = atoi(safe_token(&cp));
+    tm->tm_hour = atoi(safe_token(&cp));
+    tm->tm_min = atoi(safe_token(&cp));
+    tm->tm_sec = atoi(safe_token(&cp));
+
+    deny_str = safe_token(&cp);
+    disc_str = safe_token(&cp);
+
+    shuttime = mktime(tm);
+    if (shuttime == (time_t) -1) {
+      fclose(fp);
+      return 0;
+    }
+
+    if (deny != NULL) {
+      if (strlen(deny_str) == 4) {
+        sstrncpy(hr, deny_str, sizeof(hr));
+        hr[2] = '\0';
+        deny_str += 2;
+
+        sstrncpy(mn, deny_str, sizeof(mn));
+        mn[2] = '\0';
+
+        *deny = shuttime - ((atoi(hr) * 3600) + (atoi(mn) * 60));
+
+      } else {
+        *deny = shuttime;
+      }
+    }
+
+    if (disc != NULL) {
+      if (strlen(disc_str) == 4) {
+        sstrncpy(hr, disc_str, sizeof(hr));
+        hr[2] = '\0';
+        disc_str += 2;
+
+        sstrncpy(mn, disc_str, sizeof(mn));
+        mn[2] = '\0';
+
+        *disc = shuttime - ((atoi(hr) * 3600) + (atoi(mn) * 60));
+
+      } else {
+        *disc = shuttime;
+      }
+    }
+
+    if (fgets(buf, sizeof(buf), fp) && msg) {
+      buf[sizeof(buf)-1] = '\0';
+      CHOP(buf);
+      sstrncpy(msg, buf, msg_size-1);
+    }
+  }
+
+  fclose(fp);
+
+  if (shut != NULL) {
+    *shut = shuttime;
+  }
+
+  return 1;
 }
 
 #if !defined(PR_USE_OPENSSL) || OPENSSL_VERSION_NUMBER <= 0x000907000L
@@ -1032,7 +1040,16 @@ struct tm *pr_gmtime(pool *p, const time_t *now) {
     return NULL;
   }
 
+#if defined(HAVE_GMTIME_R)
+  if (p == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  sys_tm = gmtime_r(now, pcalloc(p, sizeof(struct tm)));
+#else
   sys_tm = gmtime(now);
+#endif /* HAVE_GMTIME_R */
   if (sys_tm == NULL) {
     return NULL;
   }
@@ -1040,7 +1057,7 @@ struct tm *pr_gmtime(pool *p, const time_t *now) {
   /* If the caller provided a pool, make a copy of the struct tm using that
    * pool.  Otherwise, return the struct tm as is.
    */
-  if (p) {
+  if (p != NULL) {
     dup_tm = pcalloc(p, sizeof(struct tm));
     memcpy(dup_tm, sys_tm, sizeof(struct tm));
 
@@ -1090,12 +1107,21 @@ struct tm *pr_localtime(pool *p, const time_t *now) {
     return NULL;
   }
 
+#if defined(HAVE_LOCALTIME_R)
+  if (p == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  sys_tm = localtime_r(now, pcalloc(p, sizeof(struct tm)));
+#else
   sys_tm = localtime(now);
+#endif /* HAVE_LOCALTIME_R */
   if (sys_tm == NULL) {
     return NULL;
   }
 
-  if (p) {
+  if (p != NULL) {
     /* If the caller provided a pool, make a copy of the returned
      * struct tm, allocated out of that pool.
      */
@@ -1110,7 +1136,7 @@ struct tm *pr_localtime(pool *p, const time_t *now) {
     dup_tm = sys_tm;
   }
 
-#ifdef HAVE_TZNAME
+#if defined(HAVE_TZNAME)
   /* Restore the old tzname values prior to returning. */
   memcpy(tzname, tzname_dup, sizeof(tzname_dup));
 #endif /* HAVE_TZNAME */
@@ -1123,6 +1149,10 @@ const char *pr_strtime(time_t t) {
 }
 
 const char *pr_strtime2(time_t t, int use_gmtime) {
+  return pr_strtime3(NULL, t, use_gmtime);
+}
+
+const char *pr_strtime3(pool *p, time_t t, int use_gmtime) {
   static char buf[64];
   static char *mons[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
     "Aug", "Sep", "Oct", "Nov", "Dec" };
@@ -1132,19 +1162,25 @@ const char *pr_strtime2(time_t t, int use_gmtime) {
   memset(buf, '\0', sizeof(buf));
 
   if (use_gmtime) {
-    tr = pr_gmtime(NULL, &t);
+    tr = pr_gmtime(p, &t);
 
   } else {
-    tr = pr_localtime(NULL, &t);
+    tr = pr_localtime(p, &t);
   }
 
-  if (tr != NULL) {
-    pr_snprintfl(__FILE__, __LINE__, buf, sizeof(buf),
-      "%s %s %02d %02d:%02d:%02d %d", days[tr->tm_wday], mons[tr->tm_mon],
-      tr->tm_mday, tr->tm_hour, tr->tm_min, tr->tm_sec, tr->tm_year + 1900);
+  if (tr == NULL) {
+    return NULL;
   }
 
+  pr_snprintfl(__FILE__, __LINE__, buf, sizeof(buf),
+    "%s %s %02d %02d:%02d:%02d %d", days[tr->tm_wday], mons[tr->tm_mon],
+    tr->tm_mday, tr->tm_hour, tr->tm_min, tr->tm_sec, tr->tm_year + 1900);
   buf[sizeof(buf)-1] = '\0';
+
+  if (p != NULL) {
+    return pstrdup(p, buf);
+  }
+
   return buf;
 }
 

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -241,16 +241,6 @@ START_TEST (fsio_sys_close_test) {
 
   res = pr_fsio_close(fh);
   fail_unless(res == 0, "Failed to close file handle: %s", strerror(errno));
-
-  mark_point();
-
-  /* Deliberately try to close an already-closed handle, to make sure we
-   * don't segfault.
-   */
-  res = pr_fsio_close(fh);
-  fail_unless(res < 0, "Failed to handle already-closed file handle");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
-    strerror(errno), errno);
 }
 END_TEST
 
@@ -1653,7 +1643,6 @@ START_TEST (fsio_sys_listxattr_test) {
   res = pr_fsio_listxattr(p, path, &names);
   fail_if(res < 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
 
-  pr_fsio_close(fh);
   (void) unlink(fsio_test_path);
 #else
   (void) fh;
@@ -1709,7 +1698,6 @@ START_TEST (fsio_sys_llistxattr_test) {
   res = pr_fsio_listxattr(p, path, &names);
   fail_if(res < 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
 
-  pr_fsio_close(fh);
   (void) unlink(fsio_test_path);
 #else
   (void) fh;

--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2015-2018 The ProFTPD Project team
+ * Copyright (c) 2015-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -827,19 +827,19 @@ START_TEST (check_shutmsg_test) {
   time_t when_shutdown = 0, when_deny = 0, when_disconnect = 0;
   char shutdown_msg[PR_TUNABLE_BUFFER_SIZE];
 
-  res = check_shutmsg(NULL, NULL, NULL, NULL, NULL, 0);
+  res = check_shutmsg(NULL, NULL, NULL, NULL, NULL, NULL, 0);
   fail_unless(res < 0, "Failed to handle null arguments");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/foo/bar/baz/quxx/quzz";
-  res = check_shutmsg(path, NULL, NULL, NULL, NULL, 0);
+  res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
   fail_unless(res < 0, "Failed to handle nonexistent path");
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   path = "/";
-  res = check_shutmsg(path, NULL, NULL, NULL, NULL, 0);
+  res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
   fail_unless(res < 0, "Failed to handle directory path");
   fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
@@ -857,7 +857,7 @@ START_TEST (check_shutmsg_test) {
   pr_env_set(p, "TZ", "GMT");
 
   mark_point();
-  res = check_shutmsg(path, &when_shutdown, &when_deny, &when_disconnect,
+  res = check_shutmsg(p, path, &when_shutdown, &when_deny, &when_disconnect,
     shutdown_msg, sizeof(shutdown_msg));
   fail_unless(res == 1, "Expected 1, got %d", res);
   fail_unless(when_shutdown == (time_t) 0, "Expected 0, got %lu",
@@ -875,7 +875,7 @@ START_TEST (check_shutmsg_test) {
   fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
-  res = check_shutmsg(path, NULL, NULL, NULL, NULL, 0);
+  res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
   fail_unless(res == 1, "Expected 1, got %d", res);
 
   (void) unlink(path);
@@ -884,7 +884,7 @@ START_TEST (check_shutmsg_test) {
   fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
-  res = check_shutmsg(path, NULL, NULL, NULL, NULL, 0);
+  res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
 
   (void) unlink(misc_test_shutmsg);
 }
@@ -1107,8 +1107,14 @@ START_TEST (gmtime_test) {
 
   mark_point();
   res = pr_gmtime(NULL, &now);
+#if defined(HAVE_GMTIME_R)
+  fail_unless(res == NULL, "Failed to handle null pool");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+#else
   fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
+#endif /* HAVE_GMTIME_R */
 
   mark_point();
   res = pr_gmtime(p, &now);
@@ -1131,8 +1137,14 @@ START_TEST (localtime_test) {
 
   mark_point();
   res = pr_localtime(NULL, &now);
+#if defined(HAVE_LOCALTIME_R)
+  fail_unless(res == NULL, "Failed to handle null pool");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+#else
   fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
+#endif /* HAVE_LOCALTIME_R */
 
   mark_point();
   res = pr_localtime(p, &now);
@@ -1148,8 +1160,14 @@ START_TEST (strtime_test) {
   mark_point();
   now = 0;
   res = pr_strtime(now);
+#if defined(HAVE_LOCALTIME_R)
+  fail_unless(res == NULL, "Failed to handle null pool");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+#else
   fail_unless(res != NULL, "Failed to convert time %lu: %s",
     (unsigned long) now, strerror(errno));
+#endif /* HAVE_LOCALTIME_R */
 }
 END_TEST
 
@@ -1162,6 +1180,36 @@ START_TEST (strtime2_test) {
   now = 0;
   expected = "Thu Jan 01 00:00:00 1970";
   res = pr_strtime2(now, TRUE);
+#if defined(HAVE_GMTIME_R)
+  fail_unless(res == NULL, "Failed to handle null pool");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+#else
+  fail_unless(res != NULL, "Failed to convert time %lu: %s",
+    (unsigned long) now, strerror(errno));
+  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+    res);
+#endif /* HAVE_GMTIME_R */
+}
+END_TEST
+
+START_TEST (strtime3_test) {
+  const char *res;
+  char *expected;
+  time_t now;
+
+  mark_point();
+  now = 0;
+#if defined(HAVE_GMTIME_R)
+  res = pr_strtime3(NULL, now, TRUE);
+  fail_unless(res == NULL, "Failed to handle null pool argument");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%s), got %s (%d)",
+    strerror(EINVAL), strerror(errno), errno);
+#endif /* HAVE_GMTIME_R */
+
+  mark_point();
+  expected = "Thu Jan 01 00:00:00 1970";
+  res = pr_strtime3(p, now, TRUE);
   fail_unless(res != NULL, "Failed to convert time %lu: %s",
     (unsigned long) now, strerror(errno));
   fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
@@ -1433,6 +1481,7 @@ Suite *tests_get_misc_suite(void) {
   tcase_add_test(testcase, localtime_test);
   tcase_add_test(testcase, strtime_test);
   tcase_add_test(testcase, strtime2_test);
+  tcase_add_test(testcase, strtime3_test);
   tcase_add_test(testcase, timeval2millis_test);
   tcase_add_test(testcase, gettimeofday_millis_test);
   tcase_add_test(testcase, snprintf_test);

--- a/tests/api/netio.c
+++ b/tests/api/netio.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2008-2016 The ProFTPD Project team
+ * Copyright (c) 2008-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -369,9 +369,6 @@ START_TEST (netio_telnet_gets_single_line_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
@@ -379,6 +376,9 @@ START_TEST (netio_telnet_gets_single_line_test) {
   fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -421,12 +421,12 @@ START_TEST (netio_telnet_gets_multi_line_test) {
   fail_unless(strcmp(buf, second_cmd) == 0, "Expected string '%s', got '%s'",
     second_cmd, buf);
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -452,12 +452,12 @@ START_TEST (netio_telnet_gets_no_newline_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res == NULL, "Read in string unexpectedly, got '%s'", buf);
   fail_unless(xerrno == E2BIG, "Failed to set errno to E2BIG, got (%d) %s",
     xerrno, strerror(xerrno));
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -538,9 +538,6 @@ START_TEST (netio_telnet_gets_telnet_bare_will_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -551,6 +548,9 @@ START_TEST (netio_telnet_gets_telnet_bare_will_test) {
     telnet_opt, buf[8]);
   fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -701,9 +701,6 @@ START_TEST (netio_telnet_gets_telnet_bare_wont_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -714,6 +711,9 @@ START_TEST (netio_telnet_gets_telnet_bare_wont_test) {
     telnet_opt, buf[8]);
   fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -794,9 +794,6 @@ START_TEST (netio_telnet_gets_telnet_bare_do_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -807,6 +804,9 @@ START_TEST (netio_telnet_gets_telnet_bare_do_test) {
     telnet_opt, buf[8]);
   fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -887,9 +887,6 @@ START_TEST (netio_telnet_gets_telnet_bare_dont_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -900,6 +897,9 @@ START_TEST (netio_telnet_gets_telnet_bare_dont_test) {
     telnet_opt, buf[8]);
   fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -927,13 +927,13 @@ START_TEST (netio_telnet_gets_telnet_ip_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -960,9 +960,6 @@ START_TEST (netio_telnet_gets_telnet_bare_ip_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -971,6 +968,9 @@ START_TEST (netio_telnet_gets_telnet_bare_ip_test) {
     buf[7]);
   fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -998,13 +998,13 @@ START_TEST (netio_telnet_gets_telnet_dm_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1031,9 +1031,6 @@ START_TEST (netio_telnet_gets_telnet_bare_dm_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -1042,6 +1039,9 @@ START_TEST (netio_telnet_gets_telnet_bare_dm_test) {
     buf[7]);
   fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1068,9 +1068,6 @@ START_TEST (netio_telnet_gets_telnet_single_iac_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -1079,6 +1076,9 @@ START_TEST (netio_telnet_gets_telnet_single_iac_test) {
     buf[7]);
   fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1105,12 +1105,12 @@ START_TEST (netio_telnet_gets_bug3521_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res == NULL, "Expected null");
   fail_unless(xerrno == E2BIG, "Failed to set errno to E2BIG, got %s (%d)",
     strerror(xerrno), xerrno);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1138,9 +1138,6 @@ START_TEST (netio_telnet_gets_bug3697_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
@@ -1149,6 +1146,9 @@ START_TEST (netio_telnet_gets_bug3697_test) {
     buf[7]);
   fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1180,13 +1180,13 @@ START_TEST (netio_telnet_gets_eof_test) {
   res = pr_netio_telnet_gets(buf, strlen(cmd) + 2, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1215,9 +1215,6 @@ START_TEST (netio_telnet_gets2_single_line_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
@@ -1228,6 +1225,9 @@ START_TEST (netio_telnet_gets2_single_line_test) {
   fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1257,9 +1257,6 @@ START_TEST (netio_telnet_gets2_single_line_crnul_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
@@ -1270,6 +1267,9 @@ START_TEST (netio_telnet_gets2_single_line_crnul_test) {
   fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 
@@ -1298,9 +1298,6 @@ START_TEST (netio_telnet_gets2_single_line_lf_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  pr_netio_close(in);
-  pr_netio_close(out);
-
   fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
   fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
@@ -1311,6 +1308,9 @@ START_TEST (netio_telnet_gets2_single_line_lf_test) {
   fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
+
+  pr_netio_close(in);
+  pr_netio_close(out);
 }
 END_TEST
 

--- a/tests/api/trace.c
+++ b/tests/api/trace.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2014-2015 The ProFTPD Project team
+ * Copyright (c) 2014-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -309,27 +309,33 @@ START_TEST (trace_msg_test) {
 
   channel = "testsuite";
 
+  mark_point();
   res = pr_trace_msg(channel, -1, NULL);
   fail_unless(res < 0, "Failed to handle bad level");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
+  mark_point();
   res = pr_trace_msg(channel, 1, NULL);
   fail_unless(res < 0, "Failed to handle null message");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
+  mark_point();
   pr_trace_set_levels(channel, 1, 10);
 
+  mark_point();
   memset(msg, 'A', sizeof(msg)-1);
   msg[sizeof(msg)-1] = '\0';
   pr_trace_msg(channel, 5, "%s", msg);
 
+  mark_point();
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
   fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
   session.c->local_addr = session.c->remote_addr =
     pr_netaddr_get_addr(p, "127.0.0.1", NULL);
 
+  mark_point();
   res = pr_trace_set_options(PR_TRACE_OPT_LOG_CONN_IPS|PR_TRACE_OPT_USE_TIMESTAMP_MILLIS);
   fail_unless(res == 0, "Failed to set options: %s", strerror(errno));
   pr_trace_msg(channel, 5, "%s", "alef bet vet?");
@@ -361,15 +367,18 @@ START_TEST (trace_set_file_test) {
   fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
+  mark_point();
   path = trace_path;
   res = pr_trace_set_file(path);
   fail_unless(res == 0, "Failed to set trace file '%s': %s", path,
     strerror(errno));
   pr_trace_set_levels("foo", 1, 20);
 
+  mark_point();
   pr_trace_msg("foo", 1, "bar?");
   pr_trace_msg("foo", 1, "baz!");
 
+  mark_point();
   res = pr_trace_set_options(PR_TRACE_OPT_LOG_CONN_IPS|PR_TRACE_OPT_USE_TIMESTAMP_MILLIS);
   fail_unless(res == 0, "Failed to set options: %s", strerror(errno));
 

--- a/utils/ftptop.c
+++ b/utils/ftptop.c
@@ -594,7 +594,11 @@ static int scoreboard_open(void) {
 
 static void show_sessions(void) {
   time_t now;
+#if defined(HAVE_CTIME_R)
+  char now_str[32];
+#else
   char *now_str = NULL;
+#endif /* HAVE_CTIME_R */
   const char *uptime_str = NULL;
 
   clear_counters();
@@ -602,8 +606,14 @@ static void show_sessions(void) {
 
   time(&now);
 
-  /* Trim ctime(3)'s trailing newline. */
+#if defined(HAVE_CTIME_R)
+  memset(now_str, '\0', sizeof(now_str));
+  (void) ctime_r(&now, now_str);
+#else
   now_str = ctime(&now);
+#endif /* HAVE_CTIME_R */
+
+  /* Trim ctime(3)'s trailing newline. */
   now_str[strlen(now_str)-1] = '\0';
 
   uptime_str = show_ftpd_uptime();


### PR DESCRIPTION
`localtime(3)` where available.

This has some wide ramifications, in that the core wrapper functions now
_require_ a pool, for allocating the necessary struct, from callers.