### PR TITLE
Issue #996: Implement batch mode in `ftptop` to be more like `top`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ task:
     - pkg install -y libmaxminddb
     - pkg install -y libmemcached
     - pkg install -y mysql57-client
+    - pkg install -y ncurses
     - pkg install -y openldap-client
     - pkg install -y openssl
     - pkg install -y pcre

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ install:
   - sudo apt-get install -y libwrap0-dev
   # for PCRE support
   - sudo apt-get install -y libpcre3-dev
+  # for ftptop
+  - sudo apt-get install -y ncurses-dev
   # for zlib support
   - sudo apt-get install -y zlib1g-dev
   # for static code analysis


### PR DESCRIPTION
Now, in batch mode, we do not paint over previous output, but instead we
append.  And now the `-d` command-line option works properly for batch and
interactive modes.