### PR TITLE
The `child_cleanup_cb` callback is never actually used, when destroy …

### DIFF
--- a/include/pool.h
+++ b/include/pool.h
@@ -92,6 +92,8 @@ extern void pr_alarms_block(void);
 extern void pr_alarms_unblock(void);
 
 void register_cleanup(pool *, void *, void (*)(void *), void (*)(void *));
+void register_cleanup2(pool *, void *, void (*)(void *));
+
 void unregister_cleanup(pool *, void *, void (*)(void *));
 
 /* minimum free bytes in a new block pool */

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -1227,8 +1227,7 @@ static int init_inetd_bindings(void) {
      */
 
     serv->listen = main_server->listen;
-    register_cleanup(serv->listen->pool, &serv->listen, server_cleanup_cb,
-      server_cleanup_cb);
+    register_cleanup2(serv->listen->pool, &serv->listen, server_cleanup_cb);
 
     is_default = FALSE;
     default_server = get_param_ptr(serv->conf, "DefaultServer", FALSE);
@@ -1416,8 +1415,7 @@ static int init_standalone_bindings(void) {
       }
 
       serv->listen = main_server->listen;
-      register_cleanup(serv->listen->pool, &serv->listen, server_cleanup_cb,
-        server_cleanup_cb);
+      register_cleanup2(serv->listen->pool, &serv->listen, server_cleanup_cb);
 
       PR_CREATE_IPBIND(serv, serv->addr, serv->ServerPort);
       PR_OPEN_IPBIND(serv->addr, serv->ServerPort, NULL, is_default, FALSE,

--- a/src/inet.c
+++ b/src/inet.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2019 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -177,7 +177,7 @@ conn_t *pr_inet_copy_conn(pool *p, conn_t *c) {
     res->remote_name = pstrdup(res->pool, c->remote_name);
   }
 
-  register_cleanup(res->pool, (void *) res, conn_cleanup_cb, conn_cleanup_cb);
+  register_cleanup2(res->pool, (void *) res, conn_cleanup_cb);
   return res;
 }
 
@@ -567,7 +567,7 @@ static conn_t *init_conn(pool *p, int fd, const pr_netaddr_t *bind_addr,
   }
 
   c->listen_fd = fd;
-  register_cleanup(c->pool, (void *) c, conn_cleanup_cb, conn_cleanup_cb);
+  register_cleanup2(c->pool, (void *) c, conn_cleanup_cb);
 
   pr_trace_msg("binding", 4, "bound address %s, port %d to socket fd %d",
     pr_netaddr_get_ipstr(&na), c->local_port, fd);

--- a/src/pool.c
+++ b/src/pool.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2017 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -810,15 +810,13 @@ array_header *append_arrays(pool *p, const array_header *first,
 /* Generic cleanups */
 
 typedef struct cleanup {
-  void *data;
-  void (*plain_cleanup_cb)(void *);
-  void (*child_cleanup_cb)(void *);
+  void *user_data;
+  void (*cleanup_cb)(void *);
   struct cleanup *next;
 
 } cleanup_t;
 
-void register_cleanup(pool *p, void *data, void (*plain_cleanup_cb)(void*),
-    void (*child_cleanup_cb)(void *)) {
+void register_cleanup2(pool *p, void *user_data, void (*cleanup_cb)(void*)) {
   cleanup_t *c;
 
   if (p == NULL) {
@@ -826,16 +824,21 @@ void register_cleanup(pool *p, void *data, void (*plain_cleanup_cb)(void*),
   }
 
   c = pcalloc(p, sizeof(cleanup_t));
-  c->data = data;
-  c->plain_cleanup_cb = plain_cleanup_cb;
-  c->child_cleanup_cb = child_cleanup_cb;
+  c->user_data = user_data;
+  c->cleanup_cb = cleanup_cb;
 
   /* Add this cleanup to the given pool's list of cleanups. */
   c->next = p->cleanups;
   p->cleanups = c;
 }
 
-void unregister_cleanup(pool *p, void *data, void (*cleanup_cb)(void *)) {
+void register_cleanup(pool *p, void *user_data, void (*plain_cleanup_cb)(void*),
+    void (*child_cleanup_cb)(void *)) {
+  (void) child_cleanup_cb;
+  register_cleanup2(p, user_data, plain_cleanup_cb);
+}
+
+void unregister_cleanup(pool *p, void *user_data, void (*cleanup_cb)(void *)) {
   cleanup_t *c, **lastp;
 
   if (p == NULL) {
@@ -845,9 +848,9 @@ void unregister_cleanup(pool *p, void *data, void (*cleanup_cb)(void *)) {
   c = p->cleanups;
   lastp = &p->cleanups;
 
-  while (c) {
-    if (c->data == data &&
-        (c->plain_cleanup_cb == cleanup_cb || cleanup_cb == NULL)) {
+  while (c != NULL) {
+    if (c->user_data == user_data &&
+        (c->cleanup_cb == cleanup_cb || cleanup_cb == NULL)) {
 
       /* Remove the given cleanup by pointing the previous next pointer to
        * the matching cleanup's next pointer.
@@ -862,9 +865,9 @@ void unregister_cleanup(pool *p, void *data, void (*cleanup_cb)(void *)) {
 }
 
 static void run_cleanups(cleanup_t *c) {
-  while (c) {
-    if (c->plain_cleanup_cb) {
-      (*c->plain_cleanup_cb)(c->data);
+  while (c != NULL) {
+    if (c->cleanup_cb) {
+      (*c->cleanup_cb)(c->user_data);
     }
 
     c = c->next;

--- a/src/redis.c
+++ b/src/redis.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2017 The ProFTPD Project team
+ * Copyright (c) 2017-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -535,7 +535,7 @@ pr_redis_t *pr_redis_conn_new(pool *p, module *m, unsigned long flags) {
     /* Register a cleanup on this redis, so that when it is destroyed, we
      * clear this sess_redis pointer, lest it remaining dangling.
      */
-    register_cleanup(redis->pool, NULL, sess_redis_cleanup, NULL);
+    register_cleanup2(redis->pool, NULL, sess_redis_cleanup);
   }
 
   return redis;

--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -392,6 +392,25 @@ START_TEST (pool_register_cleanup_test) {
 }
 END_TEST
 
+START_TEST (pool_register_cleanup2_test) {
+  pool *p;
+
+  pool_cleanup_count = 0;
+
+  mark_point();
+  register_cleanup2(NULL, NULL, NULL);
+
+  mark_point();
+  p = make_sub_pool(permanent_pool);
+  register_cleanup2(p, NULL, NULL);
+
+  register_cleanup2(p, NULL, cleanup_cb);
+  destroy_pool(p);
+  fail_unless(pool_cleanup_count > 0, "Expected cleanup count >0, got %u",
+    pool_cleanup_count);
+}
+END_TEST
+
 START_TEST (pool_unregister_cleanup_test) {
   pool *p;
 
@@ -459,6 +478,7 @@ Suite *tests_get_pool_suite(void) {
   tcase_add_test(testcase, pool_debug_flags_test);
 #endif /* PR_USE_DEVEL */
   tcase_add_test(testcase, pool_register_cleanup_test);
+  tcase_add_test(testcase, pool_register_cleanup2_test);
   tcase_add_test(testcase, pool_unregister_cleanup_test);
 
   suite_add_tcase(suite, testcase);


### PR DESCRIPTION
…a pool.

So remove it, and provide an API that doesn't require that the caller pass
in a NULL callback for this.