### PR TITLE
PID file should never be world-writable

### DIFF
--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -52,10 +52,13 @@ int pr_pidfile_set(const char *path) {
 int pr_pidfile_write(void) {
   int xerrno;
   FILE *fh = NULL;
+  mode_t prev_mask;
 
   PRIVS_ROOT
+  prev_mask = umask(0113);
   fh = fopen(pidfile_path, "w");
   xerrno = errno;
+  umask(prev_mask);
   PRIVS_RELINQUISH
 
   if (fh == NULL) {


### PR DESCRIPTION
The PID file should be created with restrictive permissions 0664, not 0666 & umask (set via the Umask directive). Since version 1.19.3 start-stop-daemon refuses to start/stop the daemon if the PID file has world-write permission.