### PR TITLE
Store a pointer to the NetIO which created the NetIO stream in the fi…

### DIFF
--- a/include/netio.h
+++ b/include/netio.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2016 The ProFTPD Project team
+ * Copyright (c) 2001-2020 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,6 +84,8 @@ typedef struct {
 
 } pr_buffer_t;
 
+typedef struct netio_rec pr_netio_t;
+
 typedef struct {
 
   /* Memory pool for this object. */
@@ -118,12 +120,15 @@ typedef struct {
   /* Private data for passing/retaining among modules. */
   pr_table_t *notes;
 
+  /* Pointer to the NetIO which opened this stream. */
+  pr_netio_t *strm_netio;
+
 } pr_netio_stream_t;
 
 #define PR_NETIO_ERRNO(s)	((s)->strm_errno)
 #define PR_NETIO_FD(s)		((s)->strm_fd)
 
-typedef struct {
+struct netio_rec {
   /* Memory pool for this object. */
   struct pool_rec *pool;
 
@@ -141,8 +146,7 @@ typedef struct {
   /* Registering/owning module */
   module *owner;
   const char *owner_name;
-
-} pr_netio_t;
+};
 
 /* Network IO function prototypes */
 pr_buffer_t *pr_netio_buffer_alloc(pr_netio_stream_t *nstrm);

--- a/src/netio.c
+++ b/src/netio.c
@@ -609,7 +609,7 @@ int pr_netio_lingering_close(pr_netio_stream_t *nstrm, long linger) {
 
 pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
     int mode) {
-  pr_netio_stream_t *nstrm = NULL;
+  pr_netio_stream_t *nstrm = NULL, *res = NULL;
   const char *nstrm_mode;
 
   if (parent_pool == NULL) {
@@ -635,7 +635,10 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for control %s stream",
           ctrl_netio->owner_name, nstrm_mode);
-        return (ctrl_netio->open)(nstrm, fd, mode);
+        res = (ctrl_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = ctrl_netio;
+        }
 
       } else {
         if (pr_table_add(nstrm->notes, pstrdup(nstrm->strm_pool, "core.netio"),
@@ -646,8 +649,12 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for control %s stream",
           default_ctrl_netio->owner_name, nstrm_mode);
-        return (default_ctrl_netio->open)(nstrm, fd, mode);
+        res = (default_ctrl_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = default_ctrl_netio;
+        }
       }
+      break;
 
     case PR_NETIO_STRM_DATA:
       nstrm->strm_type = PR_NETIO_STRM_DATA;
@@ -662,7 +669,10 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for data %s stream",
           data_netio->owner_name, nstrm_mode);
-        return (data_netio->open)(nstrm, fd, mode);
+        res = (data_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = data_netio;
+        }
 
       } else {
         if (pr_table_add(nstrm->notes, pstrdup(nstrm->strm_pool, "core.netio"),
@@ -673,8 +683,12 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for data %s stream",
           default_data_netio->owner_name, nstrm_mode);
-        return (default_data_netio->open)(nstrm, fd, mode);
+        res = (default_data_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = default_data_netio;
+        }
       }
+      break;
 
     case PR_NETIO_STRM_OTHR:
       nstrm->strm_type = PR_NETIO_STRM_OTHR;
@@ -689,7 +703,10 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for other %s stream",
           othr_netio->owner_name, nstrm_mode);
-        return (othr_netio->open)(nstrm, fd, mode);
+        res = (othr_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = othr_netio;
+        }
 
       } else {
         if (pr_table_add(nstrm->notes, pstrdup(nstrm->strm_pool, "core.netio"),
@@ -700,15 +717,21 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
         }
         pr_trace_msg(trace_channel, 19, "using %s open() for other %s stream",
           default_othr_netio->owner_name, nstrm_mode);
-        return (default_othr_netio->open)(nstrm, fd, mode);
+        res = (default_othr_netio->open)(nstrm, fd, mode);
+        if (res != NULL) {
+          res->strm_netio = default_othr_netio;
+        }
       }
+      break;
+
+    default:
+      destroy_pool(nstrm->strm_pool);
+      nstrm->strm_pool = NULL;
+      errno = EINVAL;
+      res = NULL;
   }
 
-  destroy_pool(nstrm->strm_pool);
-  nstrm->strm_pool = NULL;
-
-  errno = EPERM;
-  return NULL;
+  return res;
 }
 
 pr_netio_stream_t *pr_netio_reopen(pr_netio_stream_t *nstrm, int fd, int mode) {

--- a/tests/api/netio.c
+++ b/tests/api/netio.c
@@ -109,28 +109,31 @@ START_TEST (netio_open_test) {
 
   nstrm = pr_netio_open(p, 7777, fd, PR_NETIO_IO_RD);
   fail_unless(nstrm == NULL, "Failed to handle unknown stream type argument");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   /* open/close CTRL stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
   fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
-
+  fail_unless(nstrm->strm_netio != NULL,
+    "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 
   /* open/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_WR);
   fail_unless(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
     strerror(errno));
-
+  fail_unless(nstrm->strm_netio != NULL,
+    "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 
   /* open/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_WR);
   fail_unless(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
     strerror(errno));
-
+  fail_unless(nstrm->strm_netio != NULL,
+    "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 }
 END_TEST


### PR DESCRIPTION
…rst place.

This is very useful for modules, like mod_proxy, which manipulate the NetIO
API with customized streams.