### PR TITLE
Save errno across call to pr_trace_msg()

### DIFF
--- a/src/netaddr.c
+++ b/src/netaddr.c
@@ -590,7 +590,7 @@ static pr_netaddr_t *get_addr_by_ip(pool *p, const char *name,
 static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
     array_header **addrs) {
   pr_netaddr_t *na = NULL;
-  int res;
+  int res, xerrno;
   struct addrinfo hints, *info = NULL;
 
   memset(&hints, 0, sizeof(hints));
@@ -599,11 +599,13 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = IPPROTO_TCP;
 
+  xerrno = errno;
   pr_trace_msg(trace_channel, 7,
     "attempting to resolve '%s' to IPv4 address via DNS", name);
+  errno = xerrno;
   res = pr_getaddrinfo(name, NULL, &hints, &info);
   if (res != 0) {
-    int xerrno = errno;
+    xerrno = errno;
 
     if (res != EAI_SYSTEM) {
 #ifdef PR_USE_IPV6
@@ -766,7 +768,7 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
       "attempting to resolve '%s' to IPv6 address via DNS", name);
     res = pr_getaddrinfo(name, NULL, &hints, &info);
     if (res != 0) {
-      int xerrno = errno;
+      xerrno = errno;
 
       if (res != EAI_SYSTEM) {
         pr_trace_msg(trace_channel, 1, "IPv6 getaddrinfo '%s' error: %s",


### PR DESCRIPTION
Since `pr_trace_msg()` can cause `errno` to be set, but we're actually interested in the `errno` values resulting from name lookups, save the value of `errno` across a call to `pr_trace_msg()`.
This PR is a result of tracking down a repeatable failure in the `netaddr` API test when run on Fedora 19 (and only on that OS release for some reason). The same test (name lookup for `134.289.999.0`) did not fail with 1.3.7rc3. With 1.3.7rc4 on Fedora 19, the `pr_trace_msg()` call sets `errno` to `EPERM` and, since the test expects `errno` to be `ENOENT`, it fails.
I haven't figured out why this only happens on Fedora 19 but I suspect that there may be a lot of places where tracing might affect `errno`.
