### PR TITLE
More protection of errno from pr_trace_msg()

### DIFF
--- a/src/netaddr.c
+++ b/src/netaddr.c
@@ -623,6 +623,7 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
 
         pr_trace_msg(trace_channel, 7,
           "attempting to resolve '%s' to IPv6 address via DNS", name);
+        errno = xerrno;
         res = pr_getaddrinfo(name, NULL, &hints, &info);
         if (res != 0) {
           xerrno = errno;


### PR DESCRIPTION
This one is similar to #1029 but manifested in Fedora 13 once I'd applied #1026 to support building with OpenSSL  1.1.0. I've basically restored the value of `errno` to what it was before a couple of calls to `pr_trace_msg()`.