### PR TITLE
mod_sftp: Fix check whether st_mode change is necessary

### DIFF
--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -1409,7 +1409,7 @@ static int fxp_attrs_set(pr_fh_t *fh, const char *path, struct stat *attrs,
 
   if (attr_flags & SSH2_FX_ATTR_PERMISSIONS) {
     if (attrs->st_mode &&
-        st.st_mode != attrs->st_mode) {
+        (st.st_mode & ~S_IFMT) != (attrs->st_mode & ~S_IFMT)) {
       cmd_rec *cmd;
 
       cmd = fxp_cmd_alloc(fxp->pool, "SITE_CHMOD", pstrdup(fxp->pool, path));
@@ -1436,7 +1436,7 @@ static int fxp_attrs_set(pr_fh_t *fh, const char *path, struct stat *attrs,
 
         (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
           "error changing permissions of '%s' to 0%o: %s", path,
-          (unsigned int) attrs->st_mode, strerror(xerrno));
+          (unsigned int) (attrs->st_mode & ~S_IFMT), strerror(xerrno));
 
         status_code = fxp_errno2status(xerrno, &reason);
 


### PR DESCRIPTION
When creating a file, the mode has to be sent with the fxp open call.
This doesn't contain the file type bits, but it is later compared against
the full st_mode which contains them. Therefore it attempts to do an
unnecessary chmod, which can fail due to SITE_CHMOD being disabled.

This fixes file creation with libssh or sftp as client.