### PR TITLE
Issue #1049: Use libtool to properly clean up the generated `.lo` fil…

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -37,6 +37,7 @@ install:
 
 clean:
 	$(RM) *.o libsupp.a
+	$(LIBTOOL) --mode=clean $(RM) `echo $(LIB_OBJS) | sed 's/\.o$\/.lo/g'`
 	test -z $(LIB_DEPS) || (cd libltdl/ && $(MAKE) clean)
 
 depend:


### PR DESCRIPTION
…es in the

`lib/` build directory.