### PR TITLE
Issue #1070: Enhance the `RedisServer` directive to take an optional …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,7 @@
 --------------------------------
 - Issue 1063 - FTPS data transfers using TLSv1.3 might segfault when session
   tickets cannot be decrypted.
+- Issue 1070 - Implement support for Redis 6.x AUTH semantics.
 
 1.3.7 - Released 20-Jul-2020
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -12,3 +12,12 @@ ChangeLog files.
   + Fixed occasional segfaults with FTPS data transfers using TLSv1.3, when
     session tickets cannot be decrypted (Issue #1063).
 
+
+  + Changed Directives
+
+    RedisServer
+      Redis 6.x changed its AUTH command, due to the Redis ACL system, for
+      supporting multiple users.  Thus the `RedisServer` directive now takes
+      a username, as well as a password.  The Redis server version is auto-
+      detected; the configured username will be ignored for Redis servers
+      older than Redis 6.x.

--- a/doc/modules/mod_redis.html
+++ b/doc/modules/mod_redis.html
@@ -234,16 +234,16 @@ supports multiple databases, then you <b>will</b> need to use
 <code>RedisServer</code> as well:
 <pre>
   # Use this to configure our password and database
-  RedisServer 127.0.0.1:6379 redisr0cks 2
+  RedisServer 127.0.0.1:6379 redis redisr0cks 2
 
   # And use Sentinels to discover the true address/port
-  RedisSentine 1.2.3.4 5.6.7.8 9.10.11.12
+  RedisSentinel 1.2.3.4 5.6.7.8 9.10.11.12
 </pre>
 
 <p>
 <hr>
 <h3><a name="RedisServer">RedisServer</a></h3>
-<strong>Syntax:</strong> RedisServer <em>server [password] [db-index]</em><br>
+<strong>Syntax:</strong> RedisServer <em>server [username] [password] [db-index]</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_redis<br>
@@ -269,19 +269,20 @@ Alternatively, you can configure a Unix domain socket path using <i>e.g.</i>:
 </pre>
 
 <p>
-An optional <em>password</em> parameter can be provided, for Redis servers
-which are password protected.
+Optional <em>username<em> and <em>password</em> parameters can be provided,
+for Redis servers which are password protected.
 
 <p>
 As of ProFTPD 1.3.7rc1, the optional <em>db-index</em> parameter can be
 provided, for <i>selecting</i> the server-side Redis database by index:
 <pre>
-  RedisServer 1.2.3.4:6379 passwd 2
+  RedisServer 1.2.3.4:6379 user passwd 2
 </pre>
 Connecting to a Redis server without password authentication <i>but</i> still
-selecting the database would be done using the empty string for the password:
+selecting the database would be done using the empty string for the username
+and password:
 <pre>
-  RedisServer 1.2.3.4:6379 "" 2
+  RedisServer 1.2.3.4:6379 "" "" 2
 </pre>
 
 <p>


### PR DESCRIPTION
…username,

for supporting Redis 6.x servers.