### PR TITLE
netaddr API test: check for EAGAIN too

### DIFF
--- a/tests/api/netaddr.c
+++ b/tests/api/netaddr.c
@@ -135,7 +135,8 @@ START_TEST (netaddr_get_addr_test) {
 
   res = pr_netaddr_get_addr(p, name, NULL);
   fail_unless(res == NULL, "Unexpected got address for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  fail_unless(errno == ENOENT || errno == EAGAIN,
+    "Expected ENOENT (%d) or EAGAIN (%d), got %s (%d)", ENOENT, EAGAIN,
     strerror(errno), errno);
 
   name = "localhost";
@@ -190,7 +191,8 @@ START_TEST (netaddr_get_addr_test) {
 
   res = pr_netaddr_get_addr(p, name, NULL);
   fail_unless(res == NULL, "Resolved '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  fail_unless(errno == ENOENT || errno == EAGAIN,
+    "Expected ENOENT (%d) or EAGAIN (%d), got %s (%d)", ENOENT, EAGAIN,
     strerror(errno), errno);
 
 #if defined(PR_USE_IPV6)


### PR DESCRIPTION
If the test suite is run in an environment with networking disabled, `getaddrinfo()` can set `errno` to `EAGAIN` when doing lookups of things that don't look like valid IP addresses.

This cropped up in current Fedora Rawhide where the IPv6 lookups (but not the IPv4 lookups) of "134.289.999.0" and "foo.bar.castaglia.example.com" set `errno` to `EAGAIN` when the API tests were run in a network-disabled build environment.