### PR TITLE
Use the `-Wconstant-conversion` compiler warning, where available.

### DIFF
--- a/configure
+++ b/configure
@@ -25181,6 +25181,19 @@ $as_echo "no" >&6; }
    fi
    rm -fr conftest*
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-cc} accepts -Wconstant-conversion" >&5
+$as_echo_n "checking whether ${CC-cc} accepts -Wconstant-conversion... " >&6; }
+   echo 'void f(){}' > conftest.c
+   if test -z "`${CC-cc} -c -Wconstant-conversion conftest.c 2>&1`"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+     CFLAGS="$CFLAGS -Wconstant-conversion"
+   else
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+   fi
+   rm -fr conftest*
+
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-cc} accepts -Wdangling-else" >&5
 $as_echo_n "checking whether ${CC-cc} accepts -Wdangling-else... " >&6; }
    echo 'void f(){}' > conftest.c

--- a/configure.in
+++ b/configure.in
@@ -4096,6 +4096,7 @@ if test x"$devel" = xyes ; then
     dnl options.  Check if they are supported.  They will be added to
     dnl CFLAGS if supported.
     PR_CHECK_CC_OPT(Wcomment)
+    PR_CHECK_CC_OPT(Wconstant-conversion)
     PR_CHECK_CC_OPT(Wdangling-else)
     PR_CHECK_CC_OPT(Wdeclaration-after-statement)
     PR_CHECK_CC_OPT(Wduplicated-branches)

--- a/contrib/mod_sftp/msg.c
+++ b/contrib/mod_sftp/msg.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp message format
- * Copyright (c) 2008-2019 TJ Saunders
+ * Copyright (c) 2008-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@ unsigned char *sftp_msg_getbuf(pool *p, size_t sz) {
 }
 
 uint32_t sftp_msg_read_byte2(pool *p, unsigned char **buf, uint32_t *buflen,
-    char *byte) {
+    unsigned char *byte) {
   (void) p;
 
   if (*buflen < sizeof(char)) {
@@ -62,15 +62,16 @@ uint32_t sftp_msg_read_byte2(pool *p, unsigned char **buf, uint32_t *buflen,
     return 0;
   }
 
-  memcpy(byte, *buf, sizeof(char));
-  (*buf) += sizeof(char);
-  (*buflen) -= sizeof(char);
+  memcpy(byte, *buf, sizeof(unsigned char));
+  (*buf) += sizeof(unsigned char);
+  (*buflen) -= sizeof(unsigned char);
 
-  return sizeof(char);
+  return sizeof(unsigned char);
 }
 
-char sftp_msg_read_byte(pool *p, unsigned char **buf, uint32_t *buflen) {
-  char byte = 0;
+unsigned char sftp_msg_read_byte(pool *p, unsigned char **buf,
+    uint32_t *buflen) {
+  unsigned char byte = 0;
   uint32_t len;
 
   len = sftp_msg_read_byte2(p, buf, buflen, &byte);
@@ -84,7 +85,7 @@ char sftp_msg_read_byte(pool *p, unsigned char **buf, uint32_t *buflen) {
 
 uint32_t sftp_msg_read_bool2(pool *p, unsigned char **buf, uint32_t *buflen,
     int *bool) {
-  char byte = 0;
+  unsigned char byte = 0;
   uint32_t len;
 
   (void) p;
@@ -449,7 +450,8 @@ EC_POINT *sftp_msg_read_ecpoint(pool *p, unsigned char **buf, uint32_t *buflen,
 }
 #endif /* PR_USE_OPENSSL_ECC */
 
-uint32_t sftp_msg_write_byte(unsigned char **buf, uint32_t *buflen, char byte) {
+uint32_t sftp_msg_write_byte(unsigned char **buf, uint32_t *buflen,
+    unsigned char byte) {
   uint32_t len = 0;
 
   if (*buflen < sizeof(char)) {
@@ -460,7 +462,7 @@ uint32_t sftp_msg_write_byte(unsigned char **buf, uint32_t *buflen, char byte) {
     SFTP_DISCONNECT_CONN(SFTP_SSH2_DISCONNECT_BY_APPLICATION, NULL);
   }
 
-  len = sizeof(char);
+  len = sizeof(unsigned char);
 
   memcpy(*buf, &byte, len);
   (*buf) += len;
@@ -469,7 +471,8 @@ uint32_t sftp_msg_write_byte(unsigned char **buf, uint32_t *buflen, char byte) {
   return len;
 }
 
-uint32_t sftp_msg_write_bool(unsigned char **buf, uint32_t *buflen, char bool) {
+uint32_t sftp_msg_write_bool(unsigned char **buf, uint32_t *buflen,
+    unsigned char bool) {
   return sftp_msg_write_byte(buf, buflen, bool == 0 ? 0 : 1);
 }
 

--- a/contrib/mod_sftp/msg.h
+++ b/contrib/mod_sftp/msg.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp message format
- * Copyright (c) 2008-2019 TJ Saunders
+ * Copyright (c) 2008-2020 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@
 
 #include "mod_sftp.h"
 
-char sftp_msg_read_byte(pool *, unsigned char **, uint32_t *);
+unsigned char sftp_msg_read_byte(pool *, unsigned char **, uint32_t *);
 int sftp_msg_read_bool(pool *, unsigned char **, uint32_t *);
 unsigned char *sftp_msg_read_data(pool *, unsigned char **, uint32_t *, size_t);
 #ifdef PR_USE_OPENSSL_ECC
@@ -43,7 +43,7 @@ char *sftp_msg_read_string(pool *, unsigned char **, uint32_t *);
  * of bytes of the message actually read.  A zero-length return value indicates
  * failure to read the requested data type.
  */
-uint32_t sftp_msg_read_byte2(pool *, unsigned char **, uint32_t *, char *);
+uint32_t sftp_msg_read_byte2(pool *, unsigned char **, uint32_t *, unsigned char *);
 uint32_t sftp_msg_read_bool2(pool *, unsigned char **, uint32_t *, int *);
 uint32_t sftp_msg_read_data2(pool *, unsigned char **, uint32_t *, size_t, unsigned char **);
 #ifdef PR_USE_OPENSSL_ECC
@@ -55,8 +55,8 @@ uint32_t sftp_msg_read_long2(pool *, unsigned char **, uint32_t *, uint64_t *);
 uint32_t sftp_msg_read_mpint2(pool *, unsigned char **, uint32_t *, BIGNUM **);
 uint32_t sftp_msg_read_string2(pool *, unsigned char **, uint32_t *, char **);
 
-uint32_t sftp_msg_write_byte(unsigned char **, uint32_t *, char);
-uint32_t sftp_msg_write_bool(unsigned char **, uint32_t *, char);
+uint32_t sftp_msg_write_byte(unsigned char **, uint32_t *, unsigned char);
+uint32_t sftp_msg_write_bool(unsigned char **, uint32_t *, unsigned char);
 uint32_t sftp_msg_write_data(unsigned char **, uint32_t *,
   const unsigned char *, size_t, int);
 #ifdef PR_USE_OPENSSL_ECC


### PR DESCRIPTION
And address these warnings for mod_sftp.