### PR TITLE
Add log message when modifying fact fails

### DIFF
--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -1029,6 +1029,8 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
   if (pr_fsio_utimes_with_root(path, tvs) < 0) {
     int xerrno = errno;
 
+    pr_log_debug(DEBUG2, MOD_SITE_MISC_VERSION
+        ": error modifying fact for '%s': %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;
@@ -1211,6 +1213,8 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
   if (pr_fsio_utimes_with_root(path, tvs) < 0) {
     int xerrno = errno;
 
+    pr_log_debug(DEBUG2, MOD_SITE_MISC_VERSION
+        ": error modifying fact for '%s': %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -1030,7 +1030,7 @@ MODRET site_misc_utime_mtime(cmd_rec *cmd) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG2, MOD_SITE_MISC_VERSION
-        ": error modifying fact for '%s': %s", path, strerror(xerrno));
+        ": error modifying timestamps for '%s': %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;
@@ -1214,7 +1214,7 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG2, MOD_SITE_MISC_VERSION
-        ": error modifying fact for '%s': %s", path, strerror(xerrno));
+        ": error modifying timestamps for '%s': %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     errno = xerrno;

--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -905,7 +905,7 @@ static int facts_modify_mtime(pool *p, const char *path, char *timestamp) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG2, MOD_FACTS_VERSION
-      ": error modifying modify fact for '%s': %s", path, strerror(xerrno));
+      ": error modifying fact for '%s': %s", path, strerror(xerrno));
     errno = xerrno;
     return -1;
   }


### PR DESCRIPTION
Add debug log message for modifying fact fails, before sending the error to the client.