### PR TITLE
Add log message in site_misc_symlink()

### DIFF
--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -892,6 +892,8 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
     if (res < 0) {
       int xerrno = errno;
 
+      pr_log_debug(DEBUG7, MOD_SITE_MISC_VERSION
+        "unable to stat '%s': %s", src, strerror(xerrno));
       pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
       errno = xerrno;
@@ -901,6 +903,8 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
     if (pr_fsio_symlink(src, dst) < 0) {
       int xerrno = errno;
 
+      pr_log_debug(DEBUG2, MOD_SITE_MISC_VERSION
+        ": error symlinking '%s' to '%s': %s", src, dst, strerror(xerrno));
       pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
       errno = xerrno;


### PR DESCRIPTION
Create debug log messages before sending error to the clients.