### PR TITLE
Add log message in when check <Limit> config fails 

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -5433,6 +5433,8 @@ MODRET core_rmd(cmd_rec *cmd) {
   if (!dir_check_canon(cmd->tmp_pool, cmd, cmd->group, dir, NULL)) {
     int xerrno = EACCES;
 
+    pr_log_debug(DEBUG8, "%s command denied by <Limit> config",
+      (char *) cmd->argv[0]);
     pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -5994,6 +5996,10 @@ MODRET core_rnto(cmd_rec *cmd) {
 
   if (!path ||
       !dir_check_canon(cmd->tmp_pool, cmd, cmd->group, path, NULL)) {
+    if (path) {
+      pr_log_debug(DEBUG8, "%s command denied by <Limit> config",
+        (char *) cmd->argv[0]);
+    }
     pr_response_add_err(R_550, _("%s: %s"), cmd->arg, strerror(EPERM));
 
     pr_cmd_set_errno(cmd, EPERM);


### PR DESCRIPTION
Some logs are missing for dir_check_canon() to check the <Limit> config