### PR TITLE
Add log message for pr_fsio_stat() failures

### DIFF
--- a/contrib/mod_digest.c
+++ b/contrib/mod_digest.c
@@ -1872,7 +1872,7 @@ static modret_t *digest_xcmd(cmd_rec *cmd, unsigned long algo) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
-      ": unable to stat %s: %s", path, strerror(xerrno));
+      ": error checking %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -2038,7 +2038,7 @@ MODRET digest_hash(cmd_rec *cmd) {
     xerrno = errno;
 
     pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
-      ": unable to stat %s: %s", path, strerror(xerrno));
+      ": error checking %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -2622,7 +2622,7 @@ MODRET digest_md5(cmd_rec *cmd) {
     xerrno = errno;
 
     pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
-      ": unable to stat %s: %s", path, strerror(xerrno));
+      ": error checking %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);

--- a/contrib/mod_digest.c
+++ b/contrib/mod_digest.c
@@ -1871,6 +1871,8 @@ static modret_t *digest_xcmd(cmd_rec *cmd, unsigned long algo) {
   if (pr_fsio_stat(path, &st) < 0) {
     int xerrno = errno;
 
+    pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
+      ": unable to stat %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -2035,6 +2037,8 @@ MODRET digest_hash(cmd_rec *cmd) {
   if (pr_fsio_stat(path, &st) < 0) {
     xerrno = errno;
 
+    pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
+      ": unable to stat %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -2617,6 +2621,8 @@ MODRET digest_md5(cmd_rec *cmd) {
   if (pr_fsio_stat(path, &st) < 0) {
     xerrno = errno;
 
+    pr_log_debug(DEBUG8, MOD_DIGEST_VERSION
+      ": unable to stat %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_550, "%s: %s", orig_path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -338,7 +338,7 @@ static int site_misc_delete_path(pool *p, const char *path) {
   pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) < 0) {
     pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
-      ": unable to stat path %s", path);
+      ": error checking path %s", path);
     return -1;
   }
 
@@ -902,7 +902,7 @@ MODRET site_misc_symlink(cmd_rec *cmd) {
       int xerrno = errno;
 
       pr_log_debug(DEBUG7, MOD_SITE_MISC_VERSION
-        "unable to stat '%s': %s", src, strerror(xerrno));
+        ": error checking '%s': %s", src, strerror(xerrno));
       pr_response_add_err(R_550, "%s: %s", cmd->arg, strerror(xerrno));
 
       errno = xerrno;

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -337,6 +337,8 @@ static int site_misc_delete_path(pool *p, const char *path) {
 
   pr_fs_clear_cache2(path);
   if (pr_fsio_stat(path, &st) < 0) {
+    pr_log_debug(DEBUG4, MOD_SITE_MISC_VERSION
+      ": unable to stat path %s", path);
     return -1;
   }
 

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -2045,7 +2045,8 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
             (list_flags & LS_FL_NO_ERROR_IF_ABSENT)) {
           return 0;
         }
-
+        pr_log_debug(DEBUG8,
+          "Unable to stat %s: %s", target, strerror(xerrno));
         pr_response_add_err(R_450, "%s: %s",
           pr_fs_encode_path(cmd->tmp_pool, target), strerror(xerrno));
 
@@ -2931,6 +2932,8 @@ MODRET ls_stat(cmd_rec *cmd) {
   if (res < 0) {
     int xerrno = errno;
 
+    pr_log_debug(DEBUG8,
+          "Unable to stat %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_450, "%s: %s", path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -3181,6 +3184,8 @@ MODRET ls_nlst(cmd_rec *cmd) {
             return PR_HANDLED(cmd);
           }
 
+          pr_log_debug(DEBUG8,
+            "Unable to stat %s: %s", target, strerror(errno));
           pr_response_add_err(R_450, _("No files found"));
 
           pr_cmd_set_errno(cmd, ENOENT);
@@ -3389,6 +3394,8 @@ MODRET ls_nlst(cmd_rec *cmd) {
         return PR_HANDLED(cmd);
       }
 
+      pr_log_debug(DEBUG8,
+          "Unable to stat %s: %s", target, strerror(xerrno));
       pr_response_add_err(R_450, "%s: %s", cmd->arg, strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);

--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -2046,7 +2046,7 @@ static int dolist(cmd_rec *cmd, const char *opt, const char *resp_code,
           return 0;
         }
         pr_log_debug(DEBUG8,
-          "Unable to stat %s: %s", target, strerror(xerrno));
+          "error checking %s: %s", target, strerror(xerrno));
         pr_response_add_err(R_450, "%s: %s",
           pr_fs_encode_path(cmd->tmp_pool, target), strerror(xerrno));
 
@@ -2933,7 +2933,7 @@ MODRET ls_stat(cmd_rec *cmd) {
     int xerrno = errno;
 
     pr_log_debug(DEBUG8,
-          "Unable to stat %s: %s", path, strerror(xerrno));
+          "error checking %s: %s", path, strerror(xerrno));
     pr_response_add_err(R_450, "%s: %s", path, strerror(xerrno));
 
     pr_cmd_set_errno(cmd, xerrno);
@@ -3185,7 +3185,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
           }
 
           pr_log_debug(DEBUG8,
-            "Unable to stat %s: %s", target, strerror(errno));
+            "error checking %s: %s", target, strerror(errno));
           pr_response_add_err(R_450, _("No files found"));
 
           pr_cmd_set_errno(cmd, ENOENT);
@@ -3395,7 +3395,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
       }
 
       pr_log_debug(DEBUG8,
-          "Unable to stat %s: %s", target, strerror(xerrno));
+          "error checking %s: %s", target, strerror(xerrno));
       pr_response_add_err(R_450, "%s: %s", cmd->arg, strerror(xerrno));
 
       pr_cmd_set_errno(cmd, xerrno);

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -1904,7 +1904,7 @@ MODRET xfer_stor(cmd_rec *cmd) {
       xerrno = errno;
 
     } else if (pr_fsio_stat(path, &st) < 0) {
-      pr_log_debug(DEBUG4, "unable to stat '%s': %s", cmd->arg,
+      pr_log_debug(DEBUG4, "error checking '%s': %s", cmd->arg,
         strerror(errno));
       xerrno = errno;
     }
@@ -2651,7 +2651,7 @@ MODRET xfer_retr(cmd_rec *cmd) {
   if (pr_fsio_fstat(retr_fh, &st) < 0) {
     /* Error stat'ing the file. */
     xerrno = errno;
-    pr_log_debug(DEBUG6, "unable to stat retr path '%s': %s",
+    pr_log_debug(DEBUG6, "error checking path '%s': %s",
       dir, strerror(xerrno));
 
     pr_fsio_close(retr_fh);
@@ -4275,7 +4275,7 @@ static int xfer_sess_init(void) {
 
     } else {
       if (pr_fsio_fstat(displayfilexfer_fh, &st) < 0) {
-        pr_log_debug(DEBUG6, "unable to stat DisplayFileTransfer file '%s': %s",
+        pr_log_debug(DEBUG6, "error checking DisplayFileTransfer file '%s': %s",
           displayfilexfer, strerror(errno));
         pr_fsio_close(displayfilexfer_fh);
         displayfilexfer_fh = NULL;

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -2651,6 +2651,8 @@ MODRET xfer_retr(cmd_rec *cmd) {
   if (pr_fsio_fstat(retr_fh, &st) < 0) {
     /* Error stat'ing the file. */
     xerrno = errno;
+    pr_log_debug(DEBUG6, "unable to stat retr path '%s': %s",
+      dir, strerror(xerrno));
 
     pr_fsio_close(retr_fh);
     retr_fh = NULL;


### PR DESCRIPTION
Add a bunch of log messages and before sending the clients the error msg, when `pr_fsio_stat()` or `pr_fsio_fstat()` fails 