### PR TITLE
Issue #1149: Skip escaping of already-escaped SQL text.

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
@@ -1299,7 +1299,7 @@ EOS
     ScoreboardFile => $scoreboard_file,
     SystemLog => $log_file,
     TraceLog => $log_file,
-    Trace => 'DEFAULT:10',
+    Trace => 'DEFAULT:10 jot:30 sql:20',
 
     DefaultChdir => '~',
 


### PR DESCRIPTION
The introduction of the Jot API added proper escaping of resolved text.
However, the mod_quotatab_sql module was already escaping some of its text
in INSERT statements (but, inconsistently, not in SELECT statements), thus
the Jot API refactoring caused a regression.