### PR TITLE
Issue #548: Do not re-compile the executable when the `make install` …

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -204,7 +204,7 @@ install-man: $(DESTDIR)$(mandir) $(DESTDIR)$(mandir)/man1 $(DESTDIR)$(mandir)/ma
 
 install-all: install-proftpd install-modules install-utils install-conf install-man install-libs install-headers install-pkgconfig install-locales $(INSTALL_DEPS)
 
-install: $(BUILD_BIN) install-all
+install: install-all
 
 depend:
 	cd src/     && $(MAKE) depend


### PR DESCRIPTION
…target is used.