### PR TITLE
Issue #1111: Update our implementation of UMAC algorithm with upstream.

### DIFF
--- a/configure
+++ b/configure
@@ -15032,6 +15032,29 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -fno-strict-aliasing" >&5
+$as_echo_n "checking whether the C compiler accepts -fno-strict-aliasing... " >&6; }
+  CFLAGS="-fno-strict-aliasing"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; fullCFLAGS="$fullCFLAGS $CFLAGS"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
   CFLAGS="-g2 $fullCFLAGS"
 fi
 
@@ -16293,7 +16316,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 16296 "configure"
+#line 16319 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H

--- a/configure.in
+++ b/configure.in
@@ -1,7 +1,7 @@
 dnl ProFTPD - FTP server daemon
 dnl Copyright (c) 1997, 1998 Public Flood Software
 dnl Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
-dnl Copyright (c) 2001-2020 The ProFTPD Project team
+dnl Copyright (c) 2001-2021 The ProFTPD Project team
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -130,6 +130,13 @@ if test $ac_cv_prog_gcc = yes; then
   dnl test for -fno-omit-frame-pointer
   AC_MSG_CHECKING([whether the C compiler accepts -fno-omit-frame-pointer])
   CFLAGS="-fno-omit-frame-pointer"
+  AC_TRY_COMPILE(,,
+    AC_MSG_RESULT(yes); fullCFLAGS="$fullCFLAGS $CFLAGS",
+    AC_MSG_RESULT(no))
+
+  dnl test for -fno-strict-aliasing
+  AC_MSG_CHECKING([whether the C compiler accepts -fno-strict-aliasing])
+  CFLAGS="-fno-strict-aliasing"
   AC_TRY_COMPILE(,,
     AC_MSG_RESULT(yes); fullCFLAGS="$fullCFLAGS $CFLAGS",
     AC_MSG_RESULT(no))

--- a/contrib/mod_sftp/umac.h
+++ b/contrib/mod_sftp/umac.h
@@ -53,21 +53,21 @@
 struct umac_ctx *umac_alloc(void);
 /* Dynamically allocate a umac_ctx struct. */
 
-struct umac_ctx *umac_new(unsigned char key[]);
+struct umac_ctx *umac_new(const unsigned char key[]);
 /* Dynamically allocate a umac_ctx struct, initialize variables, 
  * generate subkeys from key.
  */
 
-void umac_init(struct umac_ctx *ctx, unsigned char key[]);
+void umac_init(struct umac_ctx *ctx, const unsigned char key[]);
 /* Initialize a previously allocated umac_ctx struct. */
 
 int umac_reset(struct umac_ctx *ctx);
 /* Reset a umac_ctx to begin authenticating a new message */
 
-int umac_update(struct umac_ctx *ctx, unsigned char *input, long len);
+int umac_update(struct umac_ctx *ctx, const unsigned char *input, long len);
 /* Incorporate len bytes pointed to by input into context ctx */
 
-int umac_final(struct umac_ctx *ctx, unsigned char tag[], unsigned char nonce[8]);
+int umac_final(struct umac_ctx *ctx, unsigned char tag[], const unsigned char nonce[8]);
 /* Incorporate any pending data and the ctr value, and return tag. 
  * This function returns error code if ctr < 0. 
  */
@@ -80,11 +80,11 @@ int umac_delete(struct umac_ctx *ctx);
  * preprocessor macros to get the umac-128 implementation.
  */
 struct umac_ctx *umac128_alloc(void);
-struct umac_ctx *umac128_new(unsigned char key[]);
-void umac128_init(struct umac_ctx *ctx, unsigned char key[]);
+struct umac_ctx *umac128_new(const unsigned char key[]);
+void umac128_init(struct umac_ctx *ctx, const unsigned char key[]);
 int umac128_reset(struct umac_ctx *ctx);
-int umac128_update(struct umac_ctx *ctx, unsigned char *input, long len);
-int umac128_final(struct umac_ctx *ctx, unsigned char tag[], unsigned char nonce[8]);
+int umac128_update(struct umac_ctx *ctx, const unsigned char *input, long len);
+int umac128_final(struct umac_ctx *ctx, unsigned char tag[], const unsigned char nonce[8]);
 int umac128_delete(struct umac_ctx *ctx);
 
 #ifdef __cplusplus


### PR DESCRIPTION
At the same time, ensure the use of the `-fno-strict-aliasing` compiler option,
where supported.

We found that, with this combination of changes, even with the "buggy"
gcc-10 versions, the `umac-64@openssh.com` SFTP algorithm works once more
as expected.