### PR TITLE
Issue #1134: Explicitly avoid using `fgetpwent(3)` _et al_ in `mod_au…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -306,12 +306,6 @@
 /* Define if you have the fdatasync function.  */
 #undef HAVE_FDATASYNC
 
-/* Define if you have the fgetgrent function.  */
-#undef HAVE_FGETGRENT
-
-/* Define if you have the fgetpwent function.  */
-#undef HAVE_FGETPWENT
-
 /* Define if you have the flock function.  */
 #undef HAVE_FLOCK
 

--- a/configure
+++ b/configure
@@ -21217,7 +21217,7 @@ done
 
 
 
-for ac_func in bcopy crypt ctime_r fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo
+for ac_func in bcopy crypt ctime_r fdatasync fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.in
+++ b/configure.in
@@ -1920,7 +1920,7 @@ AC_PROG_GCC_TRADITIONAL
 AC_TYPE_SIGNAL
 AC_FUNC_VPRINTF
 
-AC_CHECK_FUNCS(bcopy crypt ctime_r fdatasync fgetgrent fgetpwent fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo)
+AC_CHECK_FUNCS(bcopy crypt ctime_r fdatasync fgetspent flock fpathconf freeaddrinfo fsync futimes getifaddrs getpgid getpgrp gmtime_r localtime_r mkdtemp nl_langinfo)
 
 AC_CHECK_FUNC(gai_strerror,
   AC_DEFINE(HAVE_GAI_STRERROR, 1,


### PR DESCRIPTION
…th_file`, since newer library changes lead to slow logins.