### PR TITLE
build: Fix linking the static libsupp.a library.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -88,7 +88,7 @@ if test $ac_cv_prog_gcc = no -a "$OSTYPE" = "-DHPUX10"; then
   CFLAGS="$CFLAGS -Ae"
 fi
 
-LDFLAGS="-L\$(top_srcdir)/lib -L\$(top_builddir)/lib $LDFLAGS"
+LDFLAGS="-Wl,-L\$(top_srcdir)/lib,-L\$(top_builddir)/lib $LDFLAGS"
 
 # AIX has issues with the -rdynamic linker flag.  How many different AIX
 # versions should we support here?


### PR DESCRIPTION
When building proftpd with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
/usr/bin/ld: cannot find -lsupp
```
This is because only `lib/libsupp.a` is created without `$(LIBTOOL)` and there is no `.la` file to rely on which would tell where or what to link to. GNU libtool just consumes `-L./lib` and happens to work while slibtool changes it to `-L./lib/.libs`.

Given this I think the best choice is to link against `lib/libsupp.a` directly and get rid of all the `-lsupp` from `configure.in`.

Alternatives would be to use `-Wl,-L./libs` instead or to create libsupp with `$(LIBTOOL)`.

Also see this proftpd issue made for the slibtool tracker:  https://dev.midipix.org/cross/slibtool/issue/25

Full build log using the current git master: [proftpd.log](https://github.com/proftpd/proftpd/files/6176773/proftpd.log)