### PR TITLE
Documentation - How to - Fix invalid use of a directive in mod_sql how to

### DIFF
--- a/doc/howto/SQL.html
+++ b/doc/howto/SQL.html
@@ -786,7 +786,7 @@ And in your <code>proftpd.conf</code>:
       # MySQL uses lowercase hex-encoded strings for MD5() et al
       SQLPasswordEncoding hex
 
-      SQLBackend SHA256 SHA1 MD5 Backend
+      SQLAuthTypes SHA256 SHA1 MD5 Backend
     &lt;/IfModule&gt;
   &lt;/IfModule&gt;
 </pre>


### PR DESCRIPTION
Replace SQLBackend directive with SQLAuthTypes directive (copy/paste error?)