### PR TITLE
Issue #1212: When constructing the SQL statements for MySQL, use back…

### DIFF
--- a/contrib/mod_sql_mysql.c
+++ b/contrib/mod_sql_mysql.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_sql_mysql -- Support for connecting to MySQL databases.
  * Copyright (c) 2001 Andrew Houghton
- * Copyright (c) 2004-2020 TJ Saunders
+ * Copyright (c) 2004-2021 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -547,6 +547,7 @@ MODRET cmd_open(cmd_rec *cmd) {
     return mr;
   }
 
+  sql_log(DEBUG_FUNC, "MySQL version ID: %d", MYSQL_VERSION_ID);
   sql_log(DEBUG_FUNC, "MySQL client version: %s", mysql_get_client_info());
   sql_log(DEBUG_FUNC, "MySQL server version: %s",
     mysql_get_server_info(conn->mysql));
@@ -1117,7 +1118,11 @@ MODRET cmd_select(cmd_rec *cmd) {
     query = pstrcat(cmd->tmp_pool, "SELECT ", cmd->argv[1], NULL);
 
   } else {
-    query = pstrcat(cmd->tmp_pool, cmd->argv[2], " FROM ", cmd->argv[1], NULL);
+    /* Make sure to properly quote the table name, as it might be a reserved
+     * keyword; see Issue #1212.
+     */
+    query = pstrcat(cmd->tmp_pool, cmd->argv[2], " FROM `", cmd->argv[1], "`",
+      NULL);
 
     if (cmd->argc > 3 &&
         cmd->argv[3]) {
@@ -1256,7 +1261,10 @@ MODRET cmd_insert(cmd_rec *cmd) {
     query = pstrcat(cmd->tmp_pool, "INSERT ", cmd->argv[1], NULL);
 
   } else {
-    query = pstrcat(cmd->tmp_pool, "INSERT INTO ", cmd->argv[1], " (",
+    /* Make sure to properly quote the table name, as it might be a reserved
+     * keyword; see Issue #1212.
+     */
+    query = pstrcat(cmd->tmp_pool, "INSERT INTO `", cmd->argv[1], "` (",
       cmd->argv[2], ") VALUES (", cmd->argv[3], ")", NULL);
   }
 
@@ -1352,7 +1360,10 @@ MODRET cmd_update(cmd_rec *cmd) {
     query = pstrcat(cmd->tmp_pool, "UPDATE ", cmd->argv[1], NULL);
 
   } else {
-    query = pstrcat(cmd->tmp_pool, "UPDATE ", cmd->argv[1], " SET ",
+    /* Make sure to properly quote the table name, as it might be a reserved
+     * keyword; see Issue #1212.
+     */
+    query = pstrcat(cmd->tmp_pool, "UPDATE `", cmd->argv[1], "` SET ",
       cmd->argv[2], NULL);
     if (cmd->argc > 3 &&
         cmd->argv[3]) {

--- a/doc/howto/SQL.html
+++ b/doc/howto/SQL.html
@@ -231,7 +231,7 @@ to the <code>SQLAuthenticate</code> directive, you should create both the
 <p>
 To create a user table:
 <pre>
-  CREATE TABLE users (
+  CREATE TABLE `users` (
     userid VARCHAR(30) NOT NULL UNIQUE,
     passwd VARCHAR(80) NOT NULL,
     uid INTEGER UNIQUE,
@@ -241,13 +241,12 @@ To create a user table:
   );
 
   CREATE INDEX users_userid_idx ON users (userid);
-
 </pre>
 (<i>Note</i>: if you plan to reuse the same UID for multiple users, then you
 will need to remove the <code>UNIQUE</code> from the <code>uid</code> column
 description).  To create a group table:
 <pre>
-  CREATE TABLE groups (
+  CREATE TABLE `groups` (
     groupname VARCHAR(30) NOT NULL,
     gid INTEGER NOT NULL,
     members VARCHAR(255)
@@ -942,7 +941,7 @@ compiled with SSL support.
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2017-2020 The ProFTPD Project<br>
+&copy; Copyright 2017-2021 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>


### PR DESCRIPTION
…ticks to

quote the table name, as they may be reserved keywords.

Thanks, MySQL 8.x.