### PR TITLE
Issue #763: Start working to stop using OpenSSL functions deprecated …

### DIFF
--- a/contrib/mod_auth_otp/auth-otp.c
+++ b/contrib/mod_auth_otp/auth-otp.c
@@ -1,6 +1,6 @@
 /*
  * auth-otp: HOTP/TOTP tool for ProFTPD mod_auth_otp module
- * Copyright 2016 The ProFTPD Project team
+ * Copyright 2016-2021 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -262,11 +262,12 @@ int main(int argc, char **argv) {
 
   auth_otp_pool = make_sub_pool(NULL);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(HAVE_LIBRESSL)
   OPENSSL_config(NULL);
-#endif /* prior to OpenSSL-1.1.x */
   ERR_load_crypto_strings();
   OpenSSL_add_all_algorithms();
+#endif /* prior to OpenSSL-1.1.x */
 
   secret = generate_secret(auth_otp_pool);  
   if (secret == NULL) {
@@ -296,9 +297,11 @@ int main(int argc, char **argv) {
     fprintf(stdout, "-------------------------------------------------\n");
   }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   ERR_free_strings();
   EVP_cleanup();
   RAND_cleanup();
+#endif /* prior to OpenSSL-1.1.x */
 
   destroy_pool(auth_otp_pool);
   return 0;

--- a/contrib/mod_auth_otp/crypto.c
+++ b/contrib/mod_auth_otp/crypto.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_auth_otp OpenSSL interface
- * Copyright (c) 2015-2018 TJ Saunders
+ * Copyright (c) 2015-2021 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,23 +47,14 @@ void auth_otp_crypto_free(int flags) {
       pr_module_get("mod_sql_passwd.c") == NULL &&
       pr_module_get("mod_tls.c") == NULL) {
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ERR_free_strings();
-
-#if OPENSSL_VERSION_NUMBER >= 0x10000001L
-# if OPENSSL_VERSION_NUMBER >= 0x10100000L
-    /* The ERR_remove_state(0) usage is deprecated due to thread ID
-     * differences among platforms; see the OpenSSL-1.0.0c CHANGES file
-     * for details.  So for new enough OpenSSL installations, use the
-     * proper way to clear the error queue state.
-     */
-    ERR_remove_thread_state(NULL);
-# endif /* OpenSSL-1.1.x and later */
-#else
-    ERR_remove_state(0);
-#endif /* OpenSSL prior to 1.0.0-beta1 */
-
     EVP_cleanup();
     RAND_cleanup();
+# if OPENSSL_VERSION_NUMBER >= 0x10000001L
+    ERR_remove_state(0);
+# endif /* OpenSSL prior to 1.0.0-beta1 */
+#endif
   }
 }
 

--- a/contrib/mod_sftp/crypto.c
+++ b/contrib/mod_sftp/crypto.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp OpenSSL interface
- * Copyright (c) 2008-2017 TJ Saunders
+ * Copyright (c) 2008-2021 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1371,28 +1371,32 @@ void sftp_crypto_free(int flags) {
       pr_module_get("mod_sql_passwd.c") == NULL &&
       pr_module_get("mod_tls.c") == NULL) {
 
-#if OPENSSL_VERSION_NUMBER > 0x000907000L
+#if OPENSSL_VERSION_NUMBER > 0x000907000L && \
+    OPENSSL_VERSION_NUMBER < 0x10100000L
     if (crypto_engine) {
       ENGINE_cleanup();
       crypto_engine = NULL;
     }
 #endif
 
-    ERR_free_strings();
-
 #if OPENSSL_VERSION_NUMBER >= 0x10000001L
     /* The ERR_remove_state(0) usage is deprecated due to thread ID
-     * differences among platforms; see the OpenSSL-1.0.0c CHANGES file
+     * differences among platforms; see the OpenSSL-1.0.0 CHANGES file
      * for details.  So for new enough OpenSSL installations, use the
      * proper way to clear the error queue state.
      */
+# if OPENSSL_VERSION_NUMBER < 0x10100000L
     ERR_remove_thread_state(NULL);
+# endif /* prior to OpenSSL-1.1.x */
 #else
     ERR_remove_state(0);
 #endif /* OpenSSL prior to 1.0.0-beta1 */
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    ERR_free_strings();
     EVP_cleanup();
     RAND_cleanup();
+#endif /* prior to OpenSSL-1.1.x */
   }
 }
 

--- a/contrib/mod_sftp/keys.c
+++ b/contrib/mod_sftp/keys.c
@@ -2864,7 +2864,11 @@ static int decrypt_openssh_data(pool *p, const char *path,
     errno = EPERM;
     return -1;
   }
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(HAVE_LIBRESSL)
   EVP_CIPHER_CTX_init(cipher_ctx);
+#endif
 
   openssl_cipher = (cipher->get_cipher)();
 
@@ -2888,7 +2892,9 @@ static int decrypt_openssh_data(pool *p, const char *path,
         "error setting key length (%lu bytes) for %s cipher for decryption: %s",
         (unsigned long) cipher->key_len, cipher->algo,
         sftp_crypto_get_errors());
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
       EVP_CIPHER_CTX_cleanup(cipher_ctx);
+#endif /* prior to OpenSSL-1.1.0 */
       EVP_CIPHER_CTX_free(cipher_ctx);
       pr_memscrub(key, key_len);
       errno = EPERM;
@@ -2908,7 +2914,9 @@ static int decrypt_openssh_data(pool *p, const char *path,
     pr_trace_msg(trace_channel, 3,
       "error decrypting %s data for key: %s", cipher->algo,
       sftp_crypto_get_errors());
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_cleanup(cipher_ctx);
+#endif /* prior to OpenSSL-1.1.0 */
     EVP_CIPHER_CTX_free(cipher_ctx);
     pr_memscrub(key, key_len);
     pr_memscrub(buf, buflen);
@@ -2916,7 +2924,9 @@ static int decrypt_openssh_data(pool *p, const char *path,
     return -1;
   }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   EVP_CIPHER_CTX_cleanup(cipher_ctx);
+#endif /* prior to OpenSSL-1.1.0 */
   EVP_CIPHER_CTX_free(cipher_ctx);
   pr_memscrub(key, key_len);
 

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_sql -- SQL frontend
  * Copyright (c) 1998-1999 Johnie Ingram.
  * Copyright (c) 2001 Andrew Houghton.
- * Copyright (c) 2004-2020 TJ Saunders
+ * Copyright (c) 2004-2021 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,6 +37,11 @@
 
 #if defined(HAVE_OPENSSL) || defined(PR_USE_OPENSSL)
 # include <openssl/evp.h>
+#endif
+
+/* Define if you have the LibreSSL library.  */
+#if defined(LIBRESSL_VERSION_NUMBER)
+# define HAVE_LIBRESSL  1
 #endif
 
 /* default information for tables and fields */
@@ -1177,7 +1182,10 @@ static modret_t *sql_auth_openssl(cmd_rec *cmd, const char *plaintext,
   *hashvalue = '\0';
   hashvalue++;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(HAVE_LIBRESSL)
   OpenSSL_add_all_digests();
+#endif /* OpenSSL-1.1.0 and later */
 
   md = EVP_get_digestbyname(digestname);
   if (md == NULL) {

--- a/contrib/mod_sql_passwd.c
+++ b/contrib/mod_sql_passwd.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_sql_passwd -- Various SQL password handlers
- * Copyright (c) 2009-2020 TJ Saunders
+ * Copyright (c) 2009-2021 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,6 +52,11 @@
 # include <openssl/evp.h>
 # include <openssl/err.h>
 # include <openssl/objects.h>
+#endif
+
+/* Define if you have the LibreSSL library.  */
+#if defined(LIBRESSL_VERSION_NUMBER)
+# define HAVE_LIBRESSL  1
 #endif
 
 module sql_passwd_module;
@@ -1686,7 +1691,10 @@ static void sql_passwd_sess_reinit_ev(const void *event_data, void *user_data) {
  */
 
 static int sql_passwd_init(void) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(HAVE_LIBRESSL)
   OpenSSL_add_all_digests();
+#endif /* prior to OpenSSL-1.1.0 */
 
 #if defined(PR_SHARED_MODULE)
   pr_event_register(&sql_passwd_module, "core.module-unload",


### PR DESCRIPTION
…in 1.1.0.

I accomplished this by temporarily using:
```
define OPENSSL_API_COMPAT            0x10100000L
```
and addressing all of the compiler/linker errors.