### PR TITLE
Move fuzzer and oss-fuzz build script upstream

### DIFF
--- a/tests/fuzzing/json_fuzzer.c
+++ b/tests/fuzzing/json_fuzzer.c
@@ -1,0 +1,49 @@
+/*
+ * ProFTPD - FTP server fuzzing testsuite
+ * Copyright (c) 2021 The ProFTPD Project team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, The ProFTPD Project team and other respective
+ * copyright holders give permission to link this program with OpenSSL, and
+ * distribute the resulting executable, without including the source code for
+ * OpenSSL in the source distribution.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "json.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){        
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL) {
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    pool *p = make_sub_pool(NULL);
+    if (p != NULL) {
+        init_json();        
+        pr_json_object_t *json = pr_json_object_from_text(p, new_str);
+        pr_json_object_free(json);
+        finish_json();
+        destroy_pool(p);
+    }
+
+    free(new_str);
+    return 0;
+}

--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+
+export LDFLAGS="${CFLAGS}"
+./configure --enable-ctrls
+make -j$(nproc)
+
+# We need a few declarations from main.c
+# so we rename main() to main2()
+sed 's/int main(/int main2(/g' -i $SRC/proftpd/src/main.c
+
+# Compile main.c again
+export NEW_CC_FLAG="${CC} ${CFLAGS} -DHAVE_CONFIG_H -DLINUX  -I. -I./include"
+$NEW_CC_FLAG -c src/main.c -o src/main.o
+rm src/ftpdctl.o
+
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+
+# Build fuzzer(s)
+$NEW_CC_FLAG -c $SRC/fuzzer.c -o fuzzer.o
+$CC $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer \
+	src/scoreboard.o \
+	fuzz_lib.a \
+	-L/src/proftpd/lib \
+	-lsupp -lcrypt -pthread
+
+# Build seed corpus
+cd $SRC
+git clone https://github.com/dvyukov/go-fuzz-corpus
+zip $OUT/fuzzer_seed_corpus.zip go-fuzz-corpus/json/corpus/*
+


### PR DESCRIPTION
With Proftpd just having been integrated to OSS-fuzz, I am moving the fuzzer and build script upstream to allow for an easier workflow when adding more fuzzers or modifying the existing.