### PR TITLE
Issue #1232: Implement more session notes in mod_tls, correlated to t…

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -800,6 +800,7 @@ static int tls_openlog(void);
 static int tls_seed_prng(void);
 static int tls_sess_init(void);
 static void tls_setup_environ(pool *, SSL *);
+static void tls_setup_notes(pool *, SSL *);
 static int tls_verify_cb(int, X509_STORE_CTX *);
 static int tls_verify_crl(int, X509_STORE_CTX *);
 static int tls_verify_ocsp(int, X509_STORE_CTX *);
@@ -8099,8 +8100,9 @@ static int tls_accept(conn_t *conn, unsigned char on_data) {
       SSL_get_cipher_bits(ssl, NULL),
       reused > 0 ? ", resumed session" : "");
 
-    /* Setup the TLS environment variables, if requested. */
+    /* Setup the TLS environment variables and notes. */
     tls_setup_environ(session.pool, ssl);
+    tls_setup_notes(session.pool, ssl);
 
     if (reused > 0) {
       pr_log_writefile(tls_logfd, MOD_TLS_VERSION, "%s",
@@ -10102,8 +10104,30 @@ static void tls_setup_environ(pool *p, SSL *ssl) {
     tls_log("unable to set client certificate environ variables: "
       "Client certificate unavailable");
   }
+}
 
-  return;
+static void tls_setup_notes(pool *p, SSL *ssl) {
+  SSL_CIPHER *cipher = NULL;
+  const char *sni = NULL;
+
+  (void) pr_table_add_dup(session.notes, "mod_tls.FTPS", "1", 0);
+  (void) pr_table_add_dup(session.notes, "mod_tls.TLS_PROTOCOL",
+    SSL_get_version(ssl), 0);
+
+  /* Process the TLS cipher-related values. */
+  cipher = (SSL_CIPHER *) SSL_get_current_cipher(ssl);
+  if (cipher != NULL) {
+    (void) pr_table_add_dup(session.notes, "mod_tls.TLS_CIPHER",
+      SSL_CIPHER_get_name(cipher), 0);
+
+    sni = pr_table_get(session.notes, "mod_tls.sni", NULL);
+    if (sni != NULL) {
+      (void) pr_table_add_dup(session.notes, "mod_tls.TLS_SERVER_NAME", sni, 0);
+    }
+
+    (void) pr_table_add_dup(session.notes, "mod_tls.TLS_LIBRARY_VERSIONS",
+      OPENSSL_VERSION_TEXT, 0);
+  }
 }
 
 static int tls_verify_cb(int ok, X509_STORE_CTX *ctx) {

--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -2274,6 +2274,19 @@ your <code>proftpd.conf</code>:
 This trace logging can generate large files; it is intended for debugging use
 only, and should be removed from any production configuration.
 
+<p>
+<b>Note Variables</b><br>
+The <code>mod_tls</code> module provides the following <em>notes</em>, for use
+via the <code>%{note:...}</code> syntax:
+<ul>
+  <li><code>mod_tls.FTPS</code>
+  <li><code>mod_tls.TLS_PROTOCOL</code>
+  <li><code>mod_tls.TLS_CIPHER</code>
+  <li><code>mod_tls.TLS_LIBRARY_VERSION</code>
+</ul>
+These <em>notes</em> are similar to the environment variables provided when
+<code>TLSOptions StdEnvVars</code> is used.
+
 <p><a name="FAQ">
 <b>Frequently Asked Questions</b><br>
 
@@ -2357,7 +2370,7 @@ in your <code>configure</code> command, <i>e.g.</i>:
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2002-2020 TJ Saunders<br>
+&copy; Copyright 2002-2021 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -388,6 +388,16 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  sql_sqllog_var_note_ftps_without_tls_issue1232 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
+  sql_sqllog_var_note_ftps_with_tls_issue1232 => {
+    order => ++$order,
+    test_class => [qw(bug forking mod_tls)],
+  },
+
   sql_sqllogonevent_bug3893 => {
     order => ++$order,
     test_class => [qw(bug forking)],
@@ -14829,6 +14839,335 @@ EOS
     test_msg("Expected '$expected', got '$port'"));
 
   unlink($log_file);
+}
+
+sub get_ftps {
+  my $db_file = shift;
+  my $where = shift;
+
+  my $sql = "SELECT user, ip_addr, ftps FROM ftpsessions";
+  if ($where) {
+    $sql .= " WHERE $where";
+  }
+
+  my $cmd = "sqlite3 $db_file \"$sql\"";
+
+  if ($ENV{TEST_VERBOSE}) {
+    print STDERR "Executing sqlite3: $cmd\n";
+  }
+
+  my $res = join('', `$cmd`);
+  chomp($res);
+
+  # The default sqlite3 delimiter is '|'
+  return split(/\|/, $res);
+}
+
+sub sql_sqllog_var_note_ftps_without_tls_issue1232 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'sqlite');
+
+  my $test_file = File::Spec->rel2abs($setup->{config_file});
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create users, groups tables and populate them
+  my $db_script = File::Spec->rel2abs("$tmpdir/proftpd.sql");
+
+  if (open(my $fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE ftpsessions (
+  user TEXT,
+  ip_addr TEXT,
+  ftps TEXT
+);
+EOS
+
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script);
+
+  # Make sure that, if we're running as root, the database file has
+  # the permissions/privs set for use by proftpd
+  if ($< == 0) {
+    unless (chmod(0666, $db_file)) {
+      die("Can't set perms on $db_file to 0666: $!");
+    }
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sql.c' => {
+        SQLEngine => 'log',
+        SQLBackend => 'sqlite3',
+        SQLConnectInfo => $db_file,
+        SQLLogFile => $setup->{log_file},
+        SQLNamedQuery => 'on_login FREEFORM "INSERT INTO ftpsessions (user, ip_addr, ftps) VALUES (\'%u\', \'%L\', \'%{note:mod_tls.FTPS}\')"',
+        SQLLog => 'PASS on_login',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $conn = $client->retr_raw($test_file);
+      unless ($conn) {
+        die("Failed to RETR: " . $client->response_code() . " " .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 30);
+      eval { $conn->close() };
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex) if $ex;
+
+  eval {
+    my ($login, $ip_addr, $ftps);
+    ($login, $ip_addr, $ftps) = get_ftps($db_file, "user = \'$setup->{user}\'");
+
+    my $expected = $setup->{user};
+    $self->assert($expected eq $login,
+      test_msg("Expected '$expected', got '$login'"));
+
+    $expected = '127.0.0.1';
+    $self->assert($expected eq $ip_addr,
+      test_msg("Expected '$expected', got '$ip_addr'"));
+
+    $expected = '';
+    $self->assert(qr/$expected/, $ftps,
+      test_msg("Expected '$expected', got '$ftps'"));
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub sql_sqllog_var_note_ftps_with_tls_issue1232 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'sqlite');
+
+  my $test_file = File::Spec->rel2abs($setup->{config_file});
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create users, groups tables and populate them
+  my $db_script = File::Spec->rel2abs("$tmpdir/proftpd.sql");
+
+  if (open(my $fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE ftpsessions (
+  user TEXT,
+  ip_addr TEXT,
+  ftps TEXT
+);
+EOS
+
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script);
+
+  # Make sure that, if we're running as root, the database file has
+  # the permissions/privs set for use by proftpd
+  if ($< == 0) {
+    unless (chmod(0666, $db_file)) {
+      die("Can't set perms on $db_file to 0666: $!");
+    }
+  }
+
+  my $cert_file = File::Spec->rel2abs('t/etc/modules/mod_tls/server-cert.pem');
+  my $ca_file = File::Spec->rel2abs('t/etc/modules/mod_tls/ca-cert.pem');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'jot:30 sql:20 tls:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sql.c' => {
+        SQLEngine => 'log',
+        SQLBackend => 'sqlite3',
+        SQLConnectInfo => $db_file,
+        SQLLogFile => $setup->{log_file},
+        SQLNamedQuery => 'on_login FREEFORM "INSERT INTO ftpsessions (user, ip_addr, ftps) VALUES (\'%u\', \'%L\', \'%{note:mod_tls.FTPS}\')"',
+        SQLLog => 'PASS on_login',
+      },
+
+      'mod_tls.c' => {
+        TLSEngine => 'on',
+        TLSLog => $setup->{log_file},
+        TLSRequired => 'on',
+        TLSRSACertificateFile => $cert_file,
+        TLSCACertificateFile => $ca_file,
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::FTPSSL;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Give the server a chance to start up
+      sleep(2);
+
+      my $client = Net::FTPSSL->new('127.0.0.1',
+        Encryption => 'E',
+        Port => $port,
+      );
+
+      unless ($client) {
+        die("Can't connect to FTPS server: " . IO::Socket::SSL::errstr());
+      }
+
+      unless ($client->login($setup->{user}, $setup->{passwd})) {
+        die("Login failed unexpectedly: " + $client->message());
+      }
+
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex) if $ex;
+
+  eval {
+    my ($login, $ip_addr, $ftps);
+    ($login, $ip_addr, $ftps) = get_ftps($db_file, "user = \'$setup->{user}\'");
+
+    my $expected = $setup->{user};
+    $self->assert($expected eq $login,
+      test_msg("Expected '$expected', got '$login'"));
+
+    $expected = '127.0.0.1';
+    $self->assert($expected eq $ip_addr,
+      test_msg("Expected '$expected', got '$ip_addr'"));
+
+    $expected = '1';
+    $self->assert(qr/$expected/, $ftps,
+      test_msg("Expected '$expected', got '$ftps'"));
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub sql_userowner_issue346 {


### PR DESCRIPTION
…he environment variables it provides.

These can then be used in _e.g._ `SQLNamedQuery` and `SQLLog` directives via
`%{note:...}`, instead of `%{env:...}`, to avoid the parse- and run-time
evaluation issues of environment variables.