### PR TITLE
Specify file mode for open with O_CREAT or O_TMPFILE

### DIFF
--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -74,7 +74,7 @@ static int devnull_fd(void) {
 static int tmpfile_fd(void) {
   int fd;
 
-  fd = open(tmpfile_path, O_CREAT|O_RDWR);
+  fd = open(tmpfile_path, O_CREAT|O_RDWR, 0600);
   if (fd < 0) {
     fprintf(stderr, "Error opening %s: %s\n", tmpfile_path, strerror(errno));
     return -1;

--- a/tests/api/data.c
+++ b/tests/api/data.c
@@ -92,7 +92,7 @@ static void tear_down(void) {
 static int tmpfile_fd(void) {
   int fd;
 
-  fd = open(data_test_path, O_CREAT|O_RDWR);
+  fd = open(data_test_path, O_CREAT|O_RDWR, 0600);
   if (fd < 0) {
     fprintf(stderr, "Error opening %s: %s\n", data_test_path, strerror(errno));
     return -1;

--- a/tests/api/scoreboard.c
+++ b/tests/api/scoreboard.c
@@ -143,7 +143,7 @@ START_TEST (scoreboard_set_test) {
     "Failed to create set 0777 perms on '%s': %s", test_dir, strerror(errno));
 
   mark_point();
-  fd = open("/tmp/foo", O_CREAT|O_RDONLY);
+  fd = open("/tmp/foo", O_CREAT|O_RDONLY, 0400);
   if (fd < 0) {
     return;
   }


### PR DESCRIPTION
Use of `open()` with `O_CREAT` or `O_TMPFILE` in second argument requires a third argument to specify the required file mode.  Without this value, a random value from the stack is used instead.

Furthermore, with `glibc` and compiling with `-D_FORTIFY_SOURCE=1` or higher, the absence of the third argument causes errors like this:
```
In file included from /usr/include/fcntl.h:329,
                 from /usr/include/sys/file.h:24,
                 from ../include/os.h:90,
                 from ../include/conf.h:32,
                 from api/tests.h:30,
                 from api/scoreboard.c:27:
In function 'open',
    inlined from 'scoreboard_set_test_fn' at api/scoreboard.c:146:8:
/usr/include/bits/fcntl2.h:50:11: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |           __open_missing_mode ();
      |           ^~~~~~~~~~~~~~~~~~~~~~
```