### PR TITLE
check API: update from deprecated fail*() macros to ck_*() macros

### DIFF
--- a/contrib/mod_auth_otp/t/api/base32.c
+++ b/contrib/mod_auth_otp/t/api/base32.c
@@ -74,8 +74,8 @@ START_TEST (base32_encode_test) {
   int res;
 
   res = auth_otp_base32_encode(p, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   for (i = 0; i < expected_code_count; i++) {
@@ -86,9 +86,9 @@ START_TEST (base32_encode_test) {
     raw_len = strlen((char *) raw);
 
     res = auth_otp_base32_encode(p, raw, raw_len, &encoded, &encoded_len);
-    fail_unless(res == 0, "Failed to base32 encode '%s': %s",
+    ck_assert_msg(res == 0, "Failed to base32 encode '%s': %s",
       expected_codes[i].raw, strerror(errno));
-    fail_unless(strcmp((char *) encoded, expected_codes[i].encoded) == 0,
+    ck_assert_msg(strcmp((char *) encoded, expected_codes[i].encoded) == 0,
       "Expected '%s' for value '%s', got '%s'", expected_codes[i].encoded,
       expected_codes[i].raw, encoded);
   }
@@ -100,8 +100,8 @@ START_TEST (base32_decode_test) {
   int res;
 
   res = auth_otp_base32_decode(p, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   mark_point();
@@ -114,9 +114,9 @@ START_TEST (base32_decode_test) {
     encoded_len = strlen((char *) encoded);
 
     res = auth_otp_base32_decode(p, encoded, encoded_len, &raw, &raw_len);
-    fail_unless(res == 0, "Failed to base32 decode '%s': %s",
+    ck_assert_msg(res == 0, "Failed to base32 decode '%s': %s",
       expected_codes[i].encoded, strerror(errno));
-    fail_unless(strcmp((char *) raw, expected_codes[i].raw) == 0,
+    ck_assert_msg(strcmp((char *) raw, expected_codes[i].raw) == 0,
       "Expected '%s' for value '%s', got '%s'", expected_codes[i].raw,
       expected_codes[i].encoded, raw);
   }

--- a/contrib/mod_auth_otp/t/api/otp.c
+++ b/contrib/mod_auth_otp/t/api/otp.c
@@ -69,8 +69,8 @@ START_TEST (hotp_test) {
   };
 
   res = auth_otp_hotp(p, (const unsigned char *) key, key_len, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   for (i = 0; i < 10; i++) {
@@ -78,9 +78,9 @@ START_TEST (hotp_test) {
 
     res = auth_otp_hotp(p, (const unsigned char *) key, key_len,
       expected_codes[i].count, &code);
-    fail_unless(res == 0, "Failed to generate HOTP for value %lu: %s",
+    ck_assert_msg(res == 0, "Failed to generate HOTP for value %lu: %s",
       expected_codes[i].count, strerror(errno));
-    fail_unless(code == expected_codes[i].hotp,
+    ck_assert_msg(code == expected_codes[i].hotp,
       "Expected HOTP %u for value %lu, got %u", expected_codes[i].hotp,
       expected_codes[i].count, code);
   }
@@ -113,8 +113,8 @@ START_TEST (totp_sha1_test) {
   };
 
   res = auth_otp_totp(p, (const unsigned char *) key, key_len, 0, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   for (i = 0; i < 5; i++) {
@@ -122,9 +122,9 @@ START_TEST (totp_sha1_test) {
 
     res = auth_otp_totp(p, (const unsigned char *) key, key_len,
       expected_codes[i].count, AUTH_OTP_ALGO_TOTP_SHA1, &code);
-    fail_unless(res == 0, "Failed to generate TOTP-SHA1 for value %lu: %s",
+    ck_assert_msg(res == 0, "Failed to generate TOTP-SHA1 for value %lu: %s",
       expected_codes[i].count, strerror(errno));
-    fail_unless(code == expected_codes[i].totp,
+    ck_assert_msg(code == expected_codes[i].totp,
       "Expected TOTP-SHA1 %u for value %lu, got %u", expected_codes[i].totp,
       expected_codes[i].count, code);
   }
@@ -160,8 +160,8 @@ START_TEST (totp_sha256_test) {
   };
 
   res = auth_otp_totp(p, (const unsigned char *) key, key_len, 0, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   for (i = 0; i < 5; i++) {
@@ -169,9 +169,9 @@ START_TEST (totp_sha256_test) {
 
     res = auth_otp_totp(p, (const unsigned char *) key, key_len,
       expected_codes[i].count, AUTH_OTP_ALGO_TOTP_SHA256, &code);
-    fail_unless(res == 0, "Failed to generate TOTP-SHA256 for value %lu: %s",
+    ck_assert_msg(res == 0, "Failed to generate TOTP-SHA256 for value %lu: %s",
       expected_codes[i].count, strerror(errno));
-    fail_unless(code == expected_codes[i].totp,
+    ck_assert_msg(code == expected_codes[i].totp,
       "Expected TOTP-SHA256 %u for value %lu, got %u", expected_codes[i].totp,
       expected_codes[i].count, code);
   }
@@ -208,8 +208,8 @@ START_TEST (totp_sha512_test) {
   };
 
   res = auth_otp_totp(p, (const unsigned char *) key, key_len, 0, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno %s (%d), got %s (%d)",
     strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   for (i = 0; i < 5; i++) {
@@ -217,9 +217,9 @@ START_TEST (totp_sha512_test) {
 
     res = auth_otp_totp(p, (const unsigned char *) key, key_len,
       expected_codes[i].count, AUTH_OTP_ALGO_TOTP_SHA512, &code);
-    fail_unless(res == 0, "Failed to generate TOTP-SHA512 for value %lu: %s",
+    ck_assert_msg(res == 0, "Failed to generate TOTP-SHA512 for value %lu: %s",
       expected_codes[i].count, strerror(errno));
-    fail_unless(code == expected_codes[i].totp,
+    ck_assert_msg(code == expected_codes[i].totp,
       "Expected TOTP-SHA512 %u for value %lu, got %u", expected_codes[i].totp,
       expected_codes[i].count, code);
   }

--- a/tests/api/array.c
+++ b/tests/api/array.c
@@ -73,8 +73,8 @@ START_TEST (make_array_test) {
     3, list->nalloc);
   ck_assert_msg(list->nelts == 0, "Expected list->nelts of %u, got %d",
     0, list->nelts);
-  ck_assert_msg(list->elt_size == 1, "Expect list element size of %u, got %d",
-    1, list->elt_size);
+  ck_assert_msg(list->elt_size == 1, "Expect list element size of %u, got %lu",
+    1, (unsigned long)list->elt_size);
 }
 END_TEST
 
@@ -266,8 +266,8 @@ START_TEST (copy_array_test) {
   list = copy_array(p, src);
   ck_assert_msg(list != NULL, "Failed to copy list");
   ck_assert_msg(list->elt_size == src->elt_size,
-    "Copy item size wrong (expected %d, got %d)", src->elt_size,
-    list->elt_size);
+    "Copy item size wrong (expected %lu, got %lu)",
+    (unsigned long)src->elt_size, (unsigned long)list->elt_size);
   ck_assert_msg(list->nalloc == src->nalloc,
     "Copy nalloc wrong (expected %d, got %d)", src->nalloc, list->nalloc);
   ck_assert_msg(list->nelts == src->nelts,
@@ -299,8 +299,8 @@ START_TEST (copy_array_str_test) {
   list = copy_array_str(p, src);
 
   ck_assert_msg(list->elt_size == src->elt_size,
-    "Copy item size wrong (expected %d, got %d)", src->elt_size,
-    list->elt_size);
+    "Copy item size wrong (expected %lu, got %lu)",
+    (unsigned long)src->elt_size, (unsigned long)list->elt_size);
   ck_assert_msg(list->nalloc == src->nalloc,
     "Copy nalloc wrong (expected %d, got %d)", src->nalloc, list->nalloc);
   ck_assert_msg(list->nelts == src->nelts,
@@ -343,8 +343,8 @@ START_TEST (copy_array_hdr_test) {
   list = copy_array_hdr(p, src);
 
   ck_assert_msg(list->elt_size == src->elt_size,
-    "Copy item size wrong (expected %d, got %d)", src->elt_size,
-    list->elt_size);
+    "Copy item size wrong (expected %lu, got %lu)",
+    (unsigned long)src->elt_size, (unsigned long)list->elt_size);
   ck_assert_msg(list->elts == src->elts,
     "Copy elts wrong (expected %p, got %p)", src->elts, list->elts);
   ck_assert_msg(list->nelts == src->nelts,
@@ -421,7 +421,8 @@ START_TEST (append_arrays_test) {
   res = append_arrays(p, a, b);
 
   ck_assert_msg(res->elt_size == a->elt_size,
-    "Append item size wrong (expected %d, got %d)", a->elt_size, res->elt_size);
+    "Append item size wrong (expected %lu, got %lu)",
+    (unsigned long)a->elt_size, (unsigned long)res->elt_size);
   ck_assert_msg(res->nelts == 5,
     "Append nelts wrong (expected %d, got %d)", 5, res->nelts);
 

--- a/tests/api/array.c
+++ b/tests/api/array.c
@@ -45,35 +45,35 @@ START_TEST (make_array_test) {
   array_header *list;
 
   list = make_array(NULL, 0, 0);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = make_array(p, 0, 0);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = make_array(p, 1, 0);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = make_array(p, 0, 1);
-  fail_unless(list != NULL, "Failed to create an array_header: %s",
+  ck_assert_msg(list != NULL, "Failed to create an array_header: %s",
     strerror(errno));
-  fail_unless(list->nalloc == 1, "Expected list->nalloc of %u, got %d",
+  ck_assert_msg(list->nalloc == 1, "Expected list->nalloc of %u, got %d",
     1, list->nalloc);
 
   list = make_array(p, 3, 1);
-  fail_unless(list != NULL, "Failed to create an array_header: %s",
+  ck_assert_msg(list != NULL, "Failed to create an array_header: %s",
     strerror(errno));
 
-  fail_unless(list->pool == p, "List pool doesn't given pool; "
+  ck_assert_msg(list->pool == p, "List pool doesn't given pool; "
     "expected %p, got %p", p, list->pool);
-  fail_unless(list->elts != NULL, "Expected non-null elements pointer");
-  fail_unless(list->nalloc == 3, "Expected list->nalloc of %u, got %d",
+  ck_assert_msg(list->elts != NULL, "Expected non-null elements pointer");
+  ck_assert_msg(list->nalloc == 3, "Expected list->nalloc of %u, got %d",
     3, list->nalloc);
-  fail_unless(list->nelts == 0, "Expected list->nelts of %u, got %d",
+  ck_assert_msg(list->nelts == 0, "Expected list->nelts of %u, got %d",
     0, list->nelts);
-  fail_unless(list->elt_size == 1, "Expect list element size of %u, got %d",
+  ck_assert_msg(list->elt_size == 1, "Expect list element size of %u, got %d",
     1, list->elt_size);
 }
 END_TEST
@@ -83,37 +83,37 @@ START_TEST (push_array_test) {
   void *res;
 
   res = push_array(NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL for null args");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL for null args");
 
   list = make_array(p, 0, 1);
 
   res = push_array(list);
-  fail_unless(res != NULL, "Failed to allocate new list element");
-  fail_unless(list->nalloc == 1, "Incremented alloc elements needlessly ("
+  ck_assert_msg(res != NULL, "Failed to allocate new list element");
+  ck_assert_msg(list->nalloc == 1, "Incremented alloc elements needlessly ("
     "expected %u, got %d)", 1, list->nalloc);
-  fail_unless(list->nelts == 1, "Failed to increment element count "
+  ck_assert_msg(list->nelts == 1, "Failed to increment element count "
     "(expected %u, got %d)", 1, list->nelts);
 
   res = push_array(list);
-  fail_unless(res != NULL, "Failed to allocate new list element");
-  fail_unless(list->nalloc == 2, "Incremented alloc elements needlessly "
+  ck_assert_msg(res != NULL, "Failed to allocate new list element");
+  ck_assert_msg(list->nalloc == 2, "Incremented alloc elements needlessly "
     "(expected %u, got %d)", 2, list->nalloc);
-  fail_unless(list->nelts == 2, "Failed to increment element count "
+  ck_assert_msg(list->nelts == 2, "Failed to increment element count "
     "(expected %u, got %d)", 2, list->nelts);
 
   res = push_array(list);
-  fail_unless(res != NULL, "Failed to allocate new list element");
-  fail_unless(list->nalloc == 4, "Incremented alloc elements needlessly "
+  ck_assert_msg(res != NULL, "Failed to allocate new list element");
+  ck_assert_msg(list->nalloc == 4, "Incremented alloc elements needlessly "
     "(expected %u, got %d)", 4, list->nalloc);
-  fail_unless(list->nelts == 3, "Failed to increment element count "
+  ck_assert_msg(list->nelts == 3, "Failed to increment element count "
     "(expected %u, got %d)", 3, list->nelts);
 
   res = push_array(list);
-  fail_unless(res != NULL, "Failed to allocate new list element");
-  fail_unless(list->nalloc == 4, "Incremented alloc elements needlessly "
+  ck_assert_msg(res != NULL, "Failed to allocate new list element");
+  ck_assert_msg(list->nalloc == 4, "Incremented alloc elements needlessly "
     "(expected %u, got %d)", 4, list->nalloc);
-  fail_unless(list->nelts == 4, "Failed to increment element count "
+  ck_assert_msg(list->nelts == 4, "Failed to increment element count "
     "(expected %u, got %d)", 4, list->nelts);
 }
 END_TEST
@@ -137,17 +137,17 @@ START_TEST (array_cat_test) {
   mark_point();
   array_cat(dst, src);
 
-  fail_unless(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
     1, dst->nalloc);
-  fail_unless(dst->nelts == 0, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 0, "Wrong dst item count (expected %u, got %d)",
     0, dst->nelts);
 
   push_array(src);
   array_cat(dst, src);
 
-  fail_unless(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
     1, dst->nalloc);
-  fail_unless(dst->nelts == 1, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 1, "Wrong dst item count (expected %u, got %d)",
     1, dst->nelts);
 
   push_array(src);
@@ -155,9 +155,9 @@ START_TEST (array_cat_test) {
   push_array(src);
   array_cat(dst, src);
 
-  fail_unless(dst->nalloc == 8, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 8, "Wrong dst alloc count (expected %u, got %d)",
     8, dst->nalloc);
-  fail_unless(dst->nelts == 5, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 5, "Wrong dst item count (expected %u, got %d)",
     5, dst->nelts);
 }
 END_TEST
@@ -169,51 +169,51 @@ START_TEST (array_cat2_test) {
   mark_point();
 
   res = array_cat2(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
     strerror(errno), errno);
 
   dst = make_array(p, 0, 1);
   mark_point();
   res = array_cat2(dst, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
     strerror(errno), errno);
 
   src = make_array(p, 0, 1);
   mark_point();
   res = array_cat2(NULL, src);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL, got '%s' (%d)",
     strerror(errno), errno);
 
   mark_point();
   res = array_cat2(dst, src);
-  fail_unless(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
 
-  fail_unless(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
     1, dst->nalloc);
-  fail_unless(dst->nelts == 0, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 0, "Wrong dst item count (expected %u, got %d)",
     0, dst->nelts);
 
   push_array(src);
   res = array_cat2(dst, src);
-  fail_unless(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
 
-  fail_unless(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 1, "Wrong dst alloc count (expected %u, got %d)",
     1, dst->nalloc);
-  fail_unless(dst->nelts == 1, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 1, "Wrong dst item count (expected %u, got %d)",
     1, dst->nelts);
 
   push_array(src);
   push_array(src);
   push_array(src);
   res = array_cat2(dst, src);
-  fail_unless(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to concatenate arrays: %s", strerror(errno));
 
-  fail_unless(dst->nalloc == 8, "Wrong dst alloc count (expected %u, got %d)",
+  ck_assert_msg(dst->nalloc == 8, "Wrong dst alloc count (expected %u, got %d)",
     8, dst->nalloc);
-  fail_unless(dst->nelts == 5, "Wrong dst item count (expected %u, got %d)",
+  ck_assert_msg(dst->nelts == 5, "Wrong dst item count (expected %u, got %d)",
     5, dst->nelts);
 }
 END_TEST
@@ -230,16 +230,16 @@ START_TEST (clear_array_test) {
   push_array(list);
   push_array(list);
 
-  fail_unless(list->nalloc == 2, "Wrong list alloc count (expected %u, got %d)",
+  ck_assert_msg(list->nalloc == 2, "Wrong list alloc count (expected %u, got %d)",
     2, list->nalloc);
-  fail_unless(list->nelts == 2, "Wrong list item count (expected %u, got %d)",
+  ck_assert_msg(list->nelts == 2, "Wrong list item count (expected %u, got %d)",
     2, list->nelts);
 
   clear_array(list);
 
-  fail_unless(list->nalloc == 2, "Wrong list alloc count (expected %u, got %d)",
+  ck_assert_msg(list->nalloc == 2, "Wrong list alloc count (expected %u, got %d)",
     2, list->nalloc);
-  fail_unless(list->nelts == 0, "Wrong list item count (expected %u, got %d)",
+  ck_assert_msg(list->nelts == 0, "Wrong list item count (expected %u, got %d)",
     0, list->nelts);
 }
 END_TEST
@@ -248,29 +248,29 @@ START_TEST (copy_array_test) {
   array_header *list, *src;
 
   list = copy_array(NULL, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   src = make_array(p, 0, 1);
 
   list = copy_array(NULL, src);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = copy_array(p, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   push_array(src);
 
   list = copy_array(p, src);
-  fail_unless(list != NULL, "Failed to copy list");
-  fail_unless(list->elt_size == src->elt_size,
+  ck_assert_msg(list != NULL, "Failed to copy list");
+  ck_assert_msg(list->elt_size == src->elt_size,
     "Copy item size wrong (expected %d, got %d)", src->elt_size,
     list->elt_size);
-  fail_unless(list->nalloc == src->nalloc,
+  ck_assert_msg(list->nalloc == src->nalloc,
     "Copy nalloc wrong (expected %d, got %d)", src->nalloc, list->nalloc);
-  fail_unless(list->nelts == src->nelts,
+  ck_assert_msg(list->nelts == src->nelts,
     "Copy nelts wrong (expected %d, got %d)", src->nelts, list->nelts);
 }
 END_TEST
@@ -282,38 +282,38 @@ START_TEST (copy_array_str_test) {
   src = make_array(p, 0, sizeof(char *));
 
   list = copy_array_str(NULL, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = copy_array_str(NULL, src);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = copy_array_str(p, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   *((char **) push_array(src)) = pstrdup(p, "foo");
   *((char **) push_array(src)) = pstrdup(p, "bar");
 
   list = copy_array_str(p, src);
 
-  fail_unless(list->elt_size == src->elt_size,
+  ck_assert_msg(list->elt_size == src->elt_size,
     "Copy item size wrong (expected %d, got %d)", src->elt_size,
     list->elt_size);
-  fail_unless(list->nalloc == src->nalloc,
+  ck_assert_msg(list->nalloc == src->nalloc,
     "Copy nalloc wrong (expected %d, got %d)", src->nalloc, list->nalloc);
-  fail_unless(list->nelts == src->nelts,
+  ck_assert_msg(list->nelts == src->nelts,
     "Copy nelts wrong (expected %d, got %d)", src->nelts, list->nelts);
 
   elts = list->elts;
 
   elt = elts[0];
-  fail_unless(strcmp(elt, "foo") == 0,
+  ck_assert_msg(strcmp(elt, "foo") == 0,
     "Improper copy (expected '%s', got '%s')", "foo", elt);
 
   elt = elts[1];
-  fail_unless(strcmp(elt, "bar") == 0,
+  ck_assert_msg(strcmp(elt, "bar") == 0,
     "Improper copy (expected '%s', got '%s')", "bar", elt);
 }
 END_TEST
@@ -325,16 +325,16 @@ START_TEST (copy_array_hdr_test) {
   src = make_array(p, 0, sizeof(int));
 
   list = copy_array_hdr(NULL, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = copy_array_hdr(NULL, src);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   list = copy_array_hdr(p, NULL);
-  fail_unless(list == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(list == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   *((int *) push_array(src)) = -1;
   *((int *) push_array(src)) = 2;
@@ -342,29 +342,29 @@ START_TEST (copy_array_hdr_test) {
 
   list = copy_array_hdr(p, src);
 
-  fail_unless(list->elt_size == src->elt_size,
+  ck_assert_msg(list->elt_size == src->elt_size,
     "Copy item size wrong (expected %d, got %d)", src->elt_size,
     list->elt_size);
-  fail_unless(list->elts == src->elts,
+  ck_assert_msg(list->elts == src->elts,
     "Copy elts wrong (expected %p, got %p)", src->elts, list->elts);
-  fail_unless(list->nelts == src->nelts,
+  ck_assert_msg(list->nelts == src->nelts,
     "Copy nelts wrong (expected %d, got %d)", src->nelts, list->nelts);
 
-  fail_unless(list->nalloc != src->nalloc,
+  ck_assert_msg(list->nalloc != src->nalloc,
     "Copy nalloc wrong (expected %d, got %d)", src->nalloc, list->nalloc);
-  fail_unless(list->nalloc == 3,
+  ck_assert_msg(list->nalloc == 3,
     "Copy nalloc wrong (expected %d, got %d)", 3, list->nalloc);
 
   elts = list->elts;
 
   elt = elts[0];
-  fail_unless(elt == -1, "Improper copy (expected %d, got %d)", -1, elt);
+  ck_assert_msg(elt == -1, "Improper copy (expected %d, got %d)", -1, elt);
 
   elt = elts[1];
-  fail_unless(elt == 2, "Improper copy (expected %d, got %d)", 2, elt);
+  ck_assert_msg(elt == 2, "Improper copy (expected %d, got %d)", 2, elt);
 
   elt = elts[2];
-  fail_unless(elt == 2476, "Improper copy (expected %d, got %d)", 2476, elt);
+  ck_assert_msg(elt == 2476, "Improper copy (expected %d, got %d)", 2476, elt);
 }
 END_TEST
 
@@ -378,38 +378,38 @@ START_TEST (append_arrays_test) {
 
   mark_point();
   res = append_arrays(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(p, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(NULL, a, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(NULL, NULL, b);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(p, a, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(p, NULL, b);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = append_arrays(NULL, a, b);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   *((int *) push_array(a)) = -1;
   *((int *) push_array(a)) = 2;
@@ -420,30 +420,30 @@ START_TEST (append_arrays_test) {
   mark_point();
   res = append_arrays(p, a, b);
 
-  fail_unless(res->elt_size == a->elt_size,
+  ck_assert_msg(res->elt_size == a->elt_size,
     "Append item size wrong (expected %d, got %d)", a->elt_size, res->elt_size);
-  fail_unless(res->nelts == 5,
+  ck_assert_msg(res->nelts == 5,
     "Append nelts wrong (expected %d, got %d)", 5, res->nelts);
 
-  fail_unless(res->nalloc == 8,
+  ck_assert_msg(res->nalloc == 8,
     "Append nalloc wrong (expected %d, got %d)", 8, res->nalloc);
 
   elts = res->elts;
 
   elt = elts[0];
-  fail_unless(elt == -1, "Improper append (expected %d, got %d)", -1, elt);
+  ck_assert_msg(elt == -1, "Improper append (expected %d, got %d)", -1, elt);
 
   elt = elts[1];
-  fail_unless(elt == 2, "Improper append (expected %d, got %d)", 2, elt);
+  ck_assert_msg(elt == 2, "Improper append (expected %d, got %d)", 2, elt);
 
   elt = elts[2];
-  fail_unless(elt == 2476, "Improper append (expected %d, got %d)", 2476, elt);
+  ck_assert_msg(elt == 2476, "Improper append (expected %d, got %d)", 2476, elt);
 
   elt = elts[3];
-  fail_unless(elt == 4762, "Improper append (expected %d, got %d)", 4762, elt);
+  ck_assert_msg(elt == 4762, "Improper append (expected %d, got %d)", 4762, elt);
 
   elt = elts[4];
-  fail_unless(elt == 7642, "Improper append (expected %d, got %d)", 7642, elt);
+  ck_assert_msg(elt == 7642, "Improper append (expected %d, got %d)", 7642, elt);
 }
 END_TEST
 

--- a/tests/api/ascii.c
+++ b/tests/api/ascii.c
@@ -50,7 +50,7 @@ START_TEST (ascii_ftp_from_crlf_test) {
   res = pr_ascii_ftp_from_crlf(NULL, NULL, 0, NULL, NULL);
   ck_assert_msg(res == -1, "Failed to handle null arguments");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
-    strerror(errno), errno);
+    strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   /* Handle an empty input buffer. */
   pr_ascii_ftp_reset();
@@ -208,7 +208,7 @@ START_TEST (ascii_ftp_to_crlf_test) {
   res = pr_ascii_ftp_to_crlf(NULL, NULL, 0, NULL, NULL);
   ck_assert_msg(res == -1, "Failed to handle null arguments");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
-    strerror(errno), errno);
+    strerror(EINVAL), EINVAL, strerror(errno), errno);
 
   /* Handle empty input buffer. */
   mark_point();

--- a/tests/api/ascii.c
+++ b/tests/api/ascii.c
@@ -48,8 +48,8 @@ START_TEST (ascii_ftp_from_crlf_test) {
 
   pr_ascii_ftp_reset();
   res = pr_ascii_ftp_from_crlf(NULL, NULL, 0, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
     strerror(errno), errno);
 
   /* Handle an empty input buffer. */
@@ -59,8 +59,8 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle empty input buffer");
-  fail_unless(dst_len == src_len, "Failed to set output buffer length");
+  ck_assert_msg(res == 0, "Failed to handle empty input buffer");
+  ck_assert_msg(dst_len == src_len, "Failed to set output buffer length");
 
   /* Handle an input buffer with no CRLFs. */
   pr_ascii_ftp_reset();
@@ -69,14 +69,14 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with no CRLFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with no CRLFs");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
   res = strcmp(expected, dst);
-  fail_unless(res == 0, "Expected output buffer '%s', got '%s' (%d)", expected,
+  ck_assert_msg(res == 0, "Expected output buffer '%s', got '%s' (%d)", expected,
     dst, res);
 
   /* Handle an input buffer with CRs, no LFs. */
@@ -86,13 +86,13 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with CRs, no LFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with CRs, no LFs");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer with LFs, no CRs. */
@@ -102,13 +102,13 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with LFs, no CRs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with LFs, no CRs");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer with several CRLFs. */
@@ -118,13 +118,13 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with CRLFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with CRLFs");
   expected = "he\nl\nlo";
   expected_len = 7;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer ending with a CR. */
@@ -134,15 +134,15 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 1,
+  ck_assert_msg(res == 1,
     "Failed to handle input buffer with trailing CR: expected %d, got %d", 1,
     res);
   expected = "he\nl\nlo\r";
   expected_len = 7;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer of just an LF. */
@@ -152,14 +152,14 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to handle input buffer of single LF: expected %d, got %d", 0, res);
   expected = "\n";
   expected_len = 1;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer of just a CR. */
@@ -169,14 +169,14 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 1,
+  ck_assert_msg(res == 1,
     "Failed to handle input buffer of single CR: expected %d, got %d", 1, res);
   expected = "\r";
   expected_len = 0;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 
   /* Handle an input buffer of just CRs. */
@@ -186,14 +186,14 @@ START_TEST (ascii_ftp_from_crlf_test) {
   dst = pcalloc(p, src_len + 1);
   dst_len = 0;
   res = pr_ascii_ftp_from_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 1,
+  ck_assert_msg(res == 1,
     "Failed to handle input buffer of single CR: expected %d, got %d", 3, res);
   expected = "\r\r\r";
   expected_len = 2;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(strcmp(dst, expected) == 0,
+  ck_assert_msg(strcmp(dst, expected) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
 }
 END_TEST
@@ -206,8 +206,8 @@ START_TEST (ascii_ftp_to_crlf_test) {
   mark_point();
   pr_ascii_ftp_reset();
   res = pr_ascii_ftp_to_crlf(NULL, NULL, 0, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL ('%s' [%d]), got '%s' [%d]",
     strerror(errno), errno);
 
   /* Handle empty input buffer. */
@@ -218,9 +218,9 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle empty input buffer");
-  fail_unless(dst_len == src_len, "Failed to set output buffer length");
-  fail_unless(dst == src, "Failed to set output buffer");
+  ck_assert_msg(res == 0, "Failed to handle empty input buffer");
+  ck_assert_msg(dst_len == src_len, "Failed to set output buffer length");
+  ck_assert_msg(dst == src, "Failed to set output buffer");
 
   /* Handle input buffer with no CRLFs. */
   mark_point();
@@ -230,13 +230,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with no CRLFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with no CRLFs");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -248,13 +248,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with CRs, no LFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with CRs, no LFs");
   expected = src; 
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -266,13 +266,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 2, "Failed to handle input buffer with CRs, no LFs");
+  ck_assert_msg(res == 2, "Failed to handle input buffer with CRs, no LFs");
   expected = "he\r\nl\r\nlo";
   expected_len = 9;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -284,13 +284,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with CRs, no LFs");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with CRs, no LFs");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -302,13 +302,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 1, "Failed to handle input buffer with leading LF");
+  ck_assert_msg(res == 1, "Failed to handle input buffer with leading LF");
   expected = "\r\nhello";
   expected_len = 7;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -320,13 +320,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 0, "Failed to handle input buffer with trailing CR");
+  ck_assert_msg(res == 0, "Failed to handle input buffer with trailing CR");
   expected = src;
   expected_len = src_len;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 
@@ -336,13 +336,13 @@ START_TEST (ascii_ftp_to_crlf_test) {
   dst = NULL;
   dst_len = 0;
   res = pr_ascii_ftp_to_crlf(p, src, src_len, &dst, &dst_len);
-  fail_unless(res == 1, "Failed to handle next input buffer after trailing CR");
+  ck_assert_msg(res == 1, "Failed to handle next input buffer after trailing CR");
   expected = "\nlo\r\n";
   expected_len = 5;
-  fail_unless(dst_len == expected_len,
+  ck_assert_msg(dst_len == expected_len,
     "Expected output buffer length %lu, got %lu", (unsigned long) expected_len,
     (unsigned long) dst_len);
-  fail_unless(memcmp(dst, expected, dst_len) == 0,
+  ck_assert_msg(memcmp(dst, expected, dst_len) == 0,
     "Expected output buffer '%s', got '%s'", expected, dst);
   free(dst);
 }

--- a/tests/api/auth.c
+++ b/tests/api/auth.c
@@ -2155,7 +2155,7 @@ START_TEST (auth_set_max_password_len_test) {
     strerror(errno), errno);
 
   res = pr_auth_set_max_password_len(p, 0);
-  ck_assert_msg(res == 1, "Expected %lu, got %lu", 1, (unsigned long) res);
+  ck_assert_msg(res == 1, "Expected %d, got %lu", 1, (unsigned long) res);
 
   res = pr_auth_set_max_password_len(p, 0);
   ck_assert_msg(res == PR_TUNABLE_PASSWORD_MAX,

--- a/tests/api/auth.c
+++ b/tests/api/auth.c
@@ -490,7 +490,7 @@ START_TEST (auth_setpwent_test) {
   char *sym_name = "setpwent";
 
   pr_auth_setpwent(p);
-  fail_unless(setpwent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(setpwent_count == 0, "Expected call count 0, got %u",
     setpwent_count);
   mark_point();
   
@@ -501,11 +501,11 @@ START_TEST (auth_setpwent_test) {
   authtab.handler = handle_setpwent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   pr_auth_setpwent(p);
-  fail_unless(setpwent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(setpwent_count == 1, "Expected call count 1, got %u",
     setpwent_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -518,7 +518,7 @@ START_TEST (auth_endpwent_test) {
   char *sym_name = "endpwent";
 
   pr_auth_endpwent(p);
-  fail_unless(endpwent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(endpwent_count == 0, "Expected call count 0, got %u",
     endpwent_count);
   mark_point();
   
@@ -529,11 +529,11 @@ START_TEST (auth_endpwent_test) {
   authtab.handler = handle_endpwent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   pr_auth_endpwent(p);
-  fail_unless(endpwent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(endpwent_count == 1, "Expected call count 1, got %u",
     endpwent_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -549,13 +549,13 @@ START_TEST (auth_getpwent_test) {
   getpwent_count = 0;
 
   pw = pr_auth_getpwent(NULL);
-  fail_unless(pw == NULL, "Found pwent unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(pw == NULL, "Found pwent unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   pw = pr_auth_getpwent(p);
-  fail_unless(pw == NULL, "Found pwent unexpectedly");
-  fail_unless(getpwent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(pw == NULL, "Found pwent unexpectedly");
+  ck_assert_msg(getpwent_count == 0, "Expected call count 0, got %u",
     getpwent_count);
   mark_point();
   
@@ -566,26 +566,26 @@ START_TEST (auth_getpwent_test) {
   authtab.handler = handle_getpwent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   pw = pr_auth_getpwent(p);
-  fail_unless(pw != NULL, "Failed to find pwent: %s", strerror(errno));
-  fail_unless(getpwent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(pw != NULL, "Failed to find pwent: %s", strerror(errno));
+  ck_assert_msg(getpwent_count == 1, "Expected call count 1, got %u",
     getpwent_count);
 
   pw = pr_auth_getpwent(p);
-  fail_unless(pw == NULL, "Failed to avoid pwent with bad UID");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Failed to avoid pwent with bad UID");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(getpwent_count == 2, "Expected call count 2, got %u",
+  ck_assert_msg(getpwent_count == 2, "Expected call count 2, got %u",
     getpwent_count);
 
   pw = pr_auth_getpwent(p);
-  fail_unless(pw == NULL, "Failed to avoid pwent with bad GID");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Failed to avoid pwent with bad GID");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(getpwent_count == 3, "Expected call count 3, got %u",
+  ck_assert_msg(getpwent_count == 3, "Expected call count 3, got %u",
     getpwent_count);
 
   pr_auth_endpwent(p);
@@ -600,13 +600,13 @@ START_TEST (auth_getpwnam_test) {
   char *sym_name = "getpwnam";
 
   pw = pr_auth_getpwnam(NULL, NULL);
-  fail_unless(pw == NULL, "Found pwnam unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(pw == NULL, "Found pwnam unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NAME);
-  fail_unless(pw == NULL, "Found pwnam unexpectedly");
-  fail_unless(getpwnam_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(pw == NULL, "Found pwnam unexpectedly");
+  ck_assert_msg(getpwnam_count == 0, "Expected call count 0, got %u",
     getpwnam_count);
   mark_point();
   
@@ -617,40 +617,40 @@ START_TEST (auth_getpwnam_test) {
   authtab.handler = handle_getpwnam;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NOBODY);
-  fail_unless(pw == NULL, "Found user '%s' unexpectedly", PR_TEST_AUTH_NOBODY);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Found user '%s' unexpectedly", PR_TEST_AUTH_NOBODY);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NOBODY2);
-  fail_unless(pw == NULL, "Found user '%s' unexpectedly", PR_TEST_AUTH_NOBODY2);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Found user '%s' unexpectedly", PR_TEST_AUTH_NOBODY2);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NAME);
-  fail_unless(pw != NULL, "Failed to find user '%s': %s", PR_TEST_AUTH_NAME,
+  ck_assert_msg(pw != NULL, "Failed to find user '%s': %s", PR_TEST_AUTH_NAME,
     strerror(errno));
-  fail_unless(getpwnam_count == 3, "Expected call count 3, got %u",
+  ck_assert_msg(getpwnam_count == 3, "Expected call count 3, got %u",
     getpwnam_count);
 
   pw = pr_auth_getpwnam(p, PR_TEST_AUTH_NAME);
-  fail_unless(pw != NULL, "Failed to find user '%s': %s", PR_TEST_AUTH_NAME,
+  ck_assert_msg(pw != NULL, "Failed to find user '%s': %s", PR_TEST_AUTH_NAME,
     strerror(errno));
-  fail_unless(getpwnam_count == 4, "Expected call count 4, got %u",
+  ck_assert_msg(getpwnam_count == 4, "Expected call count 4, got %u",
     getpwnam_count);
 
   mark_point();
 
   pw = pr_auth_getpwnam(p, "other");
-  fail_unless(pw == NULL, "Found pwnam for user 'other' unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(pw == NULL, "Found pwnam for user 'other' unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
-  fail_unless(getpwnam_count == 5, "Expected call count 5, got %u",
+  ck_assert_msg(getpwnam_count == 5, "Expected call count 5, got %u",
     getpwnam_count);
 
   pr_auth_endpwent(p);
@@ -665,13 +665,13 @@ START_TEST (auth_getpwuid_test) {
   char *sym_name = "getpwuid";
 
   pw = pr_auth_getpwuid(NULL, -1);
-  fail_unless(pw == NULL, "Found pwuid unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(pw == NULL, "Found pwuid unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   pw = pr_auth_getpwuid(p, PR_TEST_AUTH_UID);
-  fail_unless(pw == NULL, "Found pwuid unexpectedly");
-  fail_unless(getpwuid_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(pw == NULL, "Found pwuid unexpectedly");
+  ck_assert_msg(getpwuid_count == 0, "Expected call count 0, got %u",
     getpwuid_count);
   mark_point();
   
@@ -682,34 +682,34 @@ START_TEST (auth_getpwuid_test) {
   authtab.handler = handle_getpwuid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   pw = pr_auth_getpwuid(p, PR_TEST_AUTH_UID);
-  fail_unless(pw != NULL, "Failed to find pwuid: %s", strerror(errno));
-  fail_unless(getpwuid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(pw != NULL, "Failed to find pwuid: %s", strerror(errno));
+  ck_assert_msg(getpwuid_count == 1, "Expected call count 1, got %u",
     getpwuid_count);
 
   pw = pr_auth_getpwuid(p, PR_TEST_AUTH_NOUID);
-  fail_unless(pw == NULL, "Found pwuid for NOUID unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Found pwuid for NOUID unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pw = pr_auth_getpwuid(p, PR_TEST_AUTH_NOUID2);
-  fail_unless(pw == NULL, "Found pwuid for NOUID2 unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Found pwuid for NOUID2 unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
 
   pw = pr_auth_getpwuid(p, 5);
-  fail_unless(pw == NULL, "Found pwuid for UID 5 unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(pw == NULL, "Found pwuid for UID 5 unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
-  fail_unless(getpwuid_count == 4, "Expected call count 4, got %u",
+  ck_assert_msg(getpwuid_count == 4, "Expected call count 4, got %u",
     getpwuid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -725,13 +725,13 @@ START_TEST (auth_name2uid_test) {
   pr_auth_cache_set(FALSE, PR_AUTH_CACHE_FL_BAD_NAME2UID);
 
   uid = pr_auth_name2uid(NULL, NULL);
-  fail_unless(uid == (uid_t) -1, "Found UID unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(uid == (uid_t) -1, "Found UID unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
-  fail_unless(uid == (uid_t) -1, "Found UID unexpectedly");
-  fail_unless(name2uid_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(uid == (uid_t) -1, "Found UID unexpectedly");
+  ck_assert_msg(name2uid_count == 0, "Expected call count 0, got %u",
     name2uid_count);
   mark_point();
   
@@ -742,15 +742,15 @@ START_TEST (auth_name2uid_test) {
   authtab.handler = handle_name2uid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
-  fail_unless(uid == PR_TEST_AUTH_UID, "Expected UID %lu, got %lu",
+  ck_assert_msg(uid == PR_TEST_AUTH_UID, "Expected UID %lu, got %lu",
     (unsigned long) PR_TEST_AUTH_UID, (unsigned long) uid);
-  fail_unless(name2uid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(name2uid_count == 1, "Expected call count 1, got %u",
     name2uid_count);
 
   mark_point();
@@ -758,9 +758,9 @@ START_TEST (auth_name2uid_test) {
   /* Call again; the call counter should NOT increment due to caching. */
 
   uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
-  fail_unless(uid == PR_TEST_AUTH_UID, "Expected UID %lu, got %lu",
+  ck_assert_msg(uid == PR_TEST_AUTH_UID, "Expected UID %lu, got %lu",
     (unsigned long) PR_TEST_AUTH_UID, (unsigned long) uid);
-  fail_unless(name2uid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(name2uid_count == 1, "Expected call count 1, got %u",
     name2uid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -776,17 +776,17 @@ START_TEST (auth_uid2name_test) {
   pr_auth_cache_set(FALSE, PR_AUTH_CACHE_FL_BAD_UID2NAME);
 
   name = pr_auth_uid2name(NULL, -1);
-  fail_unless(name == NULL, "Found name unexpectedly: %s", name);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(name == NULL, "Found name unexpectedly: %s", name);
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
   mark_point();
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Failed to find name for UID %lu: %s",
+  ck_assert_msg(name != NULL, "Failed to find name for UID %lu: %s",
     (unsigned long) PR_TEST_AUTH_UID, strerror(errno));
-  fail_unless(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
      "Expected name '%s', got '%s'", PR_TEST_AUTH_UID_STR, name);
-  fail_unless(uid2name_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(uid2name_count == 0, "Expected call count 0, got %u",
     uid2name_count);
   mark_point();
   
@@ -797,16 +797,16 @@ START_TEST (auth_uid2name_test) {
   authtab.handler = handle_uid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid2name_count == 1, "Expected call count 1, got %u",
     uid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -819,7 +819,7 @@ START_TEST (auth_setgrent_test) {
   char *sym_name = "setgrent";
 
   pr_auth_setgrent(p);
-  fail_unless(setgrent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(setgrent_count == 0, "Expected call count 0, got %u",
     setgrent_count);
   mark_point();
   
@@ -830,11 +830,11 @@ START_TEST (auth_setgrent_test) {
   authtab.handler = handle_setgrent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   pr_auth_setgrent(p);
-  fail_unless(setgrent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(setgrent_count == 1, "Expected call count 1, got %u",
     setgrent_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -847,7 +847,7 @@ START_TEST (auth_endgrent_test) {
   char *sym_name = "endgrent";
 
   pr_auth_endgrent(p);
-  fail_unless(endgrent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(endgrent_count == 0, "Expected call count 0, got %u",
     endgrent_count);
   mark_point();
   
@@ -858,11 +858,11 @@ START_TEST (auth_endgrent_test) {
   authtab.handler = handle_endgrent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   pr_auth_endgrent(p);
-  fail_unless(endgrent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(endgrent_count == 1, "Expected call count 1, got %u",
     endgrent_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -876,13 +876,13 @@ START_TEST (auth_getgrent_test) {
   char *sym_name = "getgrent";
 
   gr = pr_auth_getgrent(NULL);
-  fail_unless(gr == NULL, "Found grent unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(gr == NULL, "Found grent unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   gr = pr_auth_getgrent(p);
-  fail_unless(gr == NULL, "Found grent unexpectedly");
-  fail_unless(getgrent_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(gr == NULL, "Found grent unexpectedly");
+  ck_assert_msg(getgrent_count == 0, "Expected call count 0, got %u",
     getgrent_count);
   mark_point();
   
@@ -893,19 +893,19 @@ START_TEST (auth_getgrent_test) {
   authtab.handler = handle_getgrent;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   gr = pr_auth_getgrent(p);
-  fail_unless(gr != NULL, "Failed to find grent: %s", strerror(errno));
-  fail_unless(getgrent_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gr != NULL, "Failed to find grent: %s", strerror(errno));
+  ck_assert_msg(getgrent_count == 1, "Expected call count 1, got %u",
     getgrent_count);
 
   gr = pr_auth_getgrent(p);
-  fail_unless(gr == NULL, "Failed to avoid grent with bad GID");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(gr == NULL, "Failed to avoid grent with bad GID");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(getgrent_count == 2, "Expected call count 2, got %u",
+  ck_assert_msg(getgrent_count == 2, "Expected call count 2, got %u",
     getgrent_count);
 
   pr_auth_endgrent(p);
@@ -920,13 +920,13 @@ START_TEST (auth_getgrnam_test) {
   char *sym_name = "getgrnam";
 
   gr = pr_auth_getgrnam(NULL, NULL);
-  fail_unless(gr == NULL, "Found grnam unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(gr == NULL, "Found grnam unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   gr = pr_auth_getgrnam(p, PR_TEST_AUTH_NAME);
-  fail_unless(gr == NULL, "Found grnam unexpectedly");
-  fail_unless(getgrnam_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(gr == NULL, "Found grnam unexpectedly");
+  ck_assert_msg(getgrnam_count == 0, "Expected call count 0, got %u",
     getgrnam_count);
   mark_point();
   
@@ -937,29 +937,29 @@ START_TEST (auth_getgrnam_test) {
   authtab.handler = handle_getgrnam;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   gr = pr_auth_getgrnam(p, PR_TEST_AUTH_NOGROUP);
-  fail_unless(gr == NULL, "Found group '%s' unexpectedly",
+  ck_assert_msg(gr == NULL, "Found group '%s' unexpectedly",
     PR_TEST_AUTH_NOGROUP);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   gr = pr_auth_getgrnam(p, PR_TEST_AUTH_NAME);
-  fail_unless(gr != NULL, "Failed to find grnam: %s", strerror(errno));
-  fail_unless(getgrnam_count == 2, "Expected call count 2, got %u",
+  ck_assert_msg(gr != NULL, "Failed to find grnam: %s", strerror(errno));
+  ck_assert_msg(getgrnam_count == 2, "Expected call count 2, got %u",
     getgrnam_count);
 
   mark_point();
 
   gr = pr_auth_getgrnam(p, "other");
-  fail_unless(gr == NULL, "Found grnam for user 'other' unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(gr == NULL, "Found grnam for user 'other' unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
-  fail_unless(getgrnam_count == 3, "Expected call count 3, got %u",
+  ck_assert_msg(getgrnam_count == 3, "Expected call count 3, got %u",
     getgrnam_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -973,13 +973,13 @@ START_TEST (auth_getgrgid_test) {
   char *sym_name = "getgrgid";
 
   gr = pr_auth_getgrgid(NULL, -1);
-  fail_unless(gr == NULL, "Found grgid unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(gr == NULL, "Found grgid unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   gr = pr_auth_getgrgid(p, PR_TEST_AUTH_GID);
-  fail_unless(gr == NULL, "Found grgid unexpectedly");
-  fail_unless(getgrgid_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(gr == NULL, "Found grgid unexpectedly");
+  ck_assert_msg(getgrgid_count == 0, "Expected call count 0, got %u",
     getgrgid_count);
   mark_point();
   
@@ -990,29 +990,29 @@ START_TEST (auth_getgrgid_test) {
   authtab.handler = handle_getgrgid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   gr = pr_auth_getgrgid(p, PR_TEST_AUTH_GID);
-  fail_unless(gr != NULL, "Failed to find grgid: %s", strerror(errno));
-  fail_unless(getgrgid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gr != NULL, "Failed to find grgid: %s", strerror(errno));
+  ck_assert_msg(getgrgid_count == 1, "Expected call count 1, got %u",
     getgrgid_count);
 
   gr = pr_auth_getgrgid(p, PR_TEST_AUTH_NOGID);
-  fail_unless(gr == NULL, "Found grgid for NOGID unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(gr == NULL, "Found grgid for NOGID unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
 
   gr = pr_auth_getgrgid(p, 5);
-  fail_unless(gr == NULL, "Found grgid for GID 5 unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(gr == NULL, "Found grgid for GID 5 unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
-  fail_unless(getgrgid_count == 3, "Expected call count 3, got %u",
+  ck_assert_msg(getgrgid_count == 3, "Expected call count 3, got %u",
     getgrgid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1028,13 +1028,13 @@ START_TEST (auth_name2gid_test) {
   pr_auth_cache_set(FALSE, PR_AUTH_CACHE_FL_BAD_NAME2GID);
 
   gid = pr_auth_name2gid(NULL, NULL);
-  fail_unless(gid == (gid_t) -1, "Found GID unexpectedly");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(gid == (gid_t) -1, "Found GID unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == (gid_t) -1, "Found GID unexpectedly");
-  fail_unless(name2gid_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(gid == (gid_t) -1, "Found GID unexpectedly");
+  ck_assert_msg(name2gid_count == 0, "Expected call count 0, got %u",
     name2gid_count);
   mark_point();
   
@@ -1045,15 +1045,15 @@ START_TEST (auth_name2gid_test) {
   authtab.handler = handle_name2gid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == PR_TEST_AUTH_GID, "Expected GID %lu, got %lu",
+  ck_assert_msg(gid == PR_TEST_AUTH_GID, "Expected GID %lu, got %lu",
     (unsigned long) PR_TEST_AUTH_GID, (unsigned long) gid);
-  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(name2gid_count == 1, "Expected call count 1, got %u",
     name2gid_count);
 
   mark_point();
@@ -1061,9 +1061,9 @@ START_TEST (auth_name2gid_test) {
   /* Call again; the call counter should NOT increment due to caching. */
 
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == PR_TEST_AUTH_GID, "Expected GID %lu, got %lu",
+  ck_assert_msg(gid == PR_TEST_AUTH_GID, "Expected GID %lu, got %lu",
     (unsigned long) PR_TEST_AUTH_GID, (unsigned long) gid);
-  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(name2gid_count == 1, "Expected call count 1, got %u",
     name2gid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1079,17 +1079,17 @@ START_TEST (auth_gid2name_test) {
   pr_auth_cache_set(FALSE, PR_AUTH_CACHE_FL_BAD_GID2NAME);
 
   name = pr_auth_gid2name(NULL, -1);
-  fail_unless(name == NULL, "Found name unexpectedly: %s", name);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(name == NULL, "Found name unexpectedly: %s", name);
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
   mark_point();
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Failed to find name for GID %lu: %s",
+  ck_assert_msg(name != NULL, "Failed to find name for GID %lu: %s",
     (unsigned long) PR_TEST_AUTH_GID, strerror(errno));
-  fail_unless(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
      "Expected name '%s', got '%s'", PR_TEST_AUTH_GID_STR, name);
-  fail_unless(gid2name_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(gid2name_count == 0, "Expected call count 0, got %u",
     gid2name_count);
   mark_point();
   
@@ -1100,16 +1100,16 @@ START_TEST (auth_gid2name_test) {
   authtab.handler = handle_gid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid2name_count == 1, "Expected call count 1, got %u",
     gid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1123,13 +1123,13 @@ START_TEST (auth_getgroups_test) {
   char *sym_name = "getgroups";
 
   res = pr_auth_getgroups(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_auth_getgroups(p, PR_TEST_AUTH_NAME, &gids, NULL);
-  fail_unless(res < 0, "Found groups for '%s' unexpectedly", PR_TEST_AUTH_NAME);
-  fail_unless(getgroups_count == 0, "Expected call count 0, got %u",
+  ck_assert_msg(res < 0, "Found groups for '%s' unexpectedly", PR_TEST_AUTH_NAME);
+  ck_assert_msg(getgroups_count == 0, "Expected call count 0, got %u",
     getgroups_count);
   mark_point();
   
@@ -1140,20 +1140,20 @@ START_TEST (auth_getgroups_test) {
   authtab.handler = handle_getgroups;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   res = pr_auth_getgroups(p, PR_TEST_AUTH_NAME, &gids, &names);
-  fail_unless(res > 0, "Expected group count 1 for '%s', got %d: %s",
+  ck_assert_msg(res > 0, "Expected group count 1 for '%s', got %d: %s",
     PR_TEST_AUTH_NAME, res, strerror(errno));
-  fail_unless(getgroups_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(getgroups_count == 1, "Expected call count 1, got %u",
     getgroups_count);
 
   res = pr_auth_getgroups(p, "other", &gids, &names);
-  fail_unless(res < 0, "Found groups for 'other' unexpectedly");
-  fail_unless(getgroups_count == 2, "Expected call count 2, got %u",
+  ck_assert_msg(res < 0, "Found groups for 'other' unexpectedly");
+  ck_assert_msg(getgroups_count == 2, "Expected call count 2, got %u",
     getgroups_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1173,25 +1173,25 @@ START_TEST (auth_cache_uid2name_test) {
   authtab.handler = handle_uid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid2name_count == 1, "Expected call count 1, got %u",
     uid2name_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid2name_count == 1, "Expected call count 1, got %u",
     uid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1211,25 +1211,25 @@ START_TEST (auth_cache_gid2name_test) {
   authtab.handler = handle_gid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid2name_count == 1, "Expected call count 1, got %u",
     gid2name_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_NAME) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_NAME) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_NAME, name);
-  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid2name_count == 1, "Expected call count 1, got %u",
     gid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1249,25 +1249,25 @@ START_TEST (auth_cache_uid2name_failed_test) {
   authtab.handler = decline_uid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_UID_STR, name);
-  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid2name_count == 1, "Expected call count 1, got %u",
     uid2name_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   name = pr_auth_uid2name(p, PR_TEST_AUTH_UID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_UID_STR) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_UID_STR, name);
-  fail_unless(uid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid2name_count == 1, "Expected call count 1, got %u",
     uid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1287,25 +1287,25 @@ START_TEST (auth_cache_gid2name_failed_test) {
   authtab.handler = decline_gid2name;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_GID_STR, name);
-  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid2name_count == 1, "Expected call count 1, got %u",
     gid2name_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   name = pr_auth_gid2name(p, PR_TEST_AUTH_GID);
-  fail_unless(name != NULL, "Expected name, got null");
-  fail_unless(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
+  ck_assert_msg(name != NULL, "Expected name, got null");
+  ck_assert_msg(strcmp(name, PR_TEST_AUTH_GID_STR) == 0,
     "Expected name '%s', got '%s'", PR_TEST_AUTH_GID_STR, name);
-  fail_unless(gid2name_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid2name_count == 1, "Expected call count 1, got %u",
     gid2name_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1325,21 +1325,21 @@ START_TEST (auth_cache_name2uid_failed_test) {
   authtab.handler = decline_name2uid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
-  fail_unless(uid == (uid_t) -1, "Expected -1, got %lu", (unsigned long) uid);
-  fail_unless(name2uid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid == (uid_t) -1, "Expected -1, got %lu", (unsigned long) uid);
+  ck_assert_msg(name2uid_count == 1, "Expected call count 1, got %u",
     name2uid_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   uid = pr_auth_name2uid(p, PR_TEST_AUTH_NAME);
-  fail_unless(uid == (uid_t) -1, "Expected -1, got %lu", (unsigned long) uid);
-  fail_unless(name2uid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(uid == (uid_t) -1, "Expected -1, got %lu", (unsigned long) uid);
+  ck_assert_msg(name2uid_count == 1, "Expected call count 1, got %u",
     name2uid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1359,21 +1359,21 @@ START_TEST (auth_cache_name2gid_failed_test) {
   authtab.handler = decline_name2gid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
 
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
-  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
+  ck_assert_msg(name2gid_count == 1, "Expected call count 1, got %u",
     name2gid_count);
 
   /* Call again; the call counter should NOT increment due to caching. */
 
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
-  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
+  ck_assert_msg(name2gid_count == 1, "Expected call count 1, got %u",
     name2gid_count);
 
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
@@ -1396,13 +1396,13 @@ START_TEST (auth_cache_clear_test) {
   authtab.handler = decline_name2gid;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
   gid = pr_auth_name2gid(p, PR_TEST_AUTH_NAME);
-  fail_unless(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
-  fail_unless(name2gid_count == 1, "Expected call count 1, got %u",
+  ck_assert_msg(gid == (gid_t) -1, "Expected -1, got %lu", (unsigned long) gid);
+  ck_assert_msg(name2gid_count == 1, "Expected call count 1, got %u",
     name2gid_count);
 
   mark_point();
@@ -1415,16 +1415,16 @@ START_TEST (auth_cache_set_test) {
   unsigned int flags = PR_AUTH_CACHE_FL_UID2NAME|PR_AUTH_CACHE_FL_GID2NAME|PR_AUTH_CACHE_FL_AUTH_MODULE|PR_AUTH_CACHE_FL_NAME2UID|PR_AUTH_CACHE_FL_NAME2GID|PR_AUTH_CACHE_FL_BAD_UID2NAME|PR_AUTH_CACHE_FL_BAD_GID2NAME|PR_AUTH_CACHE_FL_BAD_NAME2UID|PR_AUTH_CACHE_FL_BAD_NAME2GID;
 
   res = pr_auth_cache_set(-1, 0);
-  fail_unless(res < 0, "Failed to handle invalid setting");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid setting");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_cache_set(TRUE, flags);
-  fail_unless(res == 0, "Failed to enable all auth cache settings: %s",
+  ck_assert_msg(res == 0, "Failed to enable all auth cache settings: %s",
     strerror(errno));
 
   res = pr_auth_cache_set(FALSE, flags);
-  fail_unless(res == 0, "Failed to disable all auth cache settings: %s",
+  ck_assert_msg(res == 0, "Failed to disable all auth cache settings: %s",
     strerror(errno));
 
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_DEFAULT);
@@ -1437,8 +1437,8 @@ START_TEST (auth_clear_auth_only_module_test) {
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_clear_auth_only_modules();
-  fail_unless(res < 0, "Failed to handle no auth module list");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle no auth module list");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 }
 END_TEST
@@ -1450,21 +1450,21 @@ START_TEST (auth_add_auth_only_module_test) {
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_add_auth_only_module(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_add_auth_only_module(name);
-  fail_unless(res == 0, "Failed to add auth-only module '%s': %s", name,
+  ck_assert_msg(res == 0, "Failed to add auth-only module '%s': %s", name,
     strerror(errno));
 
   res = pr_auth_add_auth_only_module(name);
-  fail_unless(res < 0, "Failed to handle duplicate auth-only module");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle duplicate auth-only module");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   res = pr_auth_clear_auth_only_modules();
-  fail_unless(res == 0, "Failed to clear auth-only modules: %s",
+  ck_assert_msg(res == 0, "Failed to clear auth-only modules: %s",
     strerror(errno));
 }
 END_TEST
@@ -1476,21 +1476,21 @@ START_TEST (auth_remove_auth_only_module_test) {
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_remove_auth_only_module(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_remove_auth_only_module(name);
-  fail_unless(res < 0, "Failed to handle empty auth-only module list");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle empty auth-only module list");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   res = pr_auth_add_auth_only_module(name);
-  fail_unless(res == 0, "Failed to add auth-only module '%s': %s", name,
+  ck_assert_msg(res == 0, "Failed to add auth-only module '%s': %s", name,
     strerror(errno));
 
   res = pr_auth_remove_auth_only_module(name);
-  fail_unless(res == 0, "Failed to remove auth-only module '%s': %s", name,
+  ck_assert_msg(res == 0, "Failed to remove auth-only module '%s': %s", name,
     strerror(errno));
 
   (void) pr_auth_clear_auth_only_modules();
@@ -1503,18 +1503,18 @@ START_TEST (auth_authenticate_test) {
   char *sym_name = "auth";
 
   res = pr_auth_authenticate(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_authenticate(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, NULL);
-  fail_unless(res < 0, "Failed to handle null password");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null password");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Load the appropriate AUTH symbol, and call it. */
@@ -1524,27 +1524,27 @@ START_TEST (auth_authenticate_test) {
   authtab.handler = handle_authn;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   res = pr_auth_authenticate(p, "other", "foobar");
-  fail_unless(res == PR_AUTH_NOPWD,
+  ck_assert_msg(res == PR_AUTH_NOPWD,
     "Authenticated user 'other' unexpectedly (expected %d, got %d)",
     PR_AUTH_NOPWD, res);
 
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, "foobar");
-  fail_unless(res == PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD,
     "Authenticated user '%s' unexpectedly (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_BADPWD, res);
 
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(res == PR_AUTH_OK,
+  ck_assert_msg(res == PR_AUTH_OK,
     "Failed to authenticate user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_OK, res);
 
   authtab.auth_flags |= PR_AUTH_FL_REQUIRED;
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(res == PR_AUTH_OK,
+  ck_assert_msg(res == PR_AUTH_OK,
     "Failed to authenticate user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_OK, res);
   authtab.auth_flags &= ~PR_AUTH_FL_REQUIRED;
@@ -1552,32 +1552,32 @@ START_TEST (auth_authenticate_test) {
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_add_auth_only_module("foo.bar");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   res = pr_auth_add_auth_only_module("mod_testsuite.c");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   res = pr_module_load(&testsuite_module);
-  fail_unless(res == 0, "Failed to load module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module: %s", strerror(errno));
 
   res = pr_auth_authenticate(p, "foo", "bar");
-  fail_unless(res == PR_AUTH_NOPWD,
+  ck_assert_msg(res == PR_AUTH_NOPWD,
     "Failed to handle unknown user 'foo' (expected %d, got %d)", PR_AUTH_NOPWD,
     res);
 
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, "bar");
-  fail_unless(res == PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD,
     "Failed to handle user '%s' with bad password (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_BADPWD, res);
 
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(res == PR_AUTH_OK,
+  ck_assert_msg(res == PR_AUTH_OK,
     "Failed to authenticate user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_OK, res);
 
   authn_rfc2228 = TRUE;
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(res == PR_AUTH_RFC2228_OK,
+  ck_assert_msg(res == PR_AUTH_RFC2228_OK,
     "Failed to authenticate user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_RFC2228_OK, res);
 
@@ -1586,7 +1586,7 @@ START_TEST (auth_authenticate_test) {
 
   authn_rfc2228 = TRUE;
   res = pr_auth_authenticate(p, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(res == PR_AUTH_RFC2228_OK,
+  ck_assert_msg(res == PR_AUTH_RFC2228_OK,
     "Failed to authenticate user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_RFC2228_OK, res);
 
@@ -1600,17 +1600,17 @@ START_TEST (auth_authorize_test) {
   char *sym_name = "authorize";
 
   res = pr_auth_authorize(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_authorize(p, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_authorize(p, PR_TEST_AUTH_NAME);
-  fail_unless(res > 0, "Failed to handle missing handler");
+  ck_assert_msg(res > 0, "Failed to handle missing handler");
 
   /* Load the appropriate AUTH symbol, and call it. */
 
@@ -1619,29 +1619,29 @@ START_TEST (auth_authorize_test) {
   authtab.handler = handle_authz;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   res = pr_auth_authorize(p, "other");
-  fail_unless(res == PR_AUTH_NOPWD,
+  ck_assert_msg(res == PR_AUTH_NOPWD,
     "Authorized user 'other' unexpectedly (expected %d, got %d)",
     PR_AUTH_NOPWD, res);
 
   res = pr_auth_authorize(p, PR_TEST_AUTH_NAME);
-  fail_unless(res == PR_AUTH_OK,
+  ck_assert_msg(res == PR_AUTH_OK,
     "Failed to authorize user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_OK, res);
 
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_add_auth_only_module("foo.bar");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   res = pr_auth_add_auth_only_module(testsuite_module.name);
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   res = pr_auth_authorize(p, PR_TEST_AUTH_NAME);
-  fail_unless(res == PR_AUTH_OK,
+  ck_assert_msg(res == PR_AUTH_OK,
     "Failed to authorize user '%s' (expected %d, got %d)",
     PR_TEST_AUTH_NAME, PR_AUTH_OK, res);
 
@@ -1679,60 +1679,60 @@ START_TEST (auth_check_errors_test) {
 
   mark_point();
   res = pr_auth_check(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_auth_check(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   name = PR_TEST_AUTH_NAME;
   res = pr_auth_check(p, NULL, name, NULL);
-  fail_unless(res < 0, "Failed to handle null cleartext password");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null cleartext password");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cleartext_passwd = PR_TEST_AUTH_PASSWD;
   res = pr_auth_check(p, NULL, name, cleartext_passwd);
-  fail_unless(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
     res);
 
   res = pr_module_load(&testsuite_module);
-  fail_unless(res == 0, "Failed to load module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module: %s", strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = sym_name;
   authtab.handler = handle_check_error;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
   res = pr_auth_add_auth_only_module("mod_testsuite.c");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   for (i = 0; test_errorcodes[i] != 0; i++) {
     mark_point();
     test_check_errorcode = test_errorcodes[i];
     res = pr_auth_check(p, "", name, cleartext_passwd);
-    fail_unless(res == test_check_errorcode, "Expected %d, got %d",
+    ck_assert_msg(res == test_check_errorcode, "Expected %d, got %d",
       test_check_errorcode, res);
   }
 
   mark_point();
   test_check_errorcode = PR_AUTH_OK_NO_PASS;
   res = pr_auth_check(p, "", name, cleartext_passwd);
-  fail_unless(res == test_check_errorcode, "Expected %d, got %d",
+  ck_assert_msg(res == test_check_errorcode, "Expected %d, got %d",
     test_check_errorcode, res);
 
   res = pr_module_unload(&testsuite_module);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
   (void) pr_auth_clear_auth_only_modules();
   pr_stash_remove_symbol(PR_SYM_AUTH, sym_name, &testsuite_module);
 }
@@ -1751,43 +1751,43 @@ START_TEST (auth_check_valid_test) {
   authtab.handler = handle_check;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   mark_point();
   cleartext_passwd = PR_TEST_AUTH_PASSWD;
   res = pr_auth_check(p, NULL, "other", cleartext_passwd);
-  fail_unless(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
     res);
 
   mark_point();
   name = PR_TEST_AUTH_NAME;
   res = pr_auth_check(p, "foo", name, cleartext_passwd);
-  fail_unless(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
     res);
 
   mark_point();
   res = pr_auth_check(p, NULL, name, cleartext_passwd);
-  fail_unless(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
+  ck_assert_msg(res == PR_AUTH_BADPWD, "Expected %d, got %d", PR_AUTH_BADPWD,
     res);
 
   mark_point();
   ciphertext_passwd = PR_TEST_AUTH_PASSWD;
   res = pr_auth_check(p, ciphertext_passwd, name, cleartext_passwd);
-  fail_unless(res == PR_AUTH_OK, "Expected %d, got %d", PR_AUTH_OK, res);
+  ck_assert_msg(res == PR_AUTH_OK, "Expected %d, got %d", PR_AUTH_OK, res);
 
   (void) pr_auth_cache_set(TRUE, PR_AUTH_CACHE_FL_AUTH_MODULE);
 
   res = pr_auth_add_auth_only_module("foo.bar");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   res = pr_auth_add_auth_only_module("mod_testsuite.c");
-  fail_unless(res == 0, "Failed to add auth-only module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add auth-only module: %s", strerror(errno));
 
   mark_point();
   check_rfc2228 = TRUE;
   res = pr_auth_check(p, ciphertext_passwd, name, cleartext_passwd);
-  fail_unless(res == PR_AUTH_RFC2228_OK,
+  ck_assert_msg(res == PR_AUTH_RFC2228_OK,
     "Failed to check user '%s' (expected %d, got %d)", name,
     PR_AUTH_RFC2228_OK, res);
 
@@ -1803,18 +1803,18 @@ START_TEST (auth_requires_pass_test) {
   char *sym_name = "requires_pass";
 
   res = pr_auth_requires_pass(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_requires_pass(p, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "other";
   res = pr_auth_requires_pass(p, name);
-  fail_unless(res == TRUE, "Unknown users should require passwords (got %d)",
+  ck_assert_msg(res == TRUE, "Unknown users should require passwords (got %d)",
     res);
 
   /* Load the appropriate AUTH symbol, and call it. */
@@ -1824,16 +1824,16 @@ START_TEST (auth_requires_pass_test) {
   authtab.handler = handle_requires_pass;
   authtab.m = &testsuite_module;
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
+  ck_assert_msg(res == 0, "Failed to add '%s' AUTH symbol: %s", sym_name,
     strerror(errno));
 
   res = pr_auth_requires_pass(p, name);
-  fail_unless(res == TRUE, "Unknown users should require passwords (got %d)",
+  ck_assert_msg(res == TRUE, "Unknown users should require passwords (got %d)",
     res);
 
   name = PR_TEST_AUTH_NAME;
   res = pr_auth_requires_pass(p, name);
-  fail_unless(res == FALSE, "Known users should NOT require passwords (got %d)",
+  ck_assert_msg(res == FALSE, "Known users should NOT require passwords (got %d)",
     res);
 }
 END_TEST
@@ -1846,7 +1846,7 @@ START_TEST (auth_get_anon_config_test) {
   mark_point();
   login_user = "test";
   res = pr_auth_get_anon_config(NULL, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
 
   mark_point();
   /* UserAlias alias realname */
@@ -1861,21 +1861,21 @@ START_TEST (auth_get_anon_config_test) {
   login_user = "test";
   anon_user = "anon";
   res = pr_auth_get_anon_config(p, &login_user, &real_user, &anon_user);
-  fail_unless(res == NULL, "Failed to handle UserAlias with mismatched alias");
-  fail_unless(login_user == NULL, "Failed to set login_user to null");
-  fail_unless(anon_user == NULL, "Failed to set anon_user to null");
+  ck_assert_msg(res == NULL, "Failed to handle UserAlias with mismatched alias");
+  ck_assert_msg(login_user == NULL, "Failed to set login_user to null");
+  ck_assert_msg(anon_user == NULL, "Failed to set anon_user to null");
 
   mark_point();
   login_user = "test";
   c->argv[0] = pstrdup(c->pool, "*");
   res = pr_auth_get_anon_config(p, &login_user, &real_user, &anon_user);
-  fail_unless(res == NULL, "Failed to handle UserAlias with globbed alias");
+  ck_assert_msg(res == NULL, "Failed to handle UserAlias with globbed alias");
 
   mark_point();
   login_user = "test";
   c->argv[0] = pstrdup(c->pool, login_user);
   res = pr_auth_get_anon_config(p, &login_user, &real_user, &anon_user);
-  fail_unless(res == NULL, "Failed to handle UserAlias with matching alias");
+  ck_assert_msg(res == NULL, "Failed to handle UserAlias with matching alias");
 
   mark_point();
   login_user = "test";
@@ -1886,8 +1886,8 @@ START_TEST (auth_get_anon_config_test) {
   *((unsigned char *) c2->argv[0]) = TRUE;
   c->parent = anon_config;
   res = pr_auth_get_anon_config(p, &login_user, &real_user, &anon_user);
-  fail_unless(res != NULL, "Failed to handle UserAlias with matching alias and <Anonymous> config");
-  fail_unless(res == anon_config, "Expected <Anonymous> config %p, got %p",
+  ck_assert_msg(res != NULL, "Failed to handle UserAlias with matching alias and <Anonymous> config");
+  ck_assert_msg(res == anon_config, "Expected <Anonymous> config %p, got %p",
     anon_config, res);
 
   mark_point();
@@ -1898,11 +1898,11 @@ START_TEST (auth_get_anon_config_test) {
   c2->argv[0] = pstrdup(c2->pool, "BAZ");
   res = pr_auth_get_anon_config(p, &login_user, &real_user, &anon_user);
 
-  fail_unless(res != NULL, "Failed to handle UserAlias with matching alias and <Anonymous> config");
-  fail_unless(res == anon_config, "Expected <Anonymous> config %p, got %p",
+  ck_assert_msg(res != NULL, "Failed to handle UserAlias with matching alias and <Anonymous> config");
+  ck_assert_msg(res == anon_config, "Expected <Anonymous> config %p, got %p",
     anon_config, res);
-  fail_unless(real_user != NULL, "Expected real_user, got NULL");
-  fail_unless(strcmp(real_user, "BAZ") == 0, "Expected real_user 'BAZ', got '%s'", real_user);
+  ck_assert_msg(real_user != NULL, "Expected real_user, got NULL");
+  ck_assert_msg(strcmp(real_user, "BAZ") == 0, "Expected real_user 'BAZ', got '%s'", real_user);
 
   (void) remove_config(test_server->conf, "AuthAliasOnly", TRUE);
   (void) remove_config(test_server->conf, "UserAlias", FALSE);
@@ -1915,15 +1915,15 @@ START_TEST (auth_chroot_test) {
 
   mark_point();
   res = pr_auth_chroot(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "tmp";
   res = pr_auth_chroot(path);
-  fail_unless(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
-  fail_unless(errno == EINVAL || errno == ENOENT,
+  ck_assert_msg(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
+  ck_assert_msg(errno == EINVAL || errno == ENOENT,
     "Expected EINVAL (%d) or ENOENT (%d), got %s (%d)", EINVAL, ENOENT,
     strerror(errno), errno);
 
@@ -1933,8 +1933,8 @@ START_TEST (auth_chroot_test) {
   mark_point();
   path = "/tmp";
   res = pr_auth_chroot(path);
-  fail_unless(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
-  fail_unless(errno == ENOENT || errno == EPERM || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
+  ck_assert_msg(errno == ENOENT || errno == EPERM || errno == EINVAL,
     "Expected ENOENT (%d), EPERM (%d) or EINVAL (%d), got %s (%d)",
     ENOENT, EPERM, EINVAL, strerror(errno), errno);
 
@@ -1943,8 +1943,8 @@ START_TEST (auth_chroot_test) {
   session.pool = p;
   path = "/tmp";
   res = pr_auth_chroot(path);
-  fail_unless(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
-  fail_unless(errno == ENOENT || errno == EPERM || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
+  ck_assert_msg(errno == ENOENT || errno == EPERM || errno == EINVAL,
     "Expected ENOENT (%d), EPERM (%d) or EINVAL (%d), got %s (%d)",
     ENOENT, EPERM, EINVAL, strerror(errno), errno);
 
@@ -1952,8 +1952,8 @@ START_TEST (auth_chroot_test) {
   mark_point();
   path = "/tmp";
   res = pr_auth_chroot(path);
-  fail_unless(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
-  fail_unless(errno == ENOENT || errno == EPERM || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to chroot to '%s': %s", path, strerror(errno));
+  ck_assert_msg(errno == ENOENT || errno == EPERM || errno == EINVAL,
     "Expected ENOENT (%d), EPERM (%d) or EINVAL (%d), got %s (%d)",
     ENOENT, EPERM, EINVAL, strerror(errno), errno);
 
@@ -1968,16 +1968,16 @@ START_TEST (auth_banned_by_ftpusers_test) {
 
   mark_point();
   res = pr_auth_banned_by_ftpusers(NULL, NULL);
-  fail_unless(res == FALSE, "Failed to handle null arguments");
+  ck_assert_msg(res == FALSE, "Failed to handle null arguments");
 
   mark_point();
   res = pr_auth_banned_by_ftpusers(test_server->conf, NULL);
-  fail_unless(res == FALSE, "Failed to handle null user");
+  ck_assert_msg(res == FALSE, "Failed to handle null user");
 
   mark_point();
   name = "testsuite";
   res = pr_auth_banned_by_ftpusers(test_server->conf, name);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   /* UseFtpUsers off */
   mark_point();
@@ -1986,7 +1986,7 @@ START_TEST (auth_banned_by_ftpusers_test) {
   *((unsigned char *) c->argv[0]) = FALSE;
 
   res = pr_auth_banned_by_ftpusers(test_server->conf, name);
-  fail_unless(res == FALSE, "Failed to handle UseFtpUsers off (got %d)",
+  ck_assert_msg(res == FALSE, "Failed to handle UseFtpUsers off (got %d)",
     res);
 
   (void) remove_config(test_server->conf, "UseFtpUsers", FALSE);
@@ -2000,21 +2000,21 @@ START_TEST (auth_is_valid_shell_test) {
 
   mark_point();
   res = pr_auth_is_valid_shell(NULL, NULL);
-  fail_unless(res == TRUE, "Failed to handle null arguments");
+  ck_assert_msg(res == TRUE, "Failed to handle null arguments");
 
   mark_point();
   res = pr_auth_is_valid_shell(test_server->conf, NULL);
-  fail_unless(res == TRUE, "Failed to handle null shell");
+  ck_assert_msg(res == TRUE, "Failed to handle null shell");
 
   shell = "/foo/bar";
   res = pr_auth_is_valid_shell(test_server->conf, shell);
-  fail_unless(res == FALSE, "Failed to handle invalid shell '%s' (got %d)",
+  ck_assert_msg(res == FALSE, "Failed to handle invalid shell '%s' (got %d)",
     shell, res);
 
   mark_point();
   shell = "/bin/sh";
   res = pr_auth_is_valid_shell(test_server->conf, shell);
-  fail_unless(res == TRUE, "Failed to handle valid shell '%s' (got %d)",
+  ck_assert_msg(res == TRUE, "Failed to handle valid shell '%s' (got %d)",
     shell, res);
 
   /* RequireValidShell off */
@@ -2025,7 +2025,7 @@ START_TEST (auth_is_valid_shell_test) {
 
   shell = "/foo/bar";
   res = pr_auth_is_valid_shell(test_server->conf, shell);
-  fail_unless(res == TRUE, "Failed to handle RequireValidShell off (got %d)",
+  ck_assert_msg(res == TRUE, "Failed to handle RequireValidShell off (got %d)",
     res);
 
   (void) remove_config(test_server->conf, "RequireValidShell", FALSE);
@@ -2042,46 +2042,46 @@ START_TEST (auth_set_groups_test) {
 
     mark_point();
     res = set_groups(NULL, 0, NULL);
-    fail_unless(res == 0, "Failed to handle zero primary gid: %s",
+    ck_assert_msg(res == 0, "Failed to handle zero primary gid: %s",
       strerror(errno));
 
     mark_point();
     res = set_groups(p, 0, NULL);
-    fail_unless(res == 0, "Failed to handle zero primary gid: %s",
+    ck_assert_msg(res == 0, "Failed to handle zero primary gid: %s",
       strerror(errno));
 
     mark_point();
     res = set_groups(NULL, gid, NULL);
-    fail_unless(res == 0, "Failed to handle current primary gid: %s",
+    ck_assert_msg(res == 0, "Failed to handle current primary gid: %s",
       strerror(errno));
 
   } else {
     mark_point();
     res = set_groups(NULL, 0, NULL);
-    fail_unless(res < 0, "Failed to handle zero primary gid: %s",
+    ck_assert_msg(res < 0, "Failed to handle zero primary gid: %s",
       strerror(errno));
-    fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+    ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
       strerror(errno), errno);
 
     mark_point();
     res = set_groups(p, 0, NULL);
-    fail_unless(res < 0, "Failed to handle zero primary gid: %s",
+    ck_assert_msg(res < 0, "Failed to handle zero primary gid: %s",
       strerror(errno));
-    fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+    ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
       strerror(errno), errno);
 
     mark_point();
     res = set_groups(p, 1, NULL);
-    fail_unless(res < 0, "Failed to handle non-root primary gid: %s",
+    ck_assert_msg(res < 0, "Failed to handle non-root primary gid: %s",
       strerror(errno));
-    fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+    ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
       strerror(errno), errno);
 
     mark_point();
     res = set_groups(p, getgid(), NULL);
-    fail_unless(res < 0, "Failed to handle current primary gid: %s",
+    ck_assert_msg(res < 0, "Failed to handle current primary gid: %s",
       strerror(errno));
-    fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+    ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
       strerror(errno), errno);
   }
 }
@@ -2092,19 +2092,19 @@ START_TEST (auth_get_home_test) {
   config_rec *c;
 
   res = pr_auth_get_home(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_get_home(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null home");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null home");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   home = "/testsuite";
   res = pr_auth_get_home(p, home);
-  fail_unless(res != NULL, "Failed to get home: %s", strerror(errno));
-  fail_unless(strcmp(home, res) == 0, "Expected '%s', got '%s'", home, res);  
+  ck_assert_msg(res != NULL, "Failed to get home: %s", strerror(errno));
+  ck_assert_msg(strcmp(home, res) == 0, "Expected '%s', got '%s'", home, res);  
 
   /* RewriteHome off */
   mark_point();
@@ -2113,23 +2113,23 @@ START_TEST (auth_get_home_test) {
   *((int *) c->argv[0]) = FALSE;
 
   res = pr_auth_get_home(p, home);
-  fail_unless(res != NULL, "Failed to get home: %s", strerror(errno));
-  fail_unless(strcmp(home, res) == 0,
+  ck_assert_msg(res != NULL, "Failed to get home: %s", strerror(errno));
+  ck_assert_msg(strcmp(home, res) == 0,
     "Failed to handle RewriteHome off, got '%s'", res);
 
   /* RewriteHome on */
   mark_point();
   *((int *) c->argv[0]) = TRUE;
   res = pr_auth_get_home(p, home);
-  fail_unless(res != NULL, "Failed to get home: %s", strerror(errno));
-  fail_unless(strcmp(home, res) == 0,
+  ck_assert_msg(res != NULL, "Failed to get home: %s", strerror(errno));
+  ck_assert_msg(strcmp(home, res) == 0,
     "Failed to handle RewriteHome on, got '%s'", res);
 
   mark_point();
   session.notes = pr_table_alloc(p, 2);
   res = pr_auth_get_home(p, home);
-  fail_unless(res != NULL, "Failed to get home: %s", strerror(errno));
-  fail_unless(strcmp(home, res) == 0,
+  ck_assert_msg(res != NULL, "Failed to get home: %s", strerror(errno));
+  ck_assert_msg(strcmp(home, res) == 0,
     "Failed to handle RewriteHome on, got '%s'", res);
 
   (void) pr_table_empty(session.notes);
@@ -2145,20 +2145,20 @@ START_TEST (auth_set_max_password_len_test) {
   size_t res;
 
   res = pr_auth_set_max_password_len(p, 1);
-  fail_unless(res == PR_TUNABLE_PASSWORD_MAX,
+  ck_assert_msg(res == PR_TUNABLE_PASSWORD_MAX,
     "Expected %lu, got %lu", (unsigned long) PR_TUNABLE_PASSWORD_MAX,
     (unsigned long) res);
 
   checked = pr_auth_check(p, NULL, PR_TEST_AUTH_NAME, PR_TEST_AUTH_PASSWD);
-  fail_unless(checked < 0, "Failed to reject too-long password");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(checked < 0, "Failed to reject too-long password");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   res = pr_auth_set_max_password_len(p, 0);
-  fail_unless(res == 1, "Expected %lu, got %lu", 1, (unsigned long) res);
+  ck_assert_msg(res == 1, "Expected %lu, got %lu", 1, (unsigned long) res);
 
   res = pr_auth_set_max_password_len(p, 0);
-  fail_unless(res == PR_TUNABLE_PASSWORD_MAX,
+  ck_assert_msg(res == PR_TUNABLE_PASSWORD_MAX,
     "Expected %lu, got %lu", (unsigned long) PR_TUNABLE_PASSWORD_MAX,
     (unsigned long) res);
 }
@@ -2169,33 +2169,33 @@ START_TEST (auth_bcrypt_test) {
   size_t hashed_len;
 
   res = pr_auth_bcrypt(NULL, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_bcrypt(p, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null key argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null key argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_bcrypt(p, "", NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null salt argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null salt argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_bcrypt(p, "", "", NULL);
-  fail_unless(res == NULL, "Failed to handle null hashed_len argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null hashed_len argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_bcrypt(p, "", "", &hashed_len);
-  fail_unless(res == NULL, "Failed to handle empty strings");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle empty strings");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_auth_bcrypt(p, "foo", "$1", &hashed_len);
-  fail_unless(res == NULL, "Failed to handle invalid salt");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid salt");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   /* TODO: Add more tests of the invalid salt constructions: bcrypt version
@@ -2205,7 +2205,7 @@ START_TEST (auth_bcrypt_test) {
   res = pr_auth_bcrypt(p, "password",
     "$2b$12$IoFxXvbRQUKssPqFacJFFuZl1KXl5ULppqf0aLFjwCFnLRh3NbYSG",
     &hashed_len);
-  fail_unless(res != NULL, "Failed to handle valid key and salt");
+  ck_assert_msg(res != NULL, "Failed to handle valid key and salt");
 }
 END_TEST
 

--- a/tests/api/class.c
+++ b/tests/api/class.c
@@ -57,21 +57,21 @@ START_TEST (class_open_test) {
   const char *name;
 
   res = pr_class_open(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_class_open(p, NULL);
-  fail_unless(res == -1, "Failed to handle NULL name argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL name argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "foo";
   res = pr_class_open(NULL, name);
-  fail_unless(res == -1, "Failed to handle NULL pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_class_open(p, name);
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
-  fail_unless(main_server->config_type == CONF_CLASS,
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(main_server->config_type == CONF_CLASS,
     "Expected config_type of %d, got %d", CONF_CLASS, main_server->config_type);
 }
 END_TEST
@@ -81,22 +81,22 @@ START_TEST (class_add_acl_test) {
   int res;
 
   res = pr_class_add_acl(NULL);
-  fail_unless(res == -1, "Failed to handle NULL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to handle ACL string 'all': %s",
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string 'all': %s",
     strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == -1, "Failed to handle unopened class");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle unopened class");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL: %s", strerror(errno));
 }
 END_TEST
 
@@ -107,22 +107,22 @@ START_TEST (class_add_note_test) {
   int res;
 
   res = pr_class_add_note(k, v, vsz);
-  fail_unless(res == -1, "Failed to handle NULL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   k = "KEY";
   v = "VALUE";
   vsz = 6;
 
   res = pr_class_add_note(k, v, vsz);
-  fail_unless(res == -1, "Failed to handle unopened class");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle unopened class");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_add_note(k, v, vsz);
-  fail_unless(res == 0, "Failed to add note: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add note: %s", strerror(errno));
 }
 END_TEST
 
@@ -131,31 +131,31 @@ START_TEST (class_close_test) {
   int res;
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close nonexistent current class: %s",
+  ck_assert_msg(res == 0, "Failed to close nonexistent current class: %s",
     strerror(errno));
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == -1, "Failed to close empty class");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
-  fail_unless(main_server->config_type == CONF_ROOT,
+  ck_assert_msg(res == -1, "Failed to close empty class");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(main_server->config_type == CONF_ROOT,
     "Expected config_type of %d, got %d", CONF_ROOT, main_server->config_type);
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to handle ACL string 'all': %s",
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string 'all': %s",
     strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
-  fail_unless(main_server->config_type == CONF_ROOT,
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(main_server->config_type == CONF_ROOT,
     "Expected config_type of %d, got %d", CONF_ROOT, main_server->config_type);
 }
 END_TEST
@@ -164,21 +164,21 @@ START_TEST (class_set_satisfy_test) {
   int res;
 
   res = pr_class_set_satisfy(PR_CLASS_SATISFY_ANY);
-  fail_unless(res == -1, "Failed to handle nonexistent current class");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle nonexistent current class");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_set_satisfy(PR_CLASS_SATISFY_ANY);
-  fail_unless(res == 0, "Failed to set SATISFY_ANY: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set SATISFY_ANY: %s", strerror(errno));
 
   res = pr_class_set_satisfy(PR_CLASS_SATISFY_ALL);
-  fail_unless(res == 0, "Failed to set SATISFY_ALL: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set SATISFY_ALL: %s", strerror(errno));
 
   res = pr_class_set_satisfy(-1);
-  fail_unless(res == -1, "Failed to handle bad satisfy value");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad satisfy value");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 }
 END_TEST
 
@@ -188,32 +188,32 @@ START_TEST (class_get_test) {
   pr_netacl_t *acl;
 
   class = pr_class_get(NULL);
-  fail_unless(class == NULL, "Failed to handle empty class list");
+  ck_assert_msg(class == NULL, "Failed to handle empty class list");
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to handle ACL string 'all': %s",
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string 'all': %s",
     strerror(errno));
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL: %s", strerror(errno));
 
   class = pr_class_get(NULL);
-  fail_unless(class == NULL, "Failed to handle unclosed class in list");
+  ck_assert_msg(class == NULL, "Failed to handle unclosed class in list");
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_get(NULL);
-  fail_unless(class != NULL, "Failed to get class in list: %s",
+  ck_assert_msg(class != NULL, "Failed to get class in list: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "foo") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "foo") == 0,
     "Expected '%s', got '%s'", "foo", class->cls_name);
 
   class = pr_class_get(class);
-  fail_unless(class == NULL, "Failed to return NULL for end-of-list");
+  ck_assert_msg(class == NULL, "Failed to return NULL for end-of-list");
 }
 END_TEST
 
@@ -223,37 +223,37 @@ START_TEST (class_find_test) {
   int res;
 
   class = pr_class_find(NULL);
-  fail_unless(class == NULL, "Failed to handle NULL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(class == NULL, "Failed to handle NULL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   class = pr_class_find("foo");
-  fail_unless(class == NULL, "Failed to handle empty list");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(class == NULL, "Failed to handle empty list");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to handle ACL string 'all': %s",
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string 'all': %s",
     strerror(errno));
 
   res = pr_class_open(p, "foo");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL: %s", strerror(errno));
 
   class = pr_class_find("foo");
-  fail_unless(class == NULL, "Failed to handle empty list");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(class == NULL, "Failed to handle empty list");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_find("foo");
-  fail_unless(class != NULL, "Failed to handle class 'foo': %s",
+  ck_assert_msg(class != NULL, "Failed to handle class 'foo': %s",
     strerror(errno));
 
   class = pr_class_find("bar");
-  fail_unless(class == NULL, "Failed to handle nonexistent class");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(class == NULL, "Failed to handle nonexistent class");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 }
 END_TEST
 
@@ -268,59 +268,59 @@ START_TEST (class_satisfied_test) {
 
   mark_point();
   res = pr_class_satisfied(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null class");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null class");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_class_open(p, "localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   cls = pr_class_find("localhost");
-  fail_unless(cls != NULL, "Failed to find class 'localhost': %s",
+  ck_assert_msg(cls != NULL, "Failed to find class 'localhost': %s",
     strerror(errno));
 
   mark_point();
   res = pr_class_satisfied(p, cls, NULL);
-  fail_unless(res < 0, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "localhost", FALSE);
-  fail_unless(addr != NULL, "Failed to get addr: %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to get addr: %s", strerror(errno));
 
   mark_point();
   res = pr_class_satisfied(p, cls, addr);
-  fail_unless(res == TRUE, "Class not satisfied by address: %s",
+  ck_assert_msg(res == TRUE, "Class not satisfied by address: %s",
     strerror(errno));
 
   res = pr_class_open(p, "!localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "!127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   cls = pr_class_find("!localhost");
-  fail_unless(cls != NULL, "Failed to find class '!localhost': %s",
+  ck_assert_msg(cls != NULL, "Failed to find class '!localhost': %s",
     strerror(errno));
 
   mark_point();
   res = pr_class_satisfied(p, cls, addr);
-  fail_unless(res == FALSE, "Class satisfied unexpectedly by address");
+  ck_assert_msg(res == FALSE, "Class satisfied unexpectedly by address");
 }
 END_TEST
 
@@ -335,77 +335,77 @@ START_TEST (class_match_addr_test) {
 
   mark_point();
   class = pr_class_match_addr(NULL);
-  fail_unless(class == NULL, "Failed to handle NULL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(class == NULL, "Failed to handle NULL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, "localhost", FALSE);
-  fail_unless(addr != NULL, "Failed to get addr: %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to get addr: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class == NULL, "Failed to handle empty class list");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(class == NULL, "Failed to handle empty class list");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_class_open(p, "localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   res = pr_class_open(p, "!localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "!127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class != NULL, "Failed to match class for addr: %s",
+  ck_assert_msg(class != NULL, "Failed to match class for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "localhost") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "localhost") == 0,
     "Expected '%s', got '%s'", "localhost", class->cls_name);
 
   /* Reset the class list, add classes in a different order, and try again. */
   init_class();
 
   res = pr_class_open(p, "!localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "!127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   res = pr_class_open(p, "localhost");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class != NULL, "Failed to match class for addr: %s",
+  ck_assert_msg(class != NULL, "Failed to match class for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "localhost") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "localhost") == 0,
     "Expected '%s', got '%s'", "localhost", class->cls_name);
 
   /* Reset the class list, and see what happens when we try to match
@@ -414,29 +414,29 @@ START_TEST (class_match_addr_test) {
   init_class();
 
   res = pr_class_open(p, "impossible");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "!127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_set_satisfy(PR_CLASS_SATISFY_ALL);
-  fail_unless(res == 0, "Failed to set satisfy value: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set satisfy value: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class == NULL, "Unexpectedly matched class for addr");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(class == NULL, "Unexpectedly matched class for addr");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   /* Reset the class list, add two classes with identical rules, and
    * verify that the first matching class wins.
@@ -444,88 +444,88 @@ START_TEST (class_match_addr_test) {
   init_class();
 
   res = pr_class_open(p, "first");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   res = pr_class_open(p, "second");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class != NULL, "Failed to match class for addr: %s",
+  ck_assert_msg(class != NULL, "Failed to match class for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "first") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "first") == 0,
     "Expected '%s', got '%s'", "first", class->cls_name);
 
   init_class();
 
   res = pr_class_open(p, "second");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   res = pr_class_open(p, "first");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class != NULL, "Failed to match class for addr: %s",
+  ck_assert_msg(class != NULL, "Failed to match class for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "second") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "second") == 0,
     "Expected '%s', got '%s'", "second", class->cls_name);
 
   init_class();
 
   res = pr_class_open(p, "match");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_set_satisfy(PR_CLASS_SATISFY_ALL);
-  fail_unless(res == 0, "Failed to set satisfy value: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set satisfy value: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   class = pr_class_match_addr(addr);
-  fail_unless(class != NULL, "Failed to match class for addr: %s",
+  ck_assert_msg(class != NULL, "Failed to match class for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(class->cls_name, "match") == 0,
+  ck_assert_msg(strcmp(class->cls_name, "match") == 0,
     "Expected '%s', got '%s'", "match", class->cls_name);
 
 }

--- a/tests/api/cmd.c
+++ b/tests/api/cmd.c
@@ -45,17 +45,17 @@ START_TEST (cmd_alloc_test) {
   cmd_rec *cmd;
 
   cmd = pr_cmd_alloc(NULL, 0);
-  fail_unless(cmd == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(cmd == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   cmd = pr_cmd_alloc(p, 0);
-  fail_unless(cmd != NULL, "Failed to create cmd_rec: %s", strerror(errno));
-  fail_unless(cmd->argc == 0, "Expected argc = 0, got %d", cmd->argc);
+  ck_assert_msg(cmd != NULL, "Failed to create cmd_rec: %s", strerror(errno));
+  ck_assert_msg(cmd->argc == 0, "Expected argc = 0, got %d", cmd->argc);
 
   cmd = pr_cmd_alloc(p, 1, "foo");
-  fail_unless(cmd != NULL, "Failed to create cmd_rec: %s", strerror(errno));
-  fail_unless(cmd->argc == 1, "Expected argc = 1, got %d", cmd->argc);
-  fail_unless(cmd->argv[1] == NULL, "Failed to null-terminate argv");
+  ck_assert_msg(cmd != NULL, "Failed to create cmd_rec: %s", strerror(errno));
+  ck_assert_msg(cmd->argc == 1, "Expected argc = 1, got %d", cmd->argc);
+  ck_assert_msg(cmd->argv[1] == NULL, "Failed to null-terminate argv");
 }
 END_TEST
 
@@ -63,257 +63,257 @@ START_TEST (cmd_get_id_test) {
   int res;
 
   res = pr_cmd_get_id(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_cmd_get_id("a");
-  fail_unless(res == -1, "Failed to handle unknown argument");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle unknown argument");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
   
   res = pr_cmd_get_id(C_USER);
-  fail_unless(res == PR_CMD_USER_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_USER_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_USER_ID, C_USER, res); 
 
   res = pr_cmd_get_id(C_PASS);
-  fail_unless(res == PR_CMD_PASS_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PASS_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PASS_ID, C_PASS, res); 
 
   res = pr_cmd_get_id(C_ACCT);
-  fail_unless(res == PR_CMD_ACCT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_ACCT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_ACCT_ID, C_ACCT, res); 
 
   res = pr_cmd_get_id(C_CWD);
-  fail_unless(res == PR_CMD_CWD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_CWD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_CWD_ID, C_CWD, res); 
 
   res = pr_cmd_get_id(C_XCWD);
-  fail_unless(res == PR_CMD_XCWD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_XCWD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_XCWD_ID, C_XCWD, res); 
 
   res = pr_cmd_get_id(C_CDUP);
-  fail_unless(res == PR_CMD_CDUP_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_CDUP_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_CDUP_ID, C_CDUP, res); 
 
   res = pr_cmd_get_id(C_XCUP);
-  fail_unless(res == PR_CMD_XCUP_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_XCUP_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_XCUP_ID, C_XCUP, res); 
 
   res = pr_cmd_get_id(C_SMNT);
-  fail_unless(res == PR_CMD_SMNT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_SMNT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_SMNT_ID, C_SMNT, res); 
 
   res = pr_cmd_get_id(C_REIN);
-  fail_unless(res == PR_CMD_REIN_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_REIN_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_REIN_ID, C_REIN, res); 
 
   res = pr_cmd_get_id(C_QUIT);
-  fail_unless(res == PR_CMD_QUIT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_QUIT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_QUIT_ID, C_QUIT, res); 
 
   res = pr_cmd_get_id(C_PORT);
-  fail_unless(res == PR_CMD_PORT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PORT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PORT_ID, C_PORT, res); 
 
   res = pr_cmd_get_id(C_EPRT);
-  fail_unless(res == PR_CMD_EPRT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_EPRT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_EPRT_ID, C_EPRT, res); 
 
   res = pr_cmd_get_id(C_PASV);
-  fail_unless(res == PR_CMD_PASV_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PASV_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PASV_ID, C_PASV, res); 
 
   res = pr_cmd_get_id(C_EPSV);
-  fail_unless(res == PR_CMD_EPSV_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_EPSV_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_EPSV_ID, C_EPSV, res); 
 
   res = pr_cmd_get_id(C_TYPE);
-  fail_unless(res == PR_CMD_TYPE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_TYPE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_TYPE_ID, C_TYPE, res); 
 
   res = pr_cmd_get_id(C_STRU);
-  fail_unless(res == PR_CMD_STRU_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_STRU_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_STRU_ID, C_STRU, res); 
 
   res = pr_cmd_get_id(C_MODE);
-  fail_unless(res == PR_CMD_MODE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MODE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MODE_ID, C_MODE, res); 
 
   res = pr_cmd_get_id(C_RETR);
-  fail_unless(res == PR_CMD_RETR_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_RETR_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_RETR_ID, C_RETR, res); 
 
   res = pr_cmd_get_id(C_STOR);
-  fail_unless(res == PR_CMD_STOR_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_STOR_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_STOR_ID, C_STOR, res); 
 
   res = pr_cmd_get_id(C_STOU);
-  fail_unless(res == PR_CMD_STOU_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_STOU_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_STOU_ID, C_STOU, res); 
 
   res = pr_cmd_get_id(C_APPE);
-  fail_unless(res == PR_CMD_APPE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_APPE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_APPE_ID, C_APPE, res); 
 
   res = pr_cmd_get_id(C_ALLO);
-  fail_unless(res == PR_CMD_ALLO_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_ALLO_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_ALLO_ID, C_ALLO, res); 
 
   res = pr_cmd_get_id(C_REST);
-  fail_unless(res == PR_CMD_REST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_REST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_REST_ID, C_REST, res); 
 
   res = pr_cmd_get_id(C_RNFR);
-  fail_unless(res == PR_CMD_RNFR_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_RNFR_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_RNFR_ID, C_RNFR, res); 
 
   res = pr_cmd_get_id(C_RNTO);
-  fail_unless(res == PR_CMD_RNTO_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_RNTO_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_RNTO_ID, C_RNTO, res); 
 
   res = pr_cmd_get_id(C_ABOR);
-  fail_unless(res == PR_CMD_ABOR_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_ABOR_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_ABOR_ID, C_ABOR, res); 
 
   res = pr_cmd_get_id(C_DELE);
-  fail_unless(res == PR_CMD_DELE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_DELE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_DELE_ID, C_DELE, res); 
 
   res = pr_cmd_get_id(C_MDTM);
-  fail_unless(res == PR_CMD_MDTM_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MDTM_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MDTM_ID, C_MDTM, res); 
 
   res = pr_cmd_get_id(C_MDTM);
-  fail_unless(res == PR_CMD_MDTM_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MDTM_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MDTM_ID, C_MDTM, res); 
 
   res = pr_cmd_get_id(C_RMD);
-  fail_unless(res == PR_CMD_RMD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_RMD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_RMD_ID, C_RMD, res); 
 
   res = pr_cmd_get_id(C_XRMD);
-  fail_unless(res == PR_CMD_XRMD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_XRMD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_XRMD_ID, C_XRMD, res); 
 
   res = pr_cmd_get_id(C_MKD);
-  fail_unless(res == PR_CMD_MKD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MKD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MKD_ID, C_MKD, res); 
 
   res = pr_cmd_get_id(C_MLSD);
-  fail_unless(res == PR_CMD_MLSD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MLSD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MLSD_ID, C_MLSD, res); 
 
   res = pr_cmd_get_id(C_MLST);
-  fail_unless(res == PR_CMD_MLST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MLST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MLST_ID, C_MLST, res); 
 
   res = pr_cmd_get_id(C_XMKD);
-  fail_unless(res == PR_CMD_XMKD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_XMKD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_XMKD_ID, C_XMKD, res); 
 
   res = pr_cmd_get_id(C_PWD);
-  fail_unless(res == PR_CMD_PWD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PWD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PWD_ID, C_PWD, res); 
 
   res = pr_cmd_get_id(C_XPWD);
-  fail_unless(res == PR_CMD_XPWD_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_XPWD_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_XPWD_ID, C_XPWD, res); 
 
   res = pr_cmd_get_id(C_SIZE);
-  fail_unless(res == PR_CMD_SIZE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_SIZE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_SIZE_ID, C_SIZE, res); 
 
   res = pr_cmd_get_id(C_LIST);
-  fail_unless(res == PR_CMD_LIST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_LIST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_LIST_ID, C_LIST, res); 
 
   res = pr_cmd_get_id(C_NLST);
-  fail_unless(res == PR_CMD_NLST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_NLST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_NLST_ID, C_NLST, res); 
 
   res = pr_cmd_get_id(C_SITE);
-  fail_unless(res == PR_CMD_SITE_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_SITE_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_SITE_ID, C_SITE, res); 
 
   res = pr_cmd_get_id(C_SYST);
-  fail_unless(res == PR_CMD_SYST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_SYST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_SYST_ID, C_SYST, res); 
 
   res = pr_cmd_get_id(C_STAT);
-  fail_unless(res == PR_CMD_STAT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_STAT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_STAT_ID, C_STAT, res); 
 
   res = pr_cmd_get_id(C_HELP);
-  fail_unless(res == PR_CMD_HELP_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_HELP_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_HELP_ID, C_HELP, res); 
 
   res = pr_cmd_get_id(C_NOOP);
-  fail_unless(res == PR_CMD_NOOP_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_NOOP_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_NOOP_ID, C_NOOP, res); 
 
   res = pr_cmd_get_id(C_FEAT);
-  fail_unless(res == PR_CMD_FEAT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_FEAT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_FEAT_ID, C_FEAT, res); 
 
   res = pr_cmd_get_id(C_OPTS);
-  fail_unless(res == PR_CMD_OPTS_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_OPTS_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_OPTS_ID, C_OPTS, res); 
 
   res = pr_cmd_get_id(C_LANG);
-  fail_unless(res == PR_CMD_LANG_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_LANG_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_LANG_ID, C_LANG, res); 
 
   res = pr_cmd_get_id(C_HOST);
-  fail_unless(res == PR_CMD_HOST_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_HOST_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_HOST_ID, C_HOST, res); 
 
   res = pr_cmd_get_id(C_CLNT);
-  fail_unless(res == PR_CMD_CLNT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_CLNT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_CLNT_ID, C_CLNT, res); 
 
   res = pr_cmd_get_id(C_RANG);
-  fail_unless(res == PR_CMD_RANG_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_RANG_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_RANG_ID, C_RANG, res);
 
   /* RFC 2228 commands */
   res = pr_cmd_get_id(C_ADAT);
-  fail_unless(res == PR_CMD_ADAT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_ADAT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_ADAT_ID, C_ADAT, res); 
 
   res = pr_cmd_get_id(C_AUTH);
-  fail_unless(res == PR_CMD_AUTH_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_AUTH_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_AUTH_ID, C_AUTH, res); 
 
   res = pr_cmd_get_id(C_CCC);
-  fail_unless(res == PR_CMD_CCC_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_CCC_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_CCC_ID, C_CCC, res); 
 
   res = pr_cmd_get_id(C_CONF);
-  fail_unless(res == PR_CMD_CONF_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_CONF_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_CONF_ID, C_CONF, res); 
 
   res = pr_cmd_get_id(C_ENC);
-  fail_unless(res == PR_CMD_ENC_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_ENC_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_ENC_ID, C_ENC, res); 
 
   res = pr_cmd_get_id(C_MIC);
-  fail_unless(res == PR_CMD_MIC_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_MIC_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_MIC_ID, C_MIC, res); 
 
   res = pr_cmd_get_id(C_PBSZ);
-  fail_unless(res == PR_CMD_PBSZ_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PBSZ_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PBSZ_ID, C_PBSZ, res); 
 
   res = pr_cmd_get_id(C_PROT);
-  fail_unless(res == PR_CMD_PROT_ID, "Expected cmd ID %d for '%s', got %d",
+  ck_assert_msg(res == PR_CMD_PROT_ID, "Expected cmd ID %d for '%s', got %d",
     PR_CMD_PROT_ID, C_PROT, res); 
 
   /* Make sure we handle lowercased, mixed-case commands as well. */
   res = pr_cmd_get_id("user");
-  fail_unless(res == PR_CMD_USER_ID, "Expected cmd ID %d for 'user', got %d",
+  ck_assert_msg(res == PR_CMD_USER_ID, "Expected cmd ID %d for 'user', got %d",
     PR_CMD_USER_ID, res);
 
   res = pr_cmd_get_id("RnTo");
-  fail_unless(res == PR_CMD_RNTO_ID, "Expected cmd ID %d for 'RnTo', got %d",
+  ck_assert_msg(res == PR_CMD_RNTO_ID, "Expected cmd ID %d for 'RnTo', got %d",
     PR_CMD_RNTO_ID, res);
 }
 END_TEST
@@ -323,30 +323,30 @@ START_TEST (cmd_cmp_test) {
   int res;
 
   res = pr_cmd_cmp(NULL, 1);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL"); 
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL"); 
 
   cmd = pr_cmd_alloc(p, 1, "foo");
   res = pr_cmd_cmp(cmd, 0);
-  fail_unless(res == -1, "Failed to handle bad ID argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL"); 
+  ck_assert_msg(res == -1, "Failed to handle bad ID argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL"); 
 
   res = pr_cmd_cmp(cmd, 1);
-  fail_unless(res == 1, "Failed to handle empty cmd_rec argument");
+  ck_assert_msg(res == 1, "Failed to handle empty cmd_rec argument");
 
   cmd = pr_cmd_alloc(p, 1, C_RETR);
   res = pr_cmd_cmp(cmd, PR_CMD_ACCT_ID);
-  fail_unless(res > 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res > 0, "Unexpected comparison result: %d", res);
 
   res = pr_cmd_cmp(cmd, PR_CMD_STOR_ID);
-  fail_unless(res < 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res < 0, "Unexpected comparison result: %d", res);
 
   res = pr_cmd_cmp(cmd, PR_CMD_RETR_ID);
-  fail_unless(res == 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res == 0, "Unexpected comparison result: %d", res);
 
   cmd = pr_cmd_alloc(p, 1, "ReTr");
   res = pr_cmd_cmp(cmd, PR_CMD_RETR_ID);
-  fail_unless(res == 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res == 0, "Unexpected comparison result: %d", res);
 }
 END_TEST
 
@@ -355,28 +355,28 @@ START_TEST (cmd_strcmp_test) {
   int res;
 
   res = pr_cmd_strcmp(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   cmd = pr_cmd_alloc(p, 0);
   res = pr_cmd_strcmp(cmd, "a");
-  fail_unless(res == 1, "Failed to handle empty cmd_rec");
+  ck_assert_msg(res == 1, "Failed to handle empty cmd_rec");
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, C_RETR);
   res = pr_cmd_strcmp(cmd, "a");
-  fail_unless(res < 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res < 0, "Unexpected comparison result: %d", res);
 
   mark_point();
   cmd->cmd_id = 0;
   res = pr_cmd_strcmp(cmd, "S");
-  fail_unless(res > 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res > 0, "Unexpected comparison result: %d", res);
 
   mark_point();
   cmd->cmd_id = 0;
   res = pr_cmd_strcmp(cmd, C_RETR);
-  fail_unless(res == 0, "Unexpected comparison result: %d", res);
+  ck_assert_msg(res == 0, "Unexpected comparison result: %d", res);
 }
 END_TEST
 
@@ -386,15 +386,15 @@ START_TEST (cmd_get_displayable_str_test) {
   size_t len = 0;
 
   res = pr_cmd_get_displayable_str(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null cmd_rec");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null cmd_rec");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   cmd = pr_cmd_alloc(p, 1, "foo");
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
   ok = "foo";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd->argc = 0;
@@ -406,10 +406,10 @@ START_TEST (cmd_get_displayable_str_test) {
    * pr_cmd_get_displayable_str() should cache the constructed string,
    * rather than creating it anew.
    */
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   if (pr_cmd_clear_cache(NULL) < 0) {
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
   }
 
@@ -419,7 +419,7 @@ START_TEST (cmd_get_displayable_str_test) {
 
   ok = "";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "bar");
@@ -428,7 +428,7 @@ START_TEST (cmd_get_displayable_str_test) {
 
   ok = "bar";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "baz");
@@ -442,7 +442,7 @@ START_TEST (cmd_get_displayable_str_test) {
    */
   ok = "";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 3, "foo", "bar", "baz");
@@ -455,7 +455,7 @@ START_TEST (cmd_get_displayable_str_test) {
    */
   ok = "foo bar baz";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   /* Make sure we can handle cases where cmd_rec->argv has been tampered
    * with.
@@ -467,23 +467,23 @@ START_TEST (cmd_get_displayable_str_test) {
 
   ok = " bar baz";
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 2, C_PASS, "foo");
   res = pr_cmd_get_displayable_str(cmd, &len);
   ok = "PASS (hidden)";
-  fail_unless(res != NULL, "Expected displayable string, got null");
-  fail_unless(len == 13, "Expected len 13, got %lu", (unsigned long) len);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Expected displayable string, got null");
+  ck_assert_msg(len == 13, "Expected len 13, got %lu", (unsigned long) len);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 2, C_ADAT, "bar baz quxx");
   res = pr_cmd_get_displayable_str(cmd, &len);
   ok = "ADAT (hidden)";
-  fail_unless(res != NULL, "Expected displayable string, got null");
-  fail_unless(len == 13, "Expected len 13, got %lu", (unsigned long) len);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Expected displayable string, got null");
+  ck_assert_msg(len == 13, "Expected len 13, got %lu", (unsigned long) len);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -492,32 +492,32 @@ START_TEST (cmd_get_errno_test) {
   cmd_rec *cmd = NULL;
 
   res = pr_cmd_get_errno(NULL);
-  fail_unless(res == -1, "Failed to handle null cmd_rec");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null cmd_rec");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   cmd = pr_cmd_alloc(p, 1, "foo");
   res = pr_cmd_get_errno(cmd);
-  fail_unless(res == 0, "Expected errno 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected errno 0, got %d", res);
 
   (void) pr_table_remove(cmd->notes, "errno", NULL);
   res = pr_cmd_get_errno(cmd);
-  fail_unless(res < 0, "Failed to handle missing 'errno' note");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle missing 'errno' note");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   xerrno = pcalloc(cmd->pool, sizeof(int));
   (void) pr_table_add(cmd->notes, "errno", xerrno, sizeof(int));
 
   res = pr_cmd_set_errno(NULL, ENOENT);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_cmd_set_errno(cmd, ENOENT);
-  fail_unless(res == 0, "Failed to stash errno ENOENT: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stash errno ENOENT: %s", strerror(errno));
 
   res = pr_cmd_get_errno(cmd);
-  fail_unless(res == ENOENT, "Expected errno ENOENT, got %s (%d)",
+  ck_assert_msg(res == ENOENT, "Expected errno ENOENT, got %s (%d)",
     strerror(res), res);
 }
 END_TEST
@@ -528,19 +528,19 @@ START_TEST (cmd_set_name_test) {
   const char *name;
 
   res = pr_cmd_set_name(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "foo");
   res = pr_cmd_set_name(cmd, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "bar";
   res = pr_cmd_set_name(cmd, name);
-  fail_unless(res == 0, "Failed to command name to '%s': %s", name,
+  ck_assert_msg(res == 0, "Failed to command name to '%s': %s", name,
     strerror(errno));
 }
 END_TEST
@@ -550,27 +550,27 @@ START_TEST (cmd_is_http_test) {
   cmd_rec *cmd;
 
   res = pr_cmd_is_http(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, C_SYST);
   cmd->argv[0] = NULL;
   res = pr_cmd_is_http(cmd);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd->argv[0] = C_SYST;
   res = pr_cmd_is_http(cmd);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "GET");
   res = pr_cmd_is_http(cmd);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 }
 END_TEST
 
@@ -579,27 +579,27 @@ START_TEST (cmd_is_smtp_test) {
   cmd_rec *cmd;
 
   res = pr_cmd_is_smtp(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, C_SYST);
   cmd->argv[0] = NULL;
   res = pr_cmd_is_smtp(cmd);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd->argv[0] = C_SYST;
   res = pr_cmd_is_smtp(cmd);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "RCPT");
   res = pr_cmd_is_smtp(cmd);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 }
 END_TEST
 
@@ -608,32 +608,32 @@ START_TEST (cmd_is_ssh2_test) {
   cmd_rec *cmd;
 
   res = pr_cmd_is_ssh2(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, C_SYST);
   cmd->argv[0] = NULL;
   res = pr_cmd_is_ssh2(cmd);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd->argv[0] = C_SYST;
   res = pr_cmd_is_ssh2(cmd);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "SSH-2.0-OpenSSH_5.6p1");
   res = pr_cmd_is_ssh2(cmd);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 
   mark_point();
   cmd = pr_cmd_alloc(p, 1, "SSH-1.99-JSCH");
   res = pr_cmd_is_ssh2(cmd);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 }
 END_TEST
 

--- a/tests/api/cmd.c
+++ b/tests/api/cmd.c
@@ -393,14 +393,14 @@ START_TEST (cmd_get_displayable_str_test) {
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
   ok = "foo";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
   cmd->argc = 0;
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
 
   /* Note: We still expect the PREVIOUS ok value, since
    * pr_cmd_get_displayable_str() should cache the constructed string,
@@ -418,7 +418,7 @@ START_TEST (cmd_get_displayable_str_test) {
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
   ok = "";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
@@ -427,7 +427,7 @@ START_TEST (cmd_get_displayable_str_test) {
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
   ok = "bar";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
@@ -441,7 +441,7 @@ START_TEST (cmd_get_displayable_str_test) {
    * empty string.
    */
   ok = "";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();
@@ -454,7 +454,7 @@ START_TEST (cmd_get_displayable_str_test) {
    * empty string.
    */
   ok = "foo bar baz";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   /* Make sure we can handle cases where cmd_rec->argv has been tampered
@@ -466,7 +466,7 @@ START_TEST (cmd_get_displayable_str_test) {
   res = pr_cmd_get_displayable_str(cmd, NULL);
 
   ok = " bar baz";
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   mark_point();

--- a/tests/api/configdb.c
+++ b/tests/api/configdb.c
@@ -253,7 +253,7 @@ START_TEST (config_add_server_config_param_str_test) {
   c = pr_conf_add_server_config_param_str(NULL, NULL, 0);
   ck_assert_msg(c == NULL, "Failed to handle null arguments");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
-    strerror(errno));
+    strerror(errno), errno);
 
   mark_point();
   s = pr_parser_server_ctxt_open("127.0.0.2");
@@ -298,7 +298,7 @@ START_TEST (config_add_config_set_test) {
 
   name = "bar";
   res = remove_config(set, name, FALSE);
-  ck_assert_msg(res == 0, "Removed config '%s' unexpectedly", name,
+  ck_assert_msg(res == 0, "Removed config '%s' unexpectedly: %s", name,
     strerror(errno));
 
   c = pr_config_add_set(&set, name, flags);

--- a/tests/api/configdb.c
+++ b/tests/api/configdb.c
@@ -72,21 +72,21 @@ START_TEST (config_alloc_test) {
 
   mark_point();
   c = pr_config_alloc(NULL, NULL, 0);
-  fail_unless(c == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   c = pr_config_alloc(p, NULL, config_type);
-  fail_unless(c != NULL, "Failed to handle null argument: %s", strerror(errno));
-  fail_unless(c->name == NULL, "Failed to handle null name");
-  fail_unless(c->config_type == config_type, "Failed to set config type");
+  ck_assert_msg(c != NULL, "Failed to handle null argument: %s", strerror(errno));
+  ck_assert_msg(c->name == NULL, "Failed to handle null name");
+  ck_assert_msg(c->config_type == config_type, "Failed to set config type");
 
   mark_point();
   c = pr_config_alloc(p, "foobar", config_type);
-  fail_unless(c != NULL, "Failed to allocate config_rec: %s", strerror(errno));
-  fail_unless(c->name != NULL, "Failed to handle name");
-  fail_unless(c->config_type == config_type, "Failed to set config type");
+  ck_assert_msg(c != NULL, "Failed to allocate config_rec: %s", strerror(errno));
+  ck_assert_msg(c->name != NULL, "Failed to handle name");
+  ck_assert_msg(c->config_type == config_type, "Failed to set config type");
 }
 END_TEST
 
@@ -96,21 +96,21 @@ START_TEST (config_add_config_to_set_test) {
 
   mark_point();
   c = pr_config_add_config_to_set(NULL, NULL, 0);
-  fail_unless(c == NULL, "Failed to handle null set");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null set");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   set = xaset_create(p, NULL);
   c = pr_config_add_config_to_set(set, NULL, 0);
-  fail_unless(c == NULL, "Failed to handle null set");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null set");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   c = pr_config_alloc(p, "foobar", 0);
   c = pr_config_add_config_to_set(set, c, 0);
-  fail_unless(c != NULL, "Failed to add config to set: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to add config to set: %s", strerror(errno));
 }
 END_TEST
 
@@ -121,15 +121,15 @@ START_TEST (config_add_config_test) {
   server_rec *s = NULL;
 
   s = pr_parser_server_ctxt_open("127.0.0.1");
-  fail_unless(s != NULL, "Failed to open server context: %s", strerror(errno));
+  ck_assert_msg(s != NULL, "Failed to open server context: %s", strerror(errno));
 
   name = "foo";
 
   mark_point();
   c = add_config(NULL, name);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
-  fail_unless(c->config_type == 0, "Expected config_type 0, got %d",
+  ck_assert_msg(c->config_type == 0, "Expected config_type 0, got %d",
     c->config_type);
 
   mark_point();
@@ -142,7 +142,7 @@ START_TEST (config_add_config_test) {
 
   mark_point();
   res = remove_config(s->conf, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 }
 END_TEST
@@ -154,20 +154,20 @@ START_TEST (config_add_config_param_test) {
   server_rec *s = NULL;
 
   s = pr_parser_server_ctxt_open("127.0.0.1");
-  fail_unless(s != NULL, "Failed to open server context: %s", strerror(errno));
+  ck_assert_msg(s != NULL, "Failed to open server context: %s", strerror(errno));
  
   c = add_config_param(NULL, 0, NULL);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno); 
 
   name = "foo";
 
   mark_point();
   c = add_config_param(name, 1, "bar");
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
-  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+  ck_assert_msg(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
     CONF_PARAM, c->config_type);
 
   mark_point();
@@ -175,7 +175,7 @@ START_TEST (config_add_config_param_test) {
 
   mark_point();
   res = pr_config_remove(s->conf, name, PR_CONFIG_FL_PRESERVE_ENTRY, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 }
 END_TEST
@@ -188,28 +188,28 @@ START_TEST (config_add_config_param_set_test) {
   name = "foo";
 
   c = add_config_param_set(NULL, name, 0);
-  fail_unless(c == NULL, "Failed to handle null set argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null set argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s' to set: %s", name,
     strerror(errno));
-  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+  ck_assert_msg(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
     CONF_PARAM, c->config_type);
-  fail_unless(c->argc == 0, "Expected argc 0, got %d", c->argc);
+  ck_assert_msg(c->argc == 0, "Expected argc 0, got %d", c->argc);
 
   c = add_config_param_set(&set, name, 2, "bar", "baz");
-  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s' to set: %s", name,
     strerror(errno));
-  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+  ck_assert_msg(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
     CONF_PARAM, c->config_type);
-  fail_unless(c->argc == 2, "Expected argc 2, got %d", c->argc);
-  fail_unless(strcmp("bar", (char *) c->argv[0]) == 0,
+  ck_assert_msg(c->argc == 2, "Expected argc 2, got %d", c->argc);
+  ck_assert_msg(strcmp("bar", (char *) c->argv[0]) == 0,
     "Expected argv[0] to be 'bar', got '%s'", (char *) c->argv[0]);
-  fail_unless(strcmp("baz", (char *) c->argv[1]) == 0,
+  ck_assert_msg(strcmp("baz", (char *) c->argv[1]) == 0,
     "Expected argv[1] to be 'baz', got '%s'", (char *) c->argv[1]);
-  fail_unless(c->argv[2] == NULL, "Expected argv[2] to be null");
+  ck_assert_msg(c->argv[2] == NULL, "Expected argv[2] to be null");
 }
 END_TEST
 
@@ -220,26 +220,26 @@ START_TEST (config_add_config_param_str_test) {
   server_rec *s = NULL;
 
   s = pr_parser_server_ctxt_open("127.0.0.1");
-  fail_unless(s != NULL, "Failed to open server context: %s", strerror(errno));
+  ck_assert_msg(s != NULL, "Failed to open server context: %s", strerror(errno));
 
   name = "foo";
 
   mark_point();
   c = add_config_param_str(name, 1, "bar");
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
-  fail_unless(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
+  ck_assert_msg(c->config_type == CONF_PARAM, "Expected config_type %d, got %d",
     CONF_PARAM, c->config_type);
 
   c2 = add_config_param_str("foo2", 1, NULL);
-  fail_unless(c2 != NULL, "Failed to add config 'foo2': %s", strerror(errno));
+  ck_assert_msg(c2 != NULL, "Failed to add config 'foo2': %s", strerror(errno));
 
   mark_point();
   pr_config_dump(NULL, s->conf, NULL);
 
   mark_point();
   res = remove_config(s->conf, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 }
 END_TEST
@@ -251,19 +251,19 @@ START_TEST (config_add_server_config_param_str_test) {
 
   mark_point();
   c = pr_conf_add_server_config_param_str(NULL, NULL, 0);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno));
 
   mark_point();
   s = pr_parser_server_ctxt_open("127.0.0.2");
-  fail_unless(s != NULL, "Failed to open server context: %s", strerror(errno));
+  ck_assert_msg(s != NULL, "Failed to open server context: %s", strerror(errno));
 
   mark_point();
   name = "foo";
 
   c = pr_conf_add_server_config_param_str(s, name, 1, "bar");
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   (void) remove_config(s->conf, name, FALSE);
@@ -277,32 +277,32 @@ START_TEST (config_add_config_set_test) {
   config_rec *c = NULL;
 
   res = remove_config(NULL, NULL, FALSE);
-  fail_unless(res == 0, "Failed to handle null arguments: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle null arguments: %s", strerror(errno));
 
   name = "foo";
 
   c = add_config_set(NULL, name);
-  fail_unless(c == NULL, "Failed to handle null set argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null set argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   c = add_config_set(&set, name);
-  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s' to set: %s", name,
     strerror(errno));
-  fail_unless(c->config_type == 0, "Expected config_type 0, got %d",
+  ck_assert_msg(c->config_type == 0, "Expected config_type 0, got %d",
     c->config_type);
 
   res = remove_config(set, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 
   name = "bar";
   res = remove_config(set, name, FALSE);
-  fail_unless(res == 0, "Removed config '%s' unexpectedly", name,
+  ck_assert_msg(res == 0, "Removed config '%s' unexpectedly", name,
     strerror(errno));
 
   c = pr_config_add_set(&set, name, flags);
-  fail_unless(c != NULL, "Failed to add config '%s' to set: %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s' to set: %s", name,
     strerror(errno));
 
   /* XXX Note that calling this with recurse=TRUE yields a test timeout,
@@ -316,7 +316,7 @@ START_TEST (config_add_config_set_test) {
    * Given the "shallowness" of this particular set.
    */
   res = remove_config(set, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 }
 END_TEST
@@ -334,26 +334,26 @@ START_TEST (config_find_config_test) {
   const char *name;
 
   c = find_config(NULL, -1, NULL, FALSE);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   c = find_config_next(NULL, NULL, CONF_PARAM, NULL, FALSE);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
 
   name = "foo";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = "bar";
   c = find_config(set, -1, name, FALSE);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
@@ -362,14 +362,14 @@ START_TEST (config_find_config_test) {
 
   name = "foo";
   c = find_config(set, -1, name, FALSE);
-  fail_unless(c != NULL, "Failed to find config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to find config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config_next(c, c->next, -1, name, FALSE);
-  fail_unless(c == NULL, "Found next config unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found next config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   /* Now add another config, find "foo" again; this time, a 'next' should
@@ -378,37 +378,37 @@ START_TEST (config_find_config_test) {
 
   name = "foo2";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = NULL;
   c = find_config(set, -1, name, FALSE);
-  fail_unless(c != NULL, "Failed to find any config: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to find any config: %s", strerror(errno));
 
   mark_point();
 
   c = find_config_next(c, c->next, -1, name, FALSE);
-  fail_unless(c != NULL, "Expected to find another config");
+  ck_assert_msg(c != NULL, "Expected to find another config");
 
   mark_point();
 
   name = "foo";
   res = remove_config(set, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config(set, -1, name, FALSE);
-  fail_unless(c == NULL, "Found config '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found config '%s' unexpectedly", name);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   name = "other";
   c = find_config(set, -1, name, TRUE);
-  fail_unless(c == NULL, "Found config '%s' unexpectedly (recurse = true)",
+  ck_assert_msg(c == NULL, "Found config '%s' unexpectedly (recurse = true)",
     name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -421,21 +421,21 @@ START_TEST (config_find_config2_test) {
   unsigned long flags = 0;
 
   c = find_config2(NULL, -1, NULL, FALSE, flags);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
 
   name = "foo";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = "bar";
   c = find_config2(set, -1, name, FALSE, flags);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
@@ -443,14 +443,14 @@ START_TEST (config_find_config2_test) {
   /* We expect to find "foo", but a 'next' should be empty. */
   name = "foo";
   c = find_config2(set, -1, name, FALSE, flags);
-  fail_unless(c != NULL, "Failed to find config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to find config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config_next2(c, c->next, -1, name, FALSE, flags);
-  fail_unless(c == NULL, "Found next config unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found next config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   /* Now add another config, find "foo" again; this time, a 'next' should
@@ -459,30 +459,30 @@ START_TEST (config_find_config2_test) {
 
   name = "foo2";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = NULL;
   c = find_config2(set, -1, name, FALSE, flags);
-  fail_unless(c != NULL, "Failed to find any config: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to find any config: %s", strerror(errno));
 
   mark_point();
 
   c = find_config_next2(c, c->next, -1, name, FALSE, flags);
-  fail_unless(c != NULL, "Expected to find another config");
+  ck_assert_msg(c != NULL, "Expected to find another config");
 
   mark_point();
 
   name = "foo";
   res = remove_config(set, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config2(set, -1, name, FALSE, flags);
-  fail_unless(c == NULL, "Found config '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found config '%s' unexpectedly", name);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -495,21 +495,21 @@ START_TEST (config_find_config2_recurse_test) {
   unsigned long flags = 0;
 
   c = find_config2(NULL, -1, NULL, TRUE, flags);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
 
   name = "foo";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = "bar";
   c = find_config2(set, -1, name, TRUE, flags);
-  fail_unless(c == NULL, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
@@ -517,14 +517,14 @@ START_TEST (config_find_config2_recurse_test) {
   /* We expect to find "foo", but a 'next' should be empty. */
   name = "foo";
   c = find_config2(set, -1, name, TRUE, flags);
-  fail_unless(c != NULL, "Failed to find config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to find config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config_next2(c, c->next, -1, name, TRUE, flags);
-  fail_unless(c == NULL, "Found next config unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found next config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   /* Now add another config, find "foo" again; this time, a 'next' should
@@ -533,30 +533,30 @@ START_TEST (config_find_config2_recurse_test) {
 
   name = "foo2";
   c = add_config_param_set(&set, name, 0);
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = NULL;
   c = find_config2(set, -1, name, TRUE, flags);
-  fail_unless(c != NULL, "Failed to find any config: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to find any config: %s", strerror(errno));
 
   mark_point();
 
   c = find_config_next2(c, c->next, -1, name, TRUE, flags);
-  fail_unless(c != NULL, "Expected to find another config");
+  ck_assert_msg(c != NULL, "Expected to find another config");
 
   mark_point();
 
   name = "foo";
   res = remove_config(set, name, FALSE);
-  fail_unless(res > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   c = find_config2(set, -1, name, TRUE, flags);
-  fail_unless(c == NULL, "Found config '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(c == NULL, "Found config '%s' unexpectedly", name);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -582,21 +582,21 @@ START_TEST (config_get_param_ptr_test) {
   const char *name = NULL;
 
   res = get_param_ptr(NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
 
   name = "foo";
   c = add_config_param_set(&set, name, 1, "bar");
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   name = "bar";
   res = get_param_ptr(set, name, FALSE);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   mark_point();
@@ -608,14 +608,14 @@ START_TEST (config_get_param_ptr_test) {
 
   name = "foo";
   res = get_param_ptr(set, name, FALSE);
-  fail_unless(res != NULL, "Failed to find config '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to find config '%s': %s", name,
     strerror(errno));
 
   mark_point();
 
   res = get_param_ptr_next(name, FALSE);
-  fail_unless(res == NULL, "Found next config unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res == NULL, "Found next config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   /* Now add another config, find "foo" again; this time, a 'next' should
@@ -624,41 +624,41 @@ START_TEST (config_get_param_ptr_test) {
 
   name = "foo2";
   c = add_config_param_set(&set, name, 1, "baz");
-  fail_unless(c != NULL, "Failed to add config '%s': %s", name,
+  ck_assert_msg(c != NULL, "Failed to add config '%s': %s", name,
     strerror(errno));
 
   get_param_ptr(NULL, NULL, FALSE);
 
   name = NULL;
   res = get_param_ptr(set, name, FALSE);
-  fail_unless(res != NULL, "Failed to find any config: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to find any config: %s", strerror(errno));
 
   mark_point();
   res = get_param_ptr_next(name, FALSE);
-  fail_unless(res != NULL, "Expected to find another config");
+  ck_assert_msg(res != NULL, "Expected to find another config");
 
   mark_point();
   res = get_param_ptr_next("foobar", TRUE);
-  fail_unless(res == NULL, "Found another config unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Found another config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = get_param_ptr_next(name, FALSE);
-  fail_unless(res == NULL, "Found another config unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Found another config unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
 
   name = "foo";
   count = remove_config(set, name, FALSE);
-  fail_unless(count > 0, "Failed to remove config '%s': %s", name,
+  ck_assert_msg(count > 0, "Failed to remove config '%s': %s", name,
     strerror(errno));
 
   mark_point();
   res = get_param_ptr(set, name, FALSE);
-  fail_unless(res == NULL, "Found config '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res == NULL, "Found config '%s' unexpectedly", name);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -668,23 +668,23 @@ START_TEST (config_set_get_id_test) {
   const char *name;
 
   res = pr_config_get_id(NULL);
-  fail_unless(res == 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_config_set_id(NULL);
-  fail_unless(res == 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   name = "foo";
 
   id = pr_config_set_id(name);
-  fail_unless(id > 0, "Failed to set ID for config '%s': %s", name,
+  ck_assert_msg(id > 0, "Failed to set ID for config '%s': %s", name,
     strerror(errno));
 
   res = pr_config_get_id(name);
-  fail_unless(res == id, "Expected ID %u for config '%s', found %u", id,
+  ck_assert_msg(res == id, "Expected ID %u for config '%s', found %u", id,
     name, res);
 }
 END_TEST

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -151,55 +151,55 @@ START_TEST (ctrls_alloc_free_test) {
 
   mark_point();
   res = pr_ctrls_free(NULL);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
-  fail_unless(ctrl != NULL, "Failed to allocate ctrl: %s", strerror(errno));
+  ck_assert_msg(ctrl != NULL, "Failed to allocate ctrl: %s", strerror(errno));
   res = pr_ctrls_free(ctrl);
-  fail_unless(res == 0, "Failed to free ctrl: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl: %s", strerror(errno));
 
   mark_point();
   ctrl = pr_ctrls_alloc();
-  fail_unless(ctrl != NULL, "Failed to allocate ctrl: %s", strerror(errno));
+  ck_assert_msg(ctrl != NULL, "Failed to allocate ctrl: %s", strerror(errno));
   res = pr_ctrls_free(ctrl);
-  fail_unless(res == 0, "Failed to free ctrl: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl: %s", strerror(errno));
 
   /* LIFO order */
   mark_point();
   ctrl = pr_ctrls_alloc();
   ctrl2 = pr_ctrls_alloc();
-  fail_unless(ctrl2 != NULL, "Failed to allocate ctrl2: %s", strerror(errno));
+  ck_assert_msg(ctrl2 != NULL, "Failed to allocate ctrl2: %s", strerror(errno));
   ctrl2->ctrls_tmp_pool = make_sub_pool(p);
   ctrl3 = pr_ctrls_alloc();
-  fail_unless(ctrl3 != NULL, "Failed to allocate ctrl3: %s", strerror(errno));
+  ck_assert_msg(ctrl3 != NULL, "Failed to allocate ctrl3: %s", strerror(errno));
   ctrl3->ctrls_tmp_pool = make_sub_pool(p);
 
   res = pr_ctrls_free(ctrl3);
-  fail_unless(res == 0, "Failed to free ctrl3 %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl3 %s", strerror(errno));
   res = pr_ctrls_free(ctrl2);
-  fail_unless(res == 0, "Failed to free ctrl2: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl2: %s", strerror(errno));
   res = pr_ctrls_free(ctrl);
-  fail_unless(res == 0, "Failed to free ctrl: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl: %s", strerror(errno));
 
   /* FIFO order */
   mark_point();
   ctrl = pr_ctrls_alloc();
   ctrl2 = pr_ctrls_alloc();
-  fail_unless(ctrl2 != NULL, "Failed to allocate ctrl2: %s", strerror(errno));
+  ck_assert_msg(ctrl2 != NULL, "Failed to allocate ctrl2: %s", strerror(errno));
   ctrl2->ctrls_tmp_pool = make_sub_pool(p);
   ctrl3 = pr_ctrls_alloc();
-  fail_unless(ctrl3 != NULL, "Failed to allocate ctrl3: %s", strerror(errno));
+  ck_assert_msg(ctrl3 != NULL, "Failed to allocate ctrl3: %s", strerror(errno));
   ctrl3->ctrls_tmp_pool = make_sub_pool(p);
 
   res = pr_ctrls_free(ctrl);
-  fail_unless(res == 0, "Failed to free ctrl: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl: %s", strerror(errno));
   res = pr_ctrls_free(ctrl2);
-  fail_unless(res == 0, "Failed to free ctrl2: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl2: %s", strerror(errno));
   res = pr_ctrls_free(ctrl3);
-  fail_unless(res == 0, "Failed to free ctrl3 %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free ctrl3 %s", strerror(errno));
 }
 END_TEST
 
@@ -208,8 +208,8 @@ START_TEST (ctrls_unregister_test) {
 
   mark_point();
   res = pr_ctrls_unregister(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle lack of registered actions");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle lack of registered actions");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -229,44 +229,44 @@ START_TEST (ctrls_register_test) {
 
   mark_point();
   res = pr_ctrls_register(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null action");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null action");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   action = "test";
   res = pr_ctrls_register(NULL, action, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null desc");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null desc");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   desc = "desc";
   res = pr_ctrls_register(NULL, action, desc, NULL);
-  fail_unless(res < 0, "Failed to handle null callback");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null callback");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 
   mark_point();
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   m.name = "test";
   res = pr_ctrls_register(&m, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 }
 END_TEST
@@ -279,15 +279,15 @@ START_TEST (ctrls_add_arg_test) {
 
   mark_point();
   res = pr_ctrls_add_arg(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
   res = pr_ctrls_add_arg(ctrl, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arg");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arg");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -300,8 +300,8 @@ START_TEST (ctrls_add_arg_test) {
   buflen = 3;
 
   res = pr_ctrls_add_arg(ctrl, buf, buflen);
-  fail_unless(res < 0, "Failed to handle bad arg");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle bad arg");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -311,7 +311,7 @@ START_TEST (ctrls_add_arg_test) {
   buflen = 3;
 
   res = pr_ctrls_add_arg(ctrl, buf, buflen);
-  fail_unless(res == 0, "Failed to add ctrl arg: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ctrl arg: %s", strerror(errno));
 }
 END_TEST
 
@@ -321,20 +321,20 @@ START_TEST (ctrls_add_response_test) {
 
   mark_point();
   res = pr_ctrls_add_response(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
   res = pr_ctrls_add_response(ctrl, NULL);
-  fail_unless(res < 0, "Failed to handle null fmt");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fmt");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_add_response(ctrl, "%s", "foo");
-  fail_unless(res == 0, "Failed to add ctrl response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ctrl response: %s", strerror(errno));
 }
 END_TEST
 
@@ -344,40 +344,40 @@ START_TEST (ctrls_copy_args_test) {
 
   mark_point();
   res = pr_ctrls_copy_args(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null src ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null src ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   src_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_copy_args(src_ctrl, NULL);
-  fail_unless(res < 0, "Failed to handle null dst ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dst ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_copy_args(src_ctrl, src_ctrl);
-  fail_unless(res < 0, "Failed to handle same src/dst ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle same src/dst ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   dst_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_copy_args(src_ctrl, dst_ctrl);
-  fail_unless(res == 0, "Failed to copy ctrl args: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy ctrl args: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_add_arg(src_ctrl, "foo", 3);
-  fail_unless(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
 
   res = pr_ctrls_add_arg(src_ctrl, "bar", 3);
-  fail_unless(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
 
   res = pr_ctrls_add_arg(src_ctrl, "baz", 3);
-  fail_unless(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add src ctrl arg: %s", strerror(errno));
 
   res = pr_ctrls_copy_args(src_ctrl, dst_ctrl);
-  fail_unless(res == 0, "Failed to copy ctrl args: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy ctrl args: %s", strerror(errno));
 }
 END_TEST
 
@@ -387,50 +387,50 @@ START_TEST (ctrls_copy_resps_test) {
 
   mark_point();
   res = pr_ctrls_copy_resps(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null src ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null src ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   src_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_copy_resps(src_ctrl, NULL);
-  fail_unless(res < 0, "Failed to handle null dst ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dst ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_copy_resps(src_ctrl, src_ctrl);
-  fail_unless(res < 0, "Failed to handle same src/dst ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle same src/dst ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   dst_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_copy_resps(src_ctrl, dst_ctrl);
-  fail_unless(res < 0, "Failed to handle src ctrl with no responses");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle src ctrl with no responses");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_add_response(src_ctrl, "%s", "foo");
-  fail_unless(res == 0, "Failed to add src ctrl response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add src ctrl response: %s", strerror(errno));
 
   res = pr_ctrls_add_response(dst_ctrl, "%s", "bar");
-  fail_unless(res == 0, "Failed to add dst ctrl response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add dst ctrl response: %s", strerror(errno));
 
   res = pr_ctrls_copy_resps(src_ctrl, dst_ctrl);
-  fail_unless(res < 0, "Failed to handle dst ctrl with responses");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle dst ctrl with responses");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   src_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_add_response(src_ctrl, "%s", "foo");
-  fail_unless(res == 0, "Failed to add src ctrl response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add src ctrl response: %s", strerror(errno));
 
   dst_ctrl = pr_ctrls_alloc();
   res = pr_ctrls_copy_resps(src_ctrl, dst_ctrl);
-  fail_unless(res == 0, "Failed to copy ctrl responses: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy ctrl responses: %s", strerror(errno));
 }
 END_TEST
 
@@ -441,28 +441,28 @@ START_TEST (ctrls_send_msg_test) {
 
   mark_point();
   res = pr_ctrls_send_msg(-1, 0, 0, NULL);
-  fail_unless(res < 0, "Failed to handle invalid fd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid fd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   fd = 7;
   res = pr_ctrls_send_msg(fd, 0, 0, NULL);
-  fail_unless(res == 0, "Failed to send zero ctrl messages: %s",
+  ck_assert_msg(res == 0, "Failed to send zero ctrl messages: %s",
     strerror(errno));
 
   mark_point();
   fd = 7;
   res = pr_ctrls_send_msg(fd, 0, msgargc, NULL);
-  fail_unless(res == 0, "Failed to send zero ctrl messages: %s",
+  ck_assert_msg(res == 0, "Failed to send zero ctrl messages: %s",
     strerror(errno));
 
   mark_point();
   fd = 7777;
   status = -24;
   res = pr_ctrls_send_msg(fd, status, msgargc, msgargv);
-  fail_unless(res < 0, "Failed to handle invalid fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle invalid fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   fd = devnull_fd();
@@ -473,7 +473,7 @@ START_TEST (ctrls_send_msg_test) {
   mark_point();
   status = -24;
   res = pr_ctrls_send_msg(fd, status, msgargc, msgargv);
-  fail_unless(res == 0, "Failed to send ctrl message: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to send ctrl message: %s", strerror(errno));
 
   (void) close(fd);
 }
@@ -486,22 +486,22 @@ START_TEST (ctrls_flush_response_test) {
 
   mark_point();
   res = pr_ctrls_flush_response(NULL);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
   res = pr_ctrls_flush_response(ctrl);
-  fail_unless(res == 0, "Failed to flush ctrl with no responses: %s",
+  ck_assert_msg(res == 0, "Failed to flush ctrl with no responses: %s",
     strerror(errno));
 
   mark_point();
   res = pr_ctrls_add_response(ctrl, "%s", "foo");
-  fail_unless(res == 0, "Failed to add ctrl response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ctrl response: %s", strerror(errno));
   res = pr_ctrls_flush_response(ctrl);
-  fail_unless(res < 0, "Failed to handle ctrl with no client");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle ctrl with no client");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -513,13 +513,13 @@ START_TEST (ctrls_flush_response_test) {
 
   ctrl->ctrls_cl = cl;
   res = pr_ctrls_flush_response(ctrl);
-  fail_unless(res == 0, "Failed to flush ctrl responses: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to flush ctrl responses: %s", strerror(errno));
 
   mark_point();
   (void) close(cl->cl_fd);
   res = pr_ctrls_flush_response(ctrl);
-  fail_unless(res < 0, "Failed to handle bad fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -531,79 +531,79 @@ START_TEST (ctrls_parse_msg_test) {
 
   mark_point();
   res = pr_ctrls_parse_msg(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_parse_msg(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null msg");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null msg");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   msg = "foo 'bar' baz";
   res = pr_ctrls_parse_msg(p, msg, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null msgargc");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null msgargc");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   msg = "foo 'bar' baz";
   res = pr_ctrls_parse_msg(p, msg, &msgargc, NULL);
-  fail_unless(res < 0, "Failed to handle null msgargv");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null msgargv");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   msg = pstrdup(p, "foo 'Bar' BAZ");
   res = pr_ctrls_parse_msg(p, msg, &msgargc, &msgargv);
-  fail_unless(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
-  fail_unless(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
-  fail_unless(msgargv != NULL, "Expected msgargv, got null");
-  fail_unless(strcmp(msgargv[0], "foo") == 0,
+  ck_assert_msg(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
+  ck_assert_msg(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
+  ck_assert_msg(msgargv != NULL, "Expected msgargv, got null");
+  ck_assert_msg(strcmp(msgargv[0], "foo") == 0,
     "Expected 'foo', got '%s'", msgargv[0]);
-  fail_unless(strcmp(msgargv[1], "'Bar'") == 0,
+  ck_assert_msg(strcmp(msgargv[1], "'Bar'") == 0,
     "Expected 'Bar', got '%s'", msgargv[1]);
-  fail_unless(strcmp(msgargv[2], "BAZ") == 0,
+  ck_assert_msg(strcmp(msgargv[2], "BAZ") == 0,
     "Expected 'BAZ', got '%s'", msgargv[2]);
   mark_point();
   msg = pstrdup(p, "foo\'s 'Bar\\\'s' BAZ");
   res = pr_ctrls_parse_msg(p, msg, &msgargc, &msgargv);
-  fail_unless(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
-  fail_unless(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
-  fail_unless(msgargv != NULL, "Expected msgargv, got null");
-  fail_unless(strcmp(msgargv[0], "foo's") == 0,
+  ck_assert_msg(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
+  ck_assert_msg(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
+  ck_assert_msg(msgargv != NULL, "Expected msgargv, got null");
+  ck_assert_msg(strcmp(msgargv[0], "foo's") == 0,
     "Expected 'foo's', got '%s'", msgargv[0]);
-  fail_unless(strcmp(msgargv[1], "'Bar\\\'s'") == 0,
+  ck_assert_msg(strcmp(msgargv[1], "'Bar\\\'s'") == 0,
     "Expected 'Bar\\\'s', got '%s'", msgargv[1]);
-  fail_unless(strcmp(msgargv[2], "BAZ") == 0,
+  ck_assert_msg(strcmp(msgargv[2], "BAZ") == 0,
     "Expected 'BAZ', got '%s'", msgargv[2]);
 
   mark_point();
   msg = pstrdup(p, "foo 'Bar' BAZ");
   res = pr_ctrls_parse_msg(p, msg, &msgargc, &msgargv);
-  fail_unless(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
-  fail_unless(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
-  fail_unless(msgargv != NULL, "Expected msgargv, got null");
-  fail_unless(strcmp(msgargv[0], "foo") == 0,
+  ck_assert_msg(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
+  ck_assert_msg(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
+  ck_assert_msg(msgargv != NULL, "Expected msgargv, got null");
+  ck_assert_msg(strcmp(msgargv[0], "foo") == 0,
     "Expected 'foo', got '%s'", msgargv[0]);
-  fail_unless(strcmp(msgargv[1], "'Bar'") == 0,
+  ck_assert_msg(strcmp(msgargv[1], "'Bar'") == 0,
     "Expected 'Bar', got '%s'", msgargv[1]);
-  fail_unless(strcmp(msgargv[2], "BAZ") == 0,
+  ck_assert_msg(strcmp(msgargv[2], "BAZ") == 0,
     "Expected 'BAZ', got '%s'", msgargv[2]);
 
   mark_point();
   msg = pstrdup(p, "foo \"Bar\\\'s\" BAZ");
   res = pr_ctrls_parse_msg(p, msg, &msgargc, &msgargv);
-  fail_unless(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
-  fail_unless(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
-  fail_unless(msgargv != NULL, "Expected msgargv, got null");
-  fail_unless(strcmp(msgargv[0], "foo") == 0,
+  ck_assert_msg(res == 0, "Failed to parse msg '%s': %s", msg, strerror(errno));
+  ck_assert_msg(msgargc == 3, "Expected msgargc 3, got %u", msgargc);
+  ck_assert_msg(msgargv != NULL, "Expected msgargv, got null");
+  ck_assert_msg(strcmp(msgargv[0], "foo") == 0,
     "Expected 'foo', got '%s'", msgargv[0]);
-  fail_unless(strcmp(msgargv[1], "Bar's") == 0,
+  ck_assert_msg(strcmp(msgargv[1], "Bar's") == 0,
     "Expected 'Bar's', got '%s'", msgargv[1]);
-  fail_unless(strcmp(msgargv[2], "BAZ") == 0,
+  ck_assert_msg(strcmp(msgargv[2], "BAZ") == 0,
     "Expected 'BAZ', got '%s'", msgargv[2]);
 }
 END_TEST
@@ -616,23 +616,23 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   res = pr_ctrls_recv_request(NULL);
-  fail_unless(res < 0, "Failed to handle null client");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null client");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cl = pcalloc(p, sizeof(pr_ctrls_cl_t));
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle client without ctrls list");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle client without ctrls list");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cl->cl_ctrls = make_array(p, 0, sizeof(pr_ctrls_t *));
   cl->cl_fd = -1;
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle client without fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle client without fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
@@ -644,8 +644,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   cl->cl_fd = fd;
   (void) close(cl->cl_fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle client with bad fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle client with bad fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
@@ -658,8 +658,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid status (too short)");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid status (too short)");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -674,8 +674,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid nreqargs (too short)");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid nreqargs (too short)");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -690,8 +690,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, &nreqargs, sizeof(nreqargs));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid nreqargs (too many)");
-  fail_unless(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
+  ck_assert_msg(res < 0, "Failed to handle invalid nreqargs (too many)");
+  ck_assert_msg(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -707,8 +707,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid actionlen (too short)");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid actionlen (too short)");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -724,8 +724,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, &actionlen, sizeof(actionlen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid actionlen (too long)");
-  fail_unless(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
+  ck_assert_msg(res < 0, "Failed to handle invalid actionlen (too long)");
+  ck_assert_msg(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -742,8 +742,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle invalid reqarg (too short)");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid reqarg (too short)");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   fd = reset_fd(fd);
@@ -761,8 +761,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
   (void) write(fd, action, actionlen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle unknown action");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle unknown action");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) close(fd);
@@ -782,7 +782,7 @@ START_TEST (ctrls_recv_request_actions_test) {
   action = "test";
   desc = "desc";
   res = pr_ctrls_register(&m, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   fd = tmpfile_fd();
@@ -803,13 +803,13 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, action, actionlen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle known action: %s", strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(res == 0, "Failed to handle known action: %s", strerror(errno));
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args == NULL,
+  ck_assert_msg(ctrl->ctrls_cb_args == NULL,
     "Expected no callback args, got %p", ctrl->ctrls_cb_args);
 
   mark_point();
@@ -828,14 +828,14 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle too-short reqarglen: %s",
+  ck_assert_msg(res == 0, "Failed to handle too-short reqarglen: %s",
     strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args == NULL,
+  ck_assert_msg(ctrl->ctrls_cb_args == NULL,
     "Expected no callback args, got %p", ctrl->ctrls_cb_args);
 
   mark_point();
@@ -854,14 +854,14 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, &reqarglen, sizeof(reqarglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle zero-length reqarg: %s",
+  ck_assert_msg(res == 0, "Failed to handle zero-length reqarg: %s",
     strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args == NULL,
+  ck_assert_msg(ctrl->ctrls_cb_args == NULL,
     "Expected no callback args, got %p", ctrl->ctrls_cb_args);
 
   mark_point();
@@ -880,10 +880,10 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, &reqarglen, sizeof(reqarglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res < 0, "Failed to handle too-long reqarg");
-  fail_unless(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
+  ck_assert_msg(res < 0, "Failed to handle too-long reqarg");
+  ck_assert_msg(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
     strerror(errno), errno);
-  fail_unless(cl->cl_ctrls->nelts == 0, "Expected 0 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 0, "Expected 0 ctrl, got %d",
     cl->cl_ctrls->nelts);
 
   mark_point();
@@ -903,14 +903,14 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
+  ck_assert_msg(res == 0, "Failed to handle truncated reqarg: %s",
     strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args == NULL,
+  ck_assert_msg(ctrl->ctrls_cb_args == NULL,
     "Expected no callback args, got %p", ctrl->ctrls_cb_args);
 
   mark_point();
@@ -931,22 +931,22 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
+  ck_assert_msg(res == 0, "Failed to handle truncated reqarg: %s",
     strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
-  fail_unless(ctrl->ctrls_cb_args->nelts == 1,
+  ck_assert_msg(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
+  ck_assert_msg(ctrl->ctrls_cb_args->nelts == 1,
     "Expected 1 callback arg, got %d", ctrl->ctrls_cb_args->nelts);
 
   /* next_action present */
 
   mark_point();
   res = pr_ctrls_register(&m, action, desc, ctrls_test2_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   fd = reset_fd(fd);
@@ -966,23 +966,23 @@ START_TEST (ctrls_recv_request_actions_test) {
   (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
+  ck_assert_msg(res == 0, "Failed to handle truncated reqarg: %s",
     strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 2, "Expected 2 ctrl, got %d",
+  ck_assert_msg(cl->cl_ctrls->nelts == 2, "Expected 2 ctrl, got %d",
     cl->cl_ctrls->nelts);
 
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
-  fail_unless(ctrl->ctrls_cb_args->nelts == 1,
+  ck_assert_msg(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
+  ck_assert_msg(ctrl->ctrls_cb_args->nelts == 1,
     "Expected 1 callback arg, got %d", ctrl->ctrls_cb_args->nelts);
 
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[1];
-  fail_unless(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
+  ck_assert_msg(ctrl->ctrls_flags & PR_CTRLS_REQUESTED,
     "Expected PR_CTRLS_REQUESTED flag, got %lu", ctrl->ctrls_flags);
-  fail_unless(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
-  fail_unless(ctrl->ctrls_cb_args->nelts == 1,
+  ck_assert_msg(ctrl->ctrls_cb_args != NULL, "Expected callback args, got NULL");
+  ck_assert_msg(ctrl->ctrls_cb_args->nelts == 1,
     "Expected 1 callback arg, got %d", ctrl->ctrls_cb_args->nelts);
 
   (void) pr_ctrls_unregister(&m, action);
@@ -997,20 +997,20 @@ START_TEST (ctrls_recv_response_test) {
 
   mark_point();
   res = pr_ctrls_recv_response(NULL, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_recv_response(p, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle invalid fd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid fd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_recv_response(p, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null status");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null status");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -1021,8 +1021,8 @@ START_TEST (ctrls_recv_response_test) {
 
   errno = 0;
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle no response");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle no response");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   (void) close(fd);
 
@@ -1035,8 +1035,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle truncated status");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle truncated status");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -1050,8 +1050,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle truncated nrespargc");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle truncated nrespargc");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -1065,8 +1065,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, &respargc, sizeof(respargc));
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle too-many respargc");
-  fail_unless(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
+  ck_assert_msg(res < 0, "Failed to handle too-many respargc");
+  ck_assert_msg(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
     strerror(errno), errno);
 
   mark_point();
@@ -1081,8 +1081,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle truncated resparglen");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle truncated resparglen");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -1097,8 +1097,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, &resparglen, sizeof(resparglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle too-long resparglen");
-  fail_unless(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
+  ck_assert_msg(res < 0, "Failed to handle too-long resparglen");
+  ck_assert_msg(errno == ENOMEM, "Expected ENOMEM (%d), got %s (%d)", ENOMEM,
     strerror(errno), errno);
 
   mark_point();
@@ -1114,8 +1114,8 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless(res < 0, "Failed to handle truncated resparg");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle truncated resparg");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
@@ -1132,12 +1132,12 @@ START_TEST (ctrls_recv_response_test) {
   (void) write(fd, resparg, resparglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
-  fail_unless((unsigned int) res == respargc, "Failed to receive response: %s",
+  ck_assert_msg((unsigned int) res == respargc, "Failed to receive response: %s",
     strerror(errno));
-  fail_unless(status == retval, "Expected %d, got %d", retval, status);
-  fail_unless(respargv != NULL, "Expected respargv, got NULL");
+  ck_assert_msg(status == retval, "Expected %d, got %d", retval, status);
+  ck_assert_msg(respargv != NULL, "Expected respargv, got NULL");
   resp = respargv[0];
-  fail_unless(strcmp(resp, resparg) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(resp, resparg) == 0, "Expected '%s', got '%s'",
     resparg, resp);
 
   (void) close(fd);
@@ -1151,8 +1151,8 @@ START_TEST (ctrls_issock_unix_test) {
   mark_point();
   mode = 0;
   res = pr_ctrls_issock_unix(mode);
-  fail_unless(res < 0, "Failed to handle invalid mode");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle invalid mode");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
 #if defined(S_ISFIFO)
@@ -1185,21 +1185,21 @@ START_TEST (ctrls_get_registered_actions_test) {
 
   mark_point();
   res = pr_get_registered_actions(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
   res = pr_get_registered_actions(ctrl, 0);
-  fail_unless(res == 0, "Failed to handle lack of registered actions: %s",
+  ck_assert_msg(res == 0, "Failed to handle lack of registered actions: %s",
     strerror(errno));
 
   mark_point();
   pr_block_ctrls();
   res = pr_get_registered_actions(ctrl, 0);
-  fail_unless(res < 0, "Failed to handle blocked actions");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle blocked actions");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   pr_unblock_ctrls();
 
@@ -1207,33 +1207,33 @@ START_TEST (ctrls_get_registered_actions_test) {
   action = "test";
   desc = "desc";
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   m.name = "test";
   res = pr_ctrls_register(&m, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_get_registered_actions(ctrl, 0);
-  fail_unless(res == 0, "Failed to handle invalid flags: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle invalid flags: %s", strerror(errno));
 
   mark_point();
   res = pr_get_registered_actions(ctrl, CTRLS_GET_ACTION_ALL);
-  fail_unless(res == 2, "Failed to handle GET_ACTION_ALL flag: %s",
+  ck_assert_msg(res == 2, "Failed to handle GET_ACTION_ALL flag: %s",
     strerror(errno));
 
   mark_point();
   res = pr_get_registered_actions(ctrl, CTRLS_GET_ACTION_ENABLED);
-  fail_unless(res == 2, "Failed to handle GET_ACTION_ENABLED flag: %s",
+  ck_assert_msg(res == 2, "Failed to handle GET_ACTION_ENABLED flag: %s",
     strerror(errno));
 
   mark_point();
   res = pr_get_registered_actions(ctrl, CTRLS_GET_DESC);
-  fail_unless(res == 2, "Failed to handle GET_DESC flag: %s", strerror(errno));
+  ck_assert_msg(res == 2, "Failed to handle GET_DESC flag: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 }
 END_TEST
@@ -1244,47 +1244,47 @@ START_TEST (ctrls_set_registered_actions_test) {
 
   mark_point();
   res = pr_set_registered_actions(NULL, NULL, FALSE, 0);
-  fail_unless(res < 0, "Failed to handle no registered actions");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no registered actions");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_set_registered_actions(NULL, NULL, FALSE, 24);
-  fail_unless(res < 0, "Failed to handle invalid flag");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid flag");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   action = "test";
   desc = "desc";
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_set_registered_actions(NULL, NULL, FALSE, 0);
-  fail_unless(res == 0, "Failed to handle no registered actions: %s",
+  ck_assert_msg(res == 0, "Failed to handle no registered actions: %s",
     strerror(errno));
 
   mark_point();
   pr_block_ctrls();
   res = pr_set_registered_actions(NULL, NULL, FALSE, 0);
-  fail_unless(res < 0, "Failed to handle blocked actions");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle blocked actions");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   pr_unblock_ctrls();
 
   mark_point();
   res = pr_set_registered_actions(NULL, action, FALSE, 0);
-  fail_unless(res == 0, "Failed to handle action '%s': %s", action,
+  ck_assert_msg(res == 0, "Failed to handle action '%s': %s", action,
     strerror(errno));
 
   mark_point();
   res = pr_set_registered_actions(NULL, "all", FALSE, 0);
-  fail_unless(res == 0, "Failed to handle action 'all': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle action 'all': %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 }
 END_TEST
@@ -1295,45 +1295,45 @@ START_TEST (ctrls_check_actions_test) {
 
   mark_point();
   res = pr_ctrls_check_actions();
-  fail_unless(res == 0, "Failed to handle no registered actions: %s",
+  ck_assert_msg(res == 0, "Failed to handle no registered actions: %s",
     strerror(errno));
 
   mark_point();
   action = "test";
   desc = "desc";
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_check_actions();
-  fail_unless(res == 0, "Failed to handle no registered actions: %s",
+  ck_assert_msg(res == 0, "Failed to handle no registered actions: %s",
     strerror(errno));
 
   /* Register a duplicate action name, then check. */
 
   mark_point();
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_check_actions();
-  fail_unless(res == 0, "Failed to handle registered actions: %s",
+  ck_assert_msg(res == 0, "Failed to handle registered actions: %s",
     strerror(errno));
 
   mark_point();
   res = pr_set_registered_actions(NULL, action, FALSE, PR_CTRLS_ACT_SOLITARY);
-  fail_unless(res == 0, "Failed to set SOLITARY action flag: %s",
+  ck_assert_msg(res == 0, "Failed to set SOLITARY action flag: %s",
     strerror(errno));
 
   mark_point();
   res = pr_ctrls_check_actions();
-  fail_unless(res < 0, "Failed to handle duplicate SOLITARY actions");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle duplicate SOLITARY actions");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 }
 END_TEST
@@ -1349,13 +1349,13 @@ START_TEST (ctrls_run_ctrls_test) {
 
   mark_point();
   res = pr_run_ctrls(NULL, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   pr_block_ctrls();
   res = pr_run_ctrls(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle blocked ctrls");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle blocked ctrls");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   pr_unblock_ctrls();
 
@@ -1365,19 +1365,19 @@ START_TEST (ctrls_run_ctrls_test) {
   m.name = "test";
   m2.name = "test2";
   res = pr_ctrls_register(&m, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_run_ctrls(NULL, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   res = pr_run_ctrls(&m2, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   res = pr_run_ctrls(&m, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   /* XXX TODO More test cases to fill in here. */
   /* Note that pr_run_ctrls() makes a lot of assumptions about recv_response,
@@ -1408,31 +1408,31 @@ START_TEST (ctrls_run_ctrls_test) {
   (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
-  fail_unless(res == 0, "Failed to handle known action: %s", strerror(errno));
-  fail_unless(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
+  ck_assert_msg(res == 0, "Failed to handle known action: %s", strerror(errno));
+  ck_assert_msg(cl->cl_ctrls->nelts == 1, "Expected 1 ctrl, got %d",
     cl->cl_ctrls->nelts);
   ctrl = ((pr_ctrls_t **) cl->cl_ctrls->elts)[0];
 
   mark_point();
   res = pr_run_ctrls(&m2, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   res = pr_run_ctrls(&m, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   cl->cl_flags = PR_CTRLS_CL_HAVEREQ;
   ctrl->ctrls_flags |= PR_CTRLS_ACT_DISABLED;
   res = pr_run_ctrls(&m, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   cl->cl_flags = PR_CTRLS_CL_HAVEREQ;
   ctrl->ctrls_flags &= ~PR_CTRLS_ACT_DISABLED;
   ctrl->ctrls_flags &= ~PR_CTRLS_REQUESTED;
   res = pr_run_ctrls(&m, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   cl->cl_flags = PR_CTRLS_CL_HAVEREQ;
@@ -1440,7 +1440,7 @@ START_TEST (ctrls_run_ctrls_test) {
   now = time(NULL);
   ctrl->ctrls_when = now + 10;
   res = pr_run_ctrls(&m, NULL);
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   cl->cl_flags = PR_CTRLS_CL_HAVEREQ;
@@ -1448,17 +1448,17 @@ START_TEST (ctrls_run_ctrls_test) {
   ctrl->ctrls_flags |= PR_CTRLS_REQUESTED;
   ctrl->ctrls_when = now - 10;
   res = pr_run_ctrls(&m, "test2");
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   cl->cl_flags = PR_CTRLS_CL_HAVEREQ;
   ctrl->ctrls_flags |= PR_CTRLS_REQUESTED;
   res = pr_run_ctrls(&m, "test");
-  fail_unless(res == 0, "Failed to run ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to run ctrls: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 
   (void) close(fd);
@@ -1471,21 +1471,21 @@ START_TEST (ctrls_reset_ctrls_test) {
 
   mark_point();
   res = pr_ctrls_reset();
-  fail_unless(res == 0, "Failed to reset ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to reset ctrls: %s", strerror(errno));
 
   mark_point();
   action = "test";
   desc = "desc";
   res = pr_ctrls_register(NULL, action, desc, ctrls_test_cb);
-  fail_unless(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to register ctrls action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_reset();
-  fail_unless(res == 0, "Failed to reset ctrls: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to reset ctrls: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_unregister(NULL, action);
-  fail_unless(res == 0, "Failed to unregister ctrls action: %s",
+  ck_assert_msg(res == 0, "Failed to unregister ctrls action: %s",
     strerror(errno));
 }
 END_TEST
@@ -1495,8 +1495,8 @@ START_TEST (ctrls_accept_test) {
 
   mark_point();
   res = pr_ctrls_accept(-1, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle bad fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
@@ -1506,8 +1506,8 @@ START_TEST (ctrls_accept_test) {
   }
 
   res = pr_ctrls_accept(fd, NULL, NULL, NULL, 5);
-  fail_unless(res < 0, "Failed to handle no clients");
-  fail_unless(errno = ENOENT, "Expected ENOENT (%d), got %d (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no clients");
+  ck_assert_msg(errno = ENOENT, "Expected ENOENT (%d), got %d (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) close(fd);
@@ -1520,15 +1520,15 @@ START_TEST (ctrls_connect_test) {
 
   mark_point();
   res = pr_ctrls_connect(NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   socket_path = "/tmp/foo.sock";
   res = pr_ctrls_connect(socket_path);
-  fail_unless(res < 0, "Failed to handle nonexistent socket path");
-  fail_unless(errno == ECONNREFUSED || errno == ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent socket path");
+  ck_assert_msg(errno == ECONNREFUSED || errno == ENOENT,
     "Expected ECONNREFUSED (%d) or ENOENT (%d), got %s (%d)", ECONNREFUSED,
     ENOENT, strerror(errno), errno);
 
@@ -1539,7 +1539,7 @@ START_TEST (ctrls_connect_test) {
   }
 
   res = pr_ctrls_connect(socket_path);
-  fail_unless(res >= 0, "Failed to connect to local socket: %s",
+  ck_assert_msg(res >= 0, "Failed to connect to local socket: %s",
     strerror(errno));
 
   (void) close(res);
@@ -1555,29 +1555,29 @@ START_TEST (ctrls_check_group_acl_test) {
 
   mark_point();
   res = pr_ctrls_check_group_acl(0, NULL);
-  fail_unless(res < 0, "Failed to handle null acl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   group_acl = pcalloc(p, sizeof(ctrls_group_acl_t));
   res = pr_ctrls_check_group_acl(0, group_acl);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   mark_point();
   group_acl->allow = TRUE;
   res = pr_ctrls_check_group_acl(0, group_acl);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   mark_point();
   group_acl->ngids = 1;
   res = pr_ctrls_check_group_acl(0, group_acl);
-  fail_unless(res == group_acl->allow, "Expected %d, got %d",
+  ck_assert_msg(res == group_acl->allow, "Expected %d, got %d",
     group_acl->allow, res);
 
   group_acl->allow = FALSE;
   res = pr_ctrls_check_group_acl(0, group_acl);
-  fail_unless(res == group_acl->allow, "Expected %d, got %d",
+  ck_assert_msg(res == group_acl->allow, "Expected %d, got %d",
     group_acl->allow, res);
 
   mark_point();
@@ -1586,10 +1586,10 @@ START_TEST (ctrls_check_group_acl_test) {
   group_acl->gids = palloc(p, sizeof(gid_t) * 2);
   ((gid_t *) group_acl->gids)[0] = gid;
   res = pr_ctrls_check_group_acl(0, group_acl);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_ctrls_check_group_acl(gid, group_acl);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 }
 END_TEST
 
@@ -1600,29 +1600,29 @@ START_TEST (ctrls_check_user_acl_test) {
 
   mark_point();
   res = pr_ctrls_check_user_acl(0, NULL);
-  fail_unless(res < 0, "Failed to handle null acl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   user_acl = pcalloc(p, sizeof(ctrls_user_acl_t));
   res = pr_ctrls_check_user_acl(0, user_acl);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   mark_point();
   user_acl->allow = TRUE;
   res = pr_ctrls_check_user_acl(0, user_acl);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   mark_point();
   user_acl->nuids = 1;
   res = pr_ctrls_check_user_acl(0, user_acl);
-  fail_unless(res == user_acl->allow, "Expected %d, got %d",
+  ck_assert_msg(res == user_acl->allow, "Expected %d, got %d",
     user_acl->allow, res);
 
   user_acl->allow = FALSE;
   res = pr_ctrls_check_user_acl(0, user_acl);
-  fail_unless(res == user_acl->allow, "Expected %d, got %d",
+  ck_assert_msg(res == user_acl->allow, "Expected %d, got %d",
     user_acl->allow, res);
 
   mark_point();
@@ -1631,10 +1631,10 @@ START_TEST (ctrls_check_user_acl_test) {
   user_acl->uids = palloc(p, sizeof(uid_t) * 2);
   ((uid_t *) user_acl->uids)[0] = uid;
   res = pr_ctrls_check_user_acl(0, user_acl);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_ctrls_check_user_acl(uid, user_acl);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 }
 END_TEST
 
@@ -1644,14 +1644,14 @@ START_TEST (ctrls_init_acl_test) {
 
   mark_point();
   res = pr_ctrls_init_acl(NULL);
-  fail_unless(res < 0, "Failed to handle null acl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
   res = pr_ctrls_init_acl(acl);
-  fail_unless(res == 0, "Failed to init acl: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to init acl: %s", strerror(errno));
 }
 END_TEST
 
@@ -1672,15 +1672,15 @@ START_TEST (ctrls_check_acl_test) {
 
   mark_point();
   res = pr_ctrls_check_acl(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null ctrl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctrl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   ctrl = pr_ctrls_alloc();
   res = pr_ctrls_check_acl(ctrl, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle ctrl without client");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle ctrl without client");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -1688,41 +1688,41 @@ START_TEST (ctrls_check_acl_test) {
   cl->cl_uid = cl->cl_gid = 1;
   ctrl->ctrls_cl = cl;
   res = pr_ctrls_check_acl(ctrl, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null acttab");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acttab");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_check_acl(ctrl, acttab, NULL);
-  fail_unless(res < 0, "Failed to handle null action");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null action");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   action = "foobar";
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   mark_point();
   action = "test";
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
   res = pr_ctrls_init_acl(acl);
   acttab[0].act_acl = acl;
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   mark_point();
   acl->acl_groups.ngids = 1;
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   acl->acl_users.nuids = 1;
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 }
 END_TEST
 
@@ -1732,33 +1732,33 @@ START_TEST (ctrls_parse_acl_test) {
 
   mark_point();
   res = pr_ctrls_parse_acl(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_parse_acl(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null ACL text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null ACL text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   names = "foo";
   res = pr_ctrls_parse_acl(p, names);
-  fail_unless(res != NULL, "Failed to parse ACL '%s': %s", names,
+  ck_assert_msg(res != NULL, "Failed to parse ACL '%s': %s", names,
     strerror(errno));
-  fail_unless(strcmp(res[0], "foo") == 0, "Expected 'foo', got '%s'", res[0]);
-  fail_unless(res[1] == NULL, "Expected NULL, got %p", res[1]);
+  ck_assert_msg(strcmp(res[0], "foo") == 0, "Expected 'foo', got '%s'", res[0]);
+  ck_assert_msg(res[1] == NULL, "Expected NULL, got %p", res[1]);
 
   mark_point();
   names = "foo,'Bar',BAZ";
   res = pr_ctrls_parse_acl(p, names);
-  fail_unless(res != NULL, "Failed to parse ACL '%s': %s", names,
+  ck_assert_msg(res != NULL, "Failed to parse ACL '%s': %s", names,
     strerror(errno));
-  fail_unless(strcmp(res[0], "foo") == 0, "Expected 'foo', got '%s'", res[0]);
-  fail_unless(strcmp(res[1], "'Bar'") == 0, "Expected 'Bar', got '%s'", res[1]);
-  fail_unless(strcmp(res[2], "BAZ") == 0, "Expected 'BAZ', got '%s'", res[2]);
-  fail_unless(res[3] == NULL, "Expected NULL, got %p", res[3]);
+  ck_assert_msg(strcmp(res[0], "foo") == 0, "Expected 'foo', got '%s'", res[0]);
+  ck_assert_msg(strcmp(res[1], "'Bar'") == 0, "Expected 'Bar', got '%s'", res[1]);
+  ck_assert_msg(strcmp(res[2], "BAZ") == 0, "Expected 'BAZ', got '%s'", res[2]);
+  ck_assert_msg(res[3] == NULL, "Expected NULL, got %p", res[3]);
 }
 END_TEST
 
@@ -1770,52 +1770,52 @@ START_TEST (ctrls_set_group_acl_test) {
 
   mark_point();
   res = pr_ctrls_set_group_acl(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_group_acl(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null group_acl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null group_acl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   group_acl = pcalloc(p, sizeof(ctrls_group_acl_t));
   res = pr_ctrls_set_group_acl(p, group_acl, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null allow");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null allow");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   allow = "allow";
   res = pr_ctrls_set_group_acl(p, group_acl, allow, NULL);
-  fail_unless(res < 0, "Failed to handle null grouplist");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null grouplist");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   grouplist = "foo,bar,baz,wheel";
   res = pr_ctrls_set_group_acl(p, group_acl, allow, grouplist);
-  fail_unless(res == 0, "Failed to set group acl: %s", strerror(errno));
-  fail_unless(group_acl->allow == TRUE, "Expected TRUE, got %d",
+  ck_assert_msg(res == 0, "Failed to set group acl: %s", strerror(errno));
+  ck_assert_msg(group_acl->allow == TRUE, "Expected TRUE, got %d",
     group_acl->allow);
   /* Note that we expect zero here, because of name/GID lookup failures. */
-  fail_unless(group_acl->ngids == 0, "Expected 0, got %d",
+  ck_assert_msg(group_acl->ngids == 0, "Expected 0, got %d",
     group_acl->ngids);
-  fail_unless(group_acl->gids != NULL, "Got NULL unexpectedly");
+  ck_assert_msg(group_acl->gids != NULL, "Got NULL unexpectedly");
 
   mark_point();
   group_acl = pcalloc(p, sizeof(ctrls_group_acl_t));
   allow = "deny";
   grouplist = "foo,*";
   res = pr_ctrls_set_group_acl(p, group_acl, allow, grouplist);
-  fail_unless(res == 0, "Failed to set group acl: %s", strerror(errno));
-  fail_unless(group_acl->allow == FALSE, "Expected FALSE, got %d",
+  ck_assert_msg(res == 0, "Failed to set group acl: %s", strerror(errno));
+  ck_assert_msg(group_acl->allow == FALSE, "Expected FALSE, got %d",
     group_acl->allow);
-  fail_unless(group_acl->ngids == 1, "Expected 1, got %d",
+  ck_assert_msg(group_acl->ngids == 1, "Expected 1, got %d",
     group_acl->ngids);
-  fail_unless(group_acl->gids == NULL, "Expected NULL, got %p",
+  ck_assert_msg(group_acl->gids == NULL, "Expected NULL, got %p",
     group_acl->gids);
 }
 END_TEST
@@ -1828,50 +1828,50 @@ START_TEST (ctrls_set_user_acl_test) {
 
   mark_point();
   res = pr_ctrls_set_user_acl(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_user_acl(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null user_acl");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null user_acl");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   user_acl = pcalloc(p, sizeof(ctrls_user_acl_t));
   res = pr_ctrls_set_user_acl(p, user_acl, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null allow");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null allow");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   allow = "allow";
   res = pr_ctrls_set_user_acl(p, user_acl, allow, NULL);
-  fail_unless(res < 0, "Failed to handle null userlist");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null userlist");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   userlist = "foo,bar,baz,root";
   res = pr_ctrls_set_user_acl(p, user_acl, allow, userlist);
-  fail_unless(res == 0, "Failed to set user acl: %s", strerror(errno));
-  fail_unless(user_acl->allow == TRUE, "Expected TRUE, got %d",
+  ck_assert_msg(res == 0, "Failed to set user acl: %s", strerror(errno));
+  ck_assert_msg(user_acl->allow == TRUE, "Expected TRUE, got %d",
     user_acl->allow);
   /* Note that we expect zero here, because of name/UID lookup failures. */
-  fail_unless(user_acl->nuids == 0, "Expected 0, got %d", user_acl->nuids);
-  fail_unless(user_acl->uids != NULL, "Got NULL unexpectedly");
+  ck_assert_msg(user_acl->nuids == 0, "Expected 0, got %d", user_acl->nuids);
+  ck_assert_msg(user_acl->uids != NULL, "Got NULL unexpectedly");
 
   mark_point();
   user_acl = pcalloc(p, sizeof(ctrls_user_acl_t));
   allow = "deny";
   userlist = "foo,*";
   res = pr_ctrls_set_user_acl(p, user_acl, allow, userlist);
-  fail_unless(res == 0, "Failed to set user acl: %s", strerror(errno));
-  fail_unless(user_acl->allow == FALSE, "Expected FALSE, got %d",
+  ck_assert_msg(res == 0, "Failed to set user acl: %s", strerror(errno));
+  ck_assert_msg(user_acl->allow == FALSE, "Expected FALSE, got %d",
     user_acl->allow);
-  fail_unless(user_acl->nuids == 1, "Expected 1, got %d", user_acl->nuids);
-  fail_unless(user_acl->uids == NULL, "Expected NULL, got %p",
+  ck_assert_msg(user_acl->nuids == 1, "Expected 1, got %d", user_acl->nuids);
+  ck_assert_msg(user_acl->uids == NULL, "Expected NULL, got %p",
     user_acl->uids);
 }
 END_TEST
@@ -1890,75 +1890,75 @@ START_TEST (ctrls_set_module_acls_test) {
 
   mark_point();
   res = pr_ctrls_set_module_acls(NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null acttab");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null acttab");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls(acttab, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null acl_pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null acl_pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls(acttab, p, NULL, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null actions");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null actions");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls(acttab, p, good_actions, NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null allow");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null allow");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   allow = "allow";
   res = pr_ctrls_set_module_acls(acttab, p, good_actions, allow, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   type = "test";
   res = pr_ctrls_set_module_acls(acttab, p, good_actions, allow, type, NULL);
-  fail_unless(res == NULL, "Failed to handle null list");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null list");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   list = "foo,bar,baz";
   res = pr_ctrls_set_module_acls(acttab, p, bad_actions, allow, type, list);
-  fail_unless(res == NULL, "Failed to handle invalid type '%s'", type);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid type '%s'", type);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   type = "user";
   res = pr_ctrls_set_module_acls(acttab, p, bad_actions, allow, type, list);
-  fail_unless(res != NULL, "Failed to handle invalid action");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res != NULL, "Failed to handle invalid action");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(strcmp(res, "bar") == 0, "Expected 'bar', got '%s'", res);
+  ck_assert_msg(strcmp(res, "bar") == 0, "Expected 'bar', got '%s'", res);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
-  fail_unless(pr_ctrls_init_acl(acl) == 0,
+  ck_assert_msg(pr_ctrls_init_acl(acl) == 0,
     "Failed to initialize acl: %s", strerror(errno));
 
   acttab[0].act_acl = acl;
   type = "group";
   res = pr_ctrls_set_module_acls(acttab, p, good_actions, allow, type, list);
-  fail_unless(res == NULL, "Failed to handle good action: %s", strerror(errno));
+  ck_assert_msg(res == NULL, "Failed to handle good action: %s", strerror(errno));
 
   mark_point();
   type = "user";
   res = pr_ctrls_set_module_acls(acttab, p, good_actions, allow, type, list);
-  fail_unless(res == NULL, "Failed to handle good action: %s", strerror(errno));
+  ck_assert_msg(res == NULL, "Failed to handle good action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_set_module_acls(acttab, p, all_actions, allow, type, list);
-  fail_unless(res == NULL, "Failed to handle all actions: %s", strerror(errno));
+  ck_assert_msg(res == NULL, "Failed to handle all actions: %s", strerror(errno));
 }
 END_TEST
 
@@ -1977,91 +1977,91 @@ START_TEST (ctrls_set_module_acls2_test) {
 
   mark_point();
   res = pr_ctrls_set_module_acls2(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null acttab");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acttab");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls2(acttab, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null acl_pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acl_pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls2(acttab, p, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null actions");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null actions");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls2(acttab, p, good_actions, NULL, NULL, NULL,
     NULL);
-  fail_unless(res < 0, "Failed to handle null allow");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null allow");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   allow = "allow";
   res = pr_ctrls_set_module_acls2(acttab, p, good_actions, allow, NULL, NULL,
     NULL);
-  fail_unless(res < 0, "Failed to handle null type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   type = "test";
   res = pr_ctrls_set_module_acls2(acttab, p, good_actions, allow, type, NULL,
     NULL);
-  fail_unless(res < 0, "Failed to handle null list");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null list");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   list = "foo,bar,baz";
   res = pr_ctrls_set_module_acls2(acttab, p, bad_actions, allow, type, list,
     NULL);
-  fail_unless(res < 0, "Failed to handle null bad_action");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null bad_action");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_set_module_acls2(acttab, p, bad_actions, allow, type, list,
     &bad_action);
-  fail_unless(res < 0, "Failed to handle invalid type '%s'", type);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid type '%s'", type);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   type = "user";
   res = pr_ctrls_set_module_acls2(acttab, p, bad_actions, allow, type, list,
     &bad_action);
-  fail_unless(res < 0, "Failed to handle invalid action");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid action");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(strcmp(bad_action, "bar") == 0,
+  ck_assert_msg(strcmp(bad_action, "bar") == 0,
     "Expected 'bar', got '%s'", bad_action);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
-  fail_unless(pr_ctrls_init_acl(acl) == 0,
+  ck_assert_msg(pr_ctrls_init_acl(acl) == 0,
     "Failed to initialize acl: %s", strerror(errno));
 
   acttab[0].act_acl = acl;
   type = "group";
   res = pr_ctrls_set_module_acls2(acttab, p, good_actions, allow, type, list,
     &bad_action);
-  fail_unless(res == 0, "Failed to handle good action: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle good action: %s", strerror(errno));
 
   mark_point();
   type = "user";
   res = pr_ctrls_set_module_acls2(acttab, p, good_actions, allow, type, list,
     &bad_action);
-  fail_unless(res == 0, "Failed to handle good action: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle good action: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_set_module_acls2(acttab, p, all_actions, allow, type, list,
     &bad_action);
-  fail_unless(res == 0, "Failed to handle all actions: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle all actions: %s", strerror(errno));
 }
 END_TEST
 
@@ -2078,37 +2078,37 @@ START_TEST (ctrls_unregister_module_actions_test) {
 
   mark_point();
   res = pr_ctrls_unregister_module_actions(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null acttab");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null acttab");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister_module_actions(acttab, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null actions");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null actions");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister_module_actions(acttab, good_actions, NULL);
-  fail_unless(res == NULL, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   m.name = "test";
   res = pr_ctrls_unregister_module_actions(acttab, bad_actions, &m);
-  fail_unless(res != NULL, "Failed to handle invalid action");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res != NULL, "Failed to handle invalid action");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(strcmp(res, "bar") == 0, "Expected 'bar', got '%s'", res);
+  ck_assert_msg(strcmp(res, "bar") == 0, "Expected 'bar', got '%s'", res);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
-  fail_unless(pr_ctrls_init_acl(acl) == 0,
+  ck_assert_msg(pr_ctrls_init_acl(acl) == 0,
     "Failed to initialize acl: %s", strerror(errno));
   acttab[0].act_acl = acl;
   res = pr_ctrls_unregister_module_actions(acttab, good_actions, &m);
-  fail_unless(res == NULL, "Failed to handle valid action: %s",
+  ck_assert_msg(res == NULL, "Failed to handle valid action: %s",
     strerror(errno));
 }
 END_TEST
@@ -2127,47 +2127,47 @@ START_TEST (ctrls_unregister_module_actions2_test) {
 
   mark_point();
   res = pr_ctrls_unregister_module_actions2(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null acttab");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null acttab");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister_module_actions2(acttab, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null actions");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null actions");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister_module_actions2(acttab, good_actions, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   m.name = "test";
   res = pr_ctrls_unregister_module_actions2(acttab, bad_actions, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null bad_action");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null bad_action");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_ctrls_unregister_module_actions2(acttab, bad_actions, &m,
     &bad_action);
-  fail_unless(res < 0, "Failed to handle invalid action");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid action");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(bad_action != NULL, "Expected bad_action, got NULL");
-  fail_unless(strcmp(bad_action, "bar") == 0,
+  ck_assert_msg(bad_action != NULL, "Expected bad_action, got NULL");
+  ck_assert_msg(strcmp(bad_action, "bar") == 0,
     "Expected 'bar', got '%s'", bad_action);
 
   mark_point();
   acl = pcalloc(p, sizeof(ctrls_acl_t));
-  fail_unless(pr_ctrls_init_acl(acl) == 0,
+  ck_assert_msg(pr_ctrls_init_acl(acl) == 0,
     "Failed to initialize acl: %s", strerror(errno));
   acttab[0].act_acl = acl;
   res = pr_ctrls_unregister_module_actions2(acttab, good_actions, &m,
     &bad_action);
-  fail_unless(res == 0, "Failed to handle valid action: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle valid action: %s", strerror(errno));
 }
 END_TEST
 
@@ -2177,13 +2177,13 @@ START_TEST (ctrls_set_logfd_test) {
   mark_point();
   fd = 0;
   res = pr_ctrls_set_logfd(fd);
-  fail_unless(res == 0, "Failed to set ctrls log fd %d: %s", fd,
+  ck_assert_msg(res == 0, "Failed to set ctrls log fd %d: %s", fd,
      strerror(errno));
 
   mark_point();
   fd = -1;
   res = pr_ctrls_set_logfd(fd);
-  fail_unless(res == 0, "Failed to set ctrls log fd %d: %s", fd,
+  ck_assert_msg(res == 0, "Failed to set ctrls log fd %d: %s", fd,
      strerror(errno));
 }
 END_TEST
@@ -2195,7 +2195,7 @@ START_TEST (ctrls_log_test) {
   fd = -1;
   pr_ctrls_set_logfd(fd);
   res = pr_ctrls_log(NULL, NULL);
-  fail_unless(res == 0, "Failed to handle bad logfd: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle bad logfd: %s", strerror(errno));
 
   mark_point();
   fd = devnull_fd();
@@ -2205,16 +2205,16 @@ START_TEST (ctrls_log_test) {
 
   pr_ctrls_set_logfd(fd);
   res = pr_ctrls_log(NULL, NULL);
-  fail_unless(res == 0, "Failed to handle bad module_version: %s",
+  ck_assert_msg(res == 0, "Failed to handle bad module_version: %s",
     strerror(errno));
 
   mark_point();
   res = pr_ctrls_log("test", NULL);
-  fail_unless(res == 0, "Failed to handle null fmt: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle null fmt: %s", strerror(errno));
 
   mark_point();
   res = pr_ctrls_log("test", "%s", "foo bar baz");
-  fail_unless(res == 0, "Failed to handle valid fmt: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle valid fmt: %s", strerror(errno));
 
   (void) close(fd);
 }

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -1161,7 +1161,7 @@ START_TEST (ctrls_issock_unix_test) {
   mode |= S_IFIFO;
   res = pr_ctrls_issock_unix(mode);
   if (res < 0) {
-    fail_if(errno != ENOSYS, "Did not expect ENOSYS (%d)", ENOSYS);
+    ck_assert_msg(errno == ENOSYS, "Did not expect ENOSYS (%d)", ENOSYS);
   }
 #endif /* S_ISFIFO */
 
@@ -1171,7 +1171,7 @@ START_TEST (ctrls_issock_unix_test) {
   mode |= S_IFSOCK;
   res = pr_ctrls_issock_unix(mode);
   if (res < 0) {
-    fail_if(errno != ENOSYS, "Did not expect ENOSYS (%d)", ENOSYS);
+    ck_assert_msg(errno == ENOSYS, "Did not expect ENOSYS (%d)", ENOSYS);
   }
 #endif /* S_ISSOCK */
 }

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -1507,7 +1507,7 @@ START_TEST (ctrls_accept_test) {
 
   res = pr_ctrls_accept(fd, NULL, NULL, NULL, 5);
   ck_assert_msg(res < 0, "Failed to handle no clients");
-  ck_assert_msg(errno = ENOENT, "Expected ENOENT (%d), got %d (%d)", ENOENT,
+  ck_assert_msg(errno = ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) close(fd);

--- a/tests/api/data.c
+++ b/tests/api/data.c
@@ -114,20 +114,20 @@ START_TEST (data_get_timeout_test) {
   int res;
 
   res = pr_data_get_timeout(-1);
-  fail_unless(res < 0, "Failed to handle invalid timeout ID");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid timeout ID");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_IDLE);
-  fail_unless(res == PR_TUNABLE_TIMEOUTIDLE, "Expected %d, got %d",
+  ck_assert_msg(res == PR_TUNABLE_TIMEOUTIDLE, "Expected %d, got %d",
     PR_TUNABLE_TIMEOUTIDLE, res);
 
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_NO_TRANSFER);
-  fail_unless(res == PR_TUNABLE_TIMEOUTNOXFER, "Expected %d, got %d",
+  ck_assert_msg(res == PR_TUNABLE_TIMEOUTNOXFER, "Expected %d, got %d",
     PR_TUNABLE_TIMEOUTNOXFER, res);
 
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_STALLED);
-  fail_unless(res == PR_TUNABLE_TIMEOUTSTALLED, "Expected %d, got %d",
+  ck_assert_msg(res == PR_TUNABLE_TIMEOUTSTALLED, "Expected %d, got %d",
     PR_TUNABLE_TIMEOUTSTALLED, res);
 }
 END_TEST
@@ -137,15 +137,15 @@ START_TEST (data_set_timeout_test) {
 
   pr_data_set_timeout(PR_DATA_TIMEOUT_IDLE, timeout);
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_IDLE);
-  fail_unless(res == timeout, "Expected %d, got %d", timeout, res);
+  ck_assert_msg(res == timeout, "Expected %d, got %d", timeout, res);
 
   pr_data_set_timeout(PR_DATA_TIMEOUT_NO_TRANSFER, timeout);
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_NO_TRANSFER);
-  fail_unless(res == timeout, "Expected %d, got %d", timeout, res);
+  ck_assert_msg(res == timeout, "Expected %d, got %d", timeout, res);
 
   pr_data_set_timeout(PR_DATA_TIMEOUT_STALLED, timeout);
   res = pr_data_get_timeout(PR_DATA_TIMEOUT_STALLED);
-  fail_unless(res == timeout, "Expected %d, got %d", timeout, res);
+  ck_assert_msg(res == timeout, "Expected %d, got %d", timeout, res);
 
   /* Interestingly, the linger timeout has its own function. */
   pr_data_set_linger(7L);
@@ -156,21 +156,21 @@ START_TEST (data_ignore_ascii_test) {
   int res;
 
   res = pr_data_ignore_ascii(-1);
-  fail_unless(res < 0, "Failed to handle invalid argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_data_ignore_ascii(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_data_ignore_ascii(TRUE);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 
   res = pr_data_ignore_ascii(FALSE);
-  fail_unless(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE (%d), got %d", TRUE, res);
 
   res = pr_data_ignore_ascii(FALSE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 }
 END_TEST
 
@@ -282,61 +282,61 @@ START_TEST (data_sendfile_test) {
   }
 
   res = pr_data_sendfile(fd, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null offset");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null offset");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_data_sendfile(fd, &offset, 0);
-  fail_unless(res < 0, "Failed to handle zero count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.xfer.direction = PR_NETIO_IO_RD;
   res = pr_data_sendfile(fd, &offset, 1);
-  fail_unless(res < 0, "Failed to handle invalid transfer direction");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid transfer direction");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   session.xfer.direction = PR_NETIO_IO_WR;
   res = pr_data_sendfile(fd, &offset, 1);
-  fail_unless(res < 0, "Failed to handle lack of data connection");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle lack of data connection");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open streams: %s", strerror(errno));
 
   mark_point();
   res = pr_data_sendfile(fd, &offset, 1);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF || errno == EINVAL,
     "Expected EBADF (%d) or EINVAL (%d), got %s (%d)", EBADF, EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(data_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", data_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", data_test_path,
     strerror(errno));
 
   text = "Hello, World!\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_unless(res >= 0, "Failed to write to '%s': %s", data_test_path,
+  ck_assert_msg(res >= 0, "Failed to write to '%s': %s", data_test_path,
     strerror(errno));
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to close '%s': %s", data_test_path,
+  ck_assert_msg(res == 0, "Failed to close '%s': %s", data_test_path,
     strerror(errno));
 
   fd = open(data_test_path, O_RDONLY);
-  fail_unless(fd >= 0, "Failed to open '%s': %s", data_test_path,
+  ck_assert_msg(fd >= 0, "Failed to open '%s': %s", data_test_path,
     strerror(errno));
 
   mark_point();
   res = pr_data_sendfile(fd, &offset, strlen(text));
   if (res < 0) {
-    fail_unless(errno == ENOTSOCK || errno == EINVAL,
+    ck_assert_msg(errno == ENOTSOCK || errno == EINVAL,
      "Expected ENOTSOCK (%d) or EINVAL (%d), got %s (%d)", ENOTSOCK, EINVAL,
      strerror(errno), errno);
   }
@@ -357,10 +357,10 @@ START_TEST (data_init_test) {
 
   mark_point();
   pr_data_init(filename, 0);
-  fail_unless(session.xfer.direction == 0, "Expected xfer direction %d, got %d",
+  ck_assert_msg(session.xfer.direction == 0, "Expected xfer direction %d, got %d",
     0, session.xfer.direction);
-  fail_unless(session.xfer.p != NULL, "Transfer pool not created as expected");
-  fail_unless(session.xfer.filename == NULL, "Expected null filename, got %s",
+  ck_assert_msg(session.xfer.p != NULL, "Transfer pool not created as expected");
+  ck_assert_msg(session.xfer.filename == NULL, "Expected null filename, got %s",
     session.xfer.filename);
 
   filename = "test.dat";
@@ -368,24 +368,24 @@ START_TEST (data_init_test) {
 
   mark_point();
   pr_data_init(filename, rd);
-  fail_unless(session.xfer.direction == rd,
+  ck_assert_msg(session.xfer.direction == rd,
     "Expected xfer direction %d, got %d", rd, session.xfer.direction);
-  fail_unless(session.xfer.p != NULL, "Transfer pool not created as expected");
-  fail_unless(session.xfer.filename != NULL, "Missing transfer filename");
-  fail_unless(strcmp(session.xfer.filename, filename) == 0,
+  ck_assert_msg(session.xfer.p != NULL, "Transfer pool not created as expected");
+  ck_assert_msg(session.xfer.filename != NULL, "Missing transfer filename");
+  ck_assert_msg(strcmp(session.xfer.filename, filename) == 0,
     "Expected '%s', got '%s'", filename, session.xfer.filename);
 
   mark_point();
   pr_data_init("test2.dat", wr);
-  fail_unless(session.xfer.direction == wr,
+  ck_assert_msg(session.xfer.direction == wr,
     "Expected xfer direction %d, got %d", wr, session.xfer.direction);
-  fail_unless(session.xfer.p != NULL, "Transfer pool not created as expected");
-  fail_unless(session.xfer.filename != NULL, "Missing transfer filename");
+  ck_assert_msg(session.xfer.p != NULL, "Transfer pool not created as expected");
+  ck_assert_msg(session.xfer.filename != NULL, "Missing transfer filename");
 
   /* Even though we opened with a new filename, the previous filename should
    * still be there, as we didn't actually clear/reset this transfer.
    */
-  fail_unless(strcmp(session.xfer.filename, filename) == 0,
+  ck_assert_msg(strcmp(session.xfer.filename, filename) == 0,
     "Expected '%s', got '%s'", filename, session.xfer.filename);
 }
 END_TEST
@@ -396,12 +396,12 @@ START_TEST (data_open_active_test) {
 
   mark_point();
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* Note: these tests REQUIRE that session.c be non-NULL */
   session.c = conn;
@@ -410,28 +410,28 @@ START_TEST (data_open_active_test) {
 
   mark_point();
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Note: we also need session.c to have valid local/remote_addr, too! */
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   session.d = session.c;
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Failed to handle non-null session.d");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle non-null session.d");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   session.d = NULL;
 
   mark_point();
   session.xfer.filename = "foo";
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
   session.xfer.filename = NULL;
@@ -441,16 +441,16 @@ START_TEST (data_open_active_test) {
 
   mark_point();
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
 
   mark_point();
   session.xfer.p = NULL;
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
 
@@ -470,14 +470,14 @@ START_TEST (data_open_active_rootrevoke_test) {
   server_rec *s;
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* Note: these tests REQUIRE that session.c be non-NULL */
   session.c = conn;
 
   /* Note: we also need session.c to have valid local/remote_addr, too! */
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   s = pr_parser_server_ctxt_open("127.0.0.1");
@@ -490,8 +490,8 @@ START_TEST (data_open_active_rootrevoke_test) {
   mark_point();
   session.xfer.filename = "foo";
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
   session.xfer.filename = NULL;
@@ -501,8 +501,8 @@ START_TEST (data_open_active_rootrevoke_test) {
   session.c->local_port = 21;
   session.xfer.filename = "foo";
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   session.c->local_port = local_port;
   session.xfer.filename = NULL;
@@ -511,8 +511,8 @@ START_TEST (data_open_active_rootrevoke_test) {
   *((int *) c->argv[0]) = 2;
   session.xfer.filename = "foo";
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
   session.xfer.filename = NULL;
@@ -521,8 +521,8 @@ START_TEST (data_open_active_rootrevoke_test) {
   *((int *) c->argv[0]) = 3;
   session.xfer.filename = "foo";
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened active READ data connection unexpectedly");
-  fail_unless(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Opened active READ data connection unexpectedly");
+  ck_assert_msg(errno == EADDRNOTAVAIL || errno == ECONNREFUSED,
     "Expected EADDRNOTAVAIL (%d) or ECONNREFUSED (%d), got %s (%d)",
     EADDRNOTAVAIL, ECONNREFUSED, strerror(errno), errno);
   session.xfer.filename = NULL;
@@ -549,18 +549,18 @@ START_TEST (data_open_passive_test) {
 
   mark_point();
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Note: these tests REQUIRE that session.c be non-NULL, AND that session.d
    * be non-NULL.
    */
   session.c = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   session.d = data_conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* Reset the session flags after every failed open. */
   session.sf_flags |= SF_PASSIVE;
@@ -569,21 +569,21 @@ START_TEST (data_open_passive_test) {
 
   mark_point();
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Note: we also need session.c to have valid local/remote_addr, too! */
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   session.d = data_conn;
   session.sf_flags |= SF_PASSIVE;
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened passive READ data connection unexpectedly");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Opened passive READ data connection unexpectedly");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
     ENOTSOCK, strerror(errno), errno);
 
   /* Open a WRITing data transfer connection...*/
@@ -594,16 +594,16 @@ START_TEST (data_open_passive_test) {
   session.sf_flags |= SF_PASSIVE;
   session.xfer.p = NULL;
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened passive WRITE data connection unexpectedly");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Opened passive WRITE data connection unexpectedly");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
     ENOTSOCK, strerror(errno), errno);
 
   mark_point();
   session.sf_flags |= SF_PASSIVE;
   session.xfer.p = NULL;
   res = pr_data_open(NULL, NULL, dir, 0);
-  fail_unless(res < 0, "Opened passive WRITE data connection unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Opened passive WRITE data connection unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_inet_close(p, session.c);
@@ -618,19 +618,19 @@ END_TEST
 START_TEST (data_close_test) {
   session.sf_flags |= SF_PASSIVE;
   pr_data_close(TRUE);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "Failed to clear SF_PASSIVE session flag");
 
   session.sf_flags |= SF_PASSIVE;
   pr_data_close(FALSE);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "Failed to clear SF_PASSIVE session flag");
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   pr_data_close(TRUE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 }
 END_TEST
 
@@ -638,83 +638,83 @@ START_TEST (data_abort_test) {
   mark_point();
   session.sf_flags |= SF_PASSIVE;
   pr_data_abort(EPERM, TRUE);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "Failed to clear SF_PASSIVE session flag");
 
   session.sf_flags |= SF_PASSIVE;
   pr_data_abort(EPERM, FALSE);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "Failed to clear SF_PASSIVE session flag");
 
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   pr_data_abort(ESPIPE, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   session.sf_flags = SF_ABORT;
   pr_data_abort(EPIPE, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
   session.sf_flags &= ~SF_POST_ABORT;
 
 #if defined(ENXIO)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(ENXIO, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* ENXIO */
 
 #if defined(ENOMEM)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(ENOMEM, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* ENOMEM */
 
 #if defined(EBUSY)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(EBUSY, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* EBUSY */
 
 #if defined(ENOSPC)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(ENOSPC, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* ENOSPC */
 
 #if defined(EFBIG)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(EFBIG, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* EFBIG */
 
 #if defined(ECONNRESET)
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(ECONNRESET, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 #endif /* ECONNRESET */
 
   mark_point();
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
   pr_data_abort(-5432, FALSE);
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 }
 END_TEST
 
@@ -724,16 +724,16 @@ START_TEST (data_reset_test) {
   /* Set a session flag, make sure it's cleared properly. */
   session.sf_flags |= SF_PASSIVE;
   pr_data_reset();
-  fail_unless(session.d == NULL, "Expected NULL session.d, got %p", session.d);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(session.d == NULL, "Expected NULL session.d, got %p", session.d);
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "SF_PASSIVE session flag not cleared");
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   pr_data_reset();
-  fail_unless(session.d == NULL, "Expected NULL session.d, got %p", session.d);
-  fail_unless(!(session.sf_flags & SF_PASSIVE),
+  ck_assert_msg(session.d == NULL, "Expected NULL session.d, got %p", session.d);
+  ck_assert_msg(!(session.sf_flags & SF_PASSIVE),
     "SF_PASSIVE session flag not cleared");
 }
 END_TEST
@@ -744,17 +744,17 @@ START_TEST (data_cleanup_test) {
   /* Set a session flag, make sure it's cleared properly. */
   session.sf_flags |= SF_PASSIVE;
   pr_data_cleanup();
-  fail_unless(session.d == NULL, "Expected NULL session.d, got %p", session.d);
-  fail_unless(session.sf_flags & SF_PASSIVE,
+  ck_assert_msg(session.d == NULL, "Expected NULL session.d, got %p", session.d);
+  ck_assert_msg(session.sf_flags & SF_PASSIVE,
     "SF_PASSIVE session flag not preserved");
-  fail_unless(session.xfer.xfer_type == STOR_DEFAULT, "Expected %d, got %d",
+  ck_assert_msg(session.xfer.xfer_type == STOR_DEFAULT, "Expected %d, got %d",
     STOR_DEFAULT, session.xfer.xfer_type);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   pr_data_cleanup();
-  fail_unless(session.d == NULL, "Failed to close session.d");
+  ck_assert_msg(session.d == NULL, "Failed to close session.d");
 }
 END_TEST
 
@@ -763,15 +763,15 @@ START_TEST (data_clear_xfer_pool_test) {
 
   mark_point();
   pr_data_clear_xfer_pool();
-  fail_unless(session.xfer.p == NULL, "Failed to clear session.xfer.p");
+  ck_assert_msg(session.xfer.p == NULL, "Failed to clear session.xfer.p");
 
   session.xfer.xfer_type = xfer_type; 
   session.xfer.p = make_sub_pool(p);
 
   mark_point();
   pr_data_clear_xfer_pool();
-  fail_unless(session.xfer.p == NULL, "Failed to clear session.xfer.p");
-  fail_unless(session.xfer.xfer_type == xfer_type, "Expected %d, got %d",
+  ck_assert_msg(session.xfer.p == NULL, "Failed to clear session.xfer.p");
+  ck_assert_msg(session.xfer.xfer_type == xfer_type, "Expected %d, got %d",
     xfer_type, session.xfer.xfer_type);
 }
 END_TEST
@@ -786,27 +786,27 @@ START_TEST (data_xfer_read_binary_test) {
   pr_data_reset();
 
   res = pr_data_xfer(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   bufsz = 1024;
   buf = palloc(p, bufsz);
 
   res = pr_data_xfer(buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == ECONNABORTED,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == ECONNABORTED,
     "Expected ECONNABORTED (%d), got %s (%d)", ECONNABORTED,
     strerror(errno), errno);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* read binary data */
   session.xfer.direction = PR_NETIO_IO_RD;
@@ -823,12 +823,12 @@ START_TEST (data_xfer_read_binary_test) {
   session.xfer.buflen = 0;
 
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   mark_point();
@@ -836,14 +836,14 @@ START_TEST (data_xfer_read_binary_test) {
   session.xfer.buflen = 0;
 
   res = pr_data_xfer(buf, bufsz);
-  fail_unless((size_t) res == expected_len, "Expected %lu, got %d",
+  ck_assert_msg((size_t) res == expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
@@ -851,9 +851,9 @@ START_TEST (data_xfer_read_binary_test) {
   session.xfer.buflen = 0;
 
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
 
@@ -865,9 +865,9 @@ START_TEST (data_xfer_read_binary_test) {
   data_read_eagain = TRUE;
 
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
 }
@@ -882,27 +882,27 @@ START_TEST (data_xfer_write_binary_test) {
   pr_data_reset();
 
   res = pr_data_xfer(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buf = "Hello, World!\n";
   buflen = strlen(buf);
 
   res = pr_data_xfer(buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_data_xfer(buf, buflen);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == ECONNABORTED,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == ECONNABORTED,
     "Expected ECONNABORTED (%d), got %s (%d)", ECONNABORTED,
     strerror(errno), errno);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* write binary data */
   session.xfer.direction = PR_NETIO_IO_WR;
@@ -913,31 +913,31 @@ START_TEST (data_xfer_write_binary_test) {
   mark_point();
   data_write_eagain = TRUE;
   res = pr_data_xfer(buf, buflen);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   mark_point();
   res = pr_data_xfer(buf, buflen);
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
   res = pr_data_xfer(buf, buflen);
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(strncmp(session.xfer.buf, buf, buflen) == 0,
+  ck_assert_msg(strncmp(session.xfer.buf, buf, buflen) == 0,
     "Expected '%s', got '%.100s'", buf, session.xfer.buf);
 }
 END_TEST
@@ -952,27 +952,27 @@ START_TEST (data_xfer_read_ascii_test) {
   pr_data_reset();
 
   res = pr_data_xfer(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   bufsz = 1024;
   buf = palloc(p, bufsz);
 
   res = pr_data_xfer(buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == ECONNABORTED,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == ECONNABORTED,
     "Expected ECONNABORTED (%d), got %s (%d)", ECONNABORTED,
     strerror(errno), errno);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* read ASCII data */
   session.xfer.direction = PR_NETIO_IO_RD;
@@ -995,12 +995,12 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   mark_point();
@@ -1012,14 +1012,14 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless((size_t) res == expected_len, "Expected %lu, got %d",
+  ck_assert_msg((size_t) res == expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
@@ -1031,12 +1031,12 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
-  fail_unless(memcmp(buf, expected, expected_len) == 0,
+  ck_assert_msg(memcmp(buf, expected, expected_len) == 0,
     "Expected '%s', got '%.100s'", expected, buf);
 
   mark_point();
@@ -1050,12 +1050,12 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
-  fail_unless(memcmp(buf, expected, expected_len) == 0,
+  ck_assert_msg(memcmp(buf, expected, expected_len) == 0,
     "Expected '%s', got '%.100s'", expected, buf);
 
   mark_point();
@@ -1069,12 +1069,12 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
-  fail_unless(memcmp(buf, expected, expected_len) == 0,
+  ck_assert_msg(memcmp(buf, expected, expected_len) == 0,
     "Expected '%s', got '%.100s'", expected, buf);
 
   /* Bug#4237 happened because of insufficient testing of the edge case
@@ -1094,12 +1094,12 @@ START_TEST (data_xfer_read_ascii_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 1,
+  ck_assert_msg(session.xfer.buflen == 1,
     "Expected session.xfer.buflen 1, got %lu",
     (unsigned long) session.xfer.buflen);
-  fail_unless(memcmp(buf, expected, expected_len) == 0,
+  ck_assert_msg(memcmp(buf, expected, expected_len) == 0,
     "Expected '%s', got '%.100s'", expected, buf);
 }
 END_TEST
@@ -1117,7 +1117,7 @@ START_TEST (data_xfer_read_ascii_with_abor_test) {
   buf = palloc(p, bufsz);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* read ASCII data */
   session.xfer.direction = PR_NETIO_IO_RD;
@@ -1131,14 +1131,14 @@ START_TEST (data_xfer_read_ascii_with_abor_test) {
   expected_len = strlen(expected);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
@@ -1159,12 +1159,12 @@ START_TEST (data_xfer_read_ascii_with_abor_test) {
   res = pr_data_xfer(buf, bufsz);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
-  fail_unless(memcmp(buf, expected, expected_len) == 0,
+  ck_assert_msg(memcmp(buf, expected, expected_len) == 0,
     "Expected '%s', got '%.100s'", expected, buf);
 }
 END_TEST
@@ -1179,8 +1179,8 @@ START_TEST (data_xfer_write_ascii_test) {
   pr_data_reset();
 
   res = pr_data_xfer(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buf = "Hello,\n World\n";
@@ -1190,19 +1190,19 @@ START_TEST (data_xfer_write_ascii_test) {
   ascii_buflen = strlen(ascii_buf);
 
   res = pr_data_xfer(buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_data_xfer(buf, buflen);
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == ECONNABORTED,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == ECONNABORTED,
     "Expected ECONNABORTED (%d), got %s (%d)", ECONNABORTED,
     strerror(errno), errno);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* write ASCII data */
   session.xfer.direction = PR_NETIO_IO_WR;
@@ -1217,12 +1217,12 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res < 0, "Transferred data unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Transferred data unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   mark_point();
@@ -1231,14 +1231,14 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
@@ -1250,9 +1250,9 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(session.xfer.buflen == ascii_buflen,
+  ck_assert_msg(session.xfer.buflen == ascii_buflen,
     "Expected session.xfer.buflen %lu, got %lu", (unsigned long) ascii_buflen,
     (unsigned long) session.xfer.buflen);
 
@@ -1267,9 +1267,9 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(session.xfer.buflen == ascii_buflen,
+  ck_assert_msg(session.xfer.buflen == ascii_buflen,
     "Expected session.xfer.buflen %lu, got %lu", (unsigned long) ascii_buflen,
     (unsigned long) session.xfer.buflen);
 
@@ -1285,9 +1285,9 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(session.xfer.buflen == ascii_buflen,
+  ck_assert_msg(session.xfer.buflen == ascii_buflen,
     "Expected session.xfer.buflen %lu, got %lu", (unsigned long) ascii_buflen,
     (unsigned long) session.xfer.buflen);
 
@@ -1300,9 +1300,9 @@ START_TEST (data_xfer_write_ascii_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(session.xfer.buflen == ascii_buflen,
+  ck_assert_msg(session.xfer.buflen == ascii_buflen,
     "Expected session.xfer.buflen %lu, got %lu", (unsigned long) ascii_buflen,
     (unsigned long) session.xfer.buflen);
 }
@@ -1324,7 +1324,7 @@ START_TEST (data_xfer_write_ascii_with_abor_test) {
   ascii_buflen = strlen(ascii_buf);
 
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* write ASCII data */
   session.xfer.direction = PR_NETIO_IO_WR;
@@ -1333,14 +1333,14 @@ START_TEST (data_xfer_write_ascii_with_abor_test) {
   session.xfer.buf = pcalloc(p, session.xfer.buflen);
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   mark_point();
@@ -1356,9 +1356,9 @@ START_TEST (data_xfer_write_ascii_with_abor_test) {
   res = pr_data_xfer(buf, buflen);
   session.sf_flags &= ~SF_ASCII_OVERRIDE;
 
-  fail_unless(res == (int) buflen, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  fail_unless(session.xfer.buflen == ascii_buflen,
+  ck_assert_msg(session.xfer.buflen == ascii_buflen,
     "Expected session.xfer.buflen %lu, got %lu", (unsigned long) ascii_buflen,
     (unsigned long) session.xfer.buflen);
 }
@@ -1376,7 +1376,7 @@ START_TEST (data_xfer_peek_nonsocket_test) {
   bufsz = 1024;
   buf = palloc(p, bufsz);
   session.d = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
 
   /* read binary data */
   session.xfer.direction = PR_NETIO_IO_RD;
@@ -1391,14 +1391,14 @@ START_TEST (data_xfer_peek_nonsocket_test) {
   session.xfer.buflen = 0;
 
   res = data_open_streams(session.d, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to open streams on session.d: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.d: %s",
     strerror(errno));
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = data_open_streams(session.c, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to open streams on session.c: %s",
+  ck_assert_msg(res == 0, "Failed to open streams on session.c: %s",
     strerror(errno));
 
   fd = tmpfile_fd();
@@ -1418,9 +1418,9 @@ START_TEST (data_xfer_peek_nonsocket_test) {
   data_write_eagain = TRUE;
 
   res = pr_data_xfer(buf, bufsz);
-  fail_unless(res == (int) expected_len, "Expected %lu, got %d",
+  ck_assert_msg(res == (int) expected_len, "Expected %lu, got %d",
     (unsigned long) expected_len, res);
-  fail_unless(session.xfer.buflen == 0,
+  ck_assert_msg(session.xfer.buflen == 0,
     "Expected session.xfer.buflen 0, got %lu",
     (unsigned long) session.xfer.buflen);
 

--- a/tests/api/display.c
+++ b/tests/api/display.c
@@ -118,33 +118,33 @@ START_TEST (display_file_test) {
   pr_class_t *conn_class;
 
   res = pr_display_file(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = display_test_file;
   res = pr_display_file(path, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null resp_code argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null resp_code argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   resp_code = R_200;
   path = "/";
   res = pr_display_file(path, NULL, resp_code, 0);
-  fail_unless(res < 0, "Failed to handle directory");
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle directory");
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   mark_point();
   path = display_test_file;
   res = pr_display_file(path, NULL, resp_code, 0);
-  fail_unless(res < 0, "Failed to handle nonexistent file");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = write_file(path, display_lines, 4);
-  fail_unless(res == 0, "Failed to write display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write display file: %s", strerror(errno));
 
   pr_response_set_pool(p);
 
@@ -155,37 +155,37 @@ START_TEST (display_file_test) {
 
   mark_point();
   res = pr_display_file(path, NULL, resp_code, 0);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last response values: %s (%d)",
+  ck_assert_msg(res == 0, "Failed to get last response values: %s (%d)",
     strerror(errno), errno);
 
-  fail_unless(last_resp_code != NULL,
+  ck_assert_msg(last_resp_code != NULL,
     "Last response code is unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
 
-  fail_unless(last_resp_msg != NULL,
+  ck_assert_msg(last_resp_msg != NULL,
     "Last response message is unexpectedly null");
 
   /* Send the display file NOW */
   mark_point();
   res = pr_display_file(path, NULL, resp_code, PR_DISPLAY_FL_SEND_NOW);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last response values: %s (%d)",
+  ck_assert_msg(res == 0, "Failed to get last response values: %s (%d)",
     strerror(errno), errno);
 
-  fail_unless(last_resp_code != NULL,
+  ck_assert_msg(last_resp_code != NULL,
     "Last response code is unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
 
-  fail_unless(last_resp_msg != NULL,
+  ck_assert_msg(last_resp_msg != NULL,
     "Last response message is unexpectedly null");
 
   /* Send the display file NOW, with no EOM */
@@ -193,30 +193,30 @@ START_TEST (display_file_test) {
   mark_point();
   res = pr_display_file(path, NULL, resp_code,
     PR_DISPLAY_FL_SEND_NOW|PR_DISPLAY_FL_NO_EOM);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last response values: %s (%d)",
+  ck_assert_msg(res == 0, "Failed to get last response values: %s (%d)",
     strerror(errno), errno);
 
-  fail_unless(last_resp_code != NULL,
+  ck_assert_msg(last_resp_code != NULL,
     "Last response code is unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
 
-  fail_unless(last_resp_msg != NULL,
+  ck_assert_msg(last_resp_msg != NULL,
     "Last response message is unexpectedly null");
 
   /* With MultilineRFC2228 on */
   mark_point();
   res = pr_display_file(path, NULL, resp_code,
     PR_DISPLAY_FL_SEND_NOW|PR_DISPLAY_FL_NO_EOM);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_display_file(path, NULL, resp_code, PR_DISPLAY_FL_SEND_NOW);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   /* With session.auth_mech */
   session.auth_mech = "testsuite";
@@ -224,11 +224,11 @@ START_TEST (display_file_test) {
   mark_point();
   res = pr_display_file(path, NULL, resp_code,
     PR_DISPLAY_FL_SEND_NOW|PR_DISPLAY_FL_NO_EOM);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_display_file(path, NULL, resp_code, PR_DISPLAY_FL_SEND_NOW);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 }
 END_TEST
 
@@ -239,22 +239,22 @@ START_TEST (display_fh_test) {
   const char *last_resp_code = NULL, *last_resp_msg = NULL;
 
   res = pr_display_fh(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(display_test_file);
   res = write_file(display_test_file, display_lines, 4);
-  fail_unless(res == 0, "Failed to write display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write display file: %s", strerror(errno));
 
   path = display_test_file;
   fh = pr_fsio_open(path, O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
 
   mark_point();
   res = pr_display_fh(fh, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null resp_code argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null resp_code argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   resp_code = R_200;
@@ -262,19 +262,19 @@ START_TEST (display_fh_test) {
 
   mark_point();
   res = pr_display_fh(fh, NULL, resp_code, 0);
-  fail_unless(res == 0, "Failed to display file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to display file: %s", strerror(errno));
 
   mark_point();
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last response values: %s (%d)",
+  ck_assert_msg(res == 0, "Failed to get last response values: %s (%d)",
     strerror(errno), errno);
 
-  fail_unless(last_resp_code != NULL,
+  ck_assert_msg(last_resp_code != NULL,
     "Last response code is unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
 
-  fail_unless(last_resp_msg != NULL,
+  ck_assert_msg(last_resp_msg != NULL,
     "Last response message is unexpectedly null");
 }
 END_TEST

--- a/tests/api/encode.c
+++ b/tests/api/encode.c
@@ -66,29 +66,29 @@ START_TEST (encode_encode_str_test) {
 
   mark_point();
   res = pr_encode_str(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_encode_str(p, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null input string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null input string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   in_str = "OK";
   in_len = 2;
   res = pr_encode_str(p, in_str, in_len, NULL);
-  fail_unless(res == NULL, "Failed to handle null output string len");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null output string len");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_encode_str(p, in_str, in_len, &out_len);
-  fail_unless(res != NULL, "Failed to encode '%s': %s", in_str,
+  ck_assert_msg(res != NULL, "Failed to encode '%s': %s", in_str,
     strerror(errno));
-  fail_unless(strcmp(res, in_str) == 0, "Expected '%s', got '%s'", in_str,
+  ck_assert_msg(strcmp(res, in_str) == 0, "Expected '%s', got '%s'", in_str,
     res);
 
   mark_point();
@@ -98,8 +98,8 @@ START_TEST (encode_encode_str_test) {
   in_str = junk;
   in_len = sizeof(junk);
   res = pr_encode_str(p, in_str, in_len, &out_len);
-  fail_unless(res == NULL, "Failed to handle bad input");
-  fail_unless(errno == EILSEQ, "Expected EILSEQ (%d), got %s (%d)", EILSEQ,
+  ck_assert_msg(res == NULL, "Failed to handle bad input");
+  ck_assert_msg(errno == EILSEQ, "Expected EILSEQ (%d), got %s (%d)", EILSEQ,
     strerror(errno), errno);
 }
 END_TEST
@@ -112,29 +112,29 @@ START_TEST (encode_decode_str_test) {
 
   mark_point();
   res = pr_decode_str(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_decode_str(p, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null input string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null input string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   in_str = "OK";
   in_len = 2;
   res = pr_decode_str(p, in_str, in_len, NULL);
-  fail_unless(res == NULL, "Failed to handle null output string len");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null output string len");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_decode_str(p, in_str, in_len, &out_len);
-  fail_unless(res != NULL, "Failed to decode '%s': %s", in_str,
+  ck_assert_msg(res != NULL, "Failed to decode '%s': %s", in_str,
     strerror(errno));
-  fail_unless(strcmp(res, in_str) == 0, "Expected '%s', got '%s'", in_str,
+  ck_assert_msg(strcmp(res, in_str) == 0, "Expected '%s', got '%s'", in_str,
     res);
 
   mark_point();
@@ -144,8 +144,8 @@ START_TEST (encode_decode_str_test) {
   in_str = junk;
   in_len = sizeof(junk);
   res = pr_decode_str(p, in_str, in_len, &out_len);
-  fail_unless(res == NULL, "Failed to handle bad input");
-  fail_unless(errno == EILSEQ, "Expected EILSEQ (%d), got %s (%d)", EILSEQ,
+  ck_assert_msg(res == NULL, "Failed to handle bad input");
+  ck_assert_msg(errno == EILSEQ, "Expected EILSEQ (%d), got %s (%d)", EILSEQ,
     strerror(errno), errno);
 }
 END_TEST
@@ -155,53 +155,53 @@ START_TEST (encode_charset_test) {
   const char *charset, *encoding;
 
   charset = pr_encode_get_charset();
-  fail_unless(charset != NULL, "Failed to get current charset: %s",
+  ck_assert_msg(charset != NULL, "Failed to get current charset: %s",
     strerror(errno));
 
   res = pr_encode_is_utf8(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   charset = "utf8";
   res = pr_encode_is_utf8(charset);
-  fail_unless(res == TRUE, "Expected TRUE for '%s', got %d", charset, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE for '%s', got %d", charset, res);
 
   charset = "utf-8";
   res = pr_encode_is_utf8(charset);
-  fail_unless(res == TRUE, "Expected TRUE for '%s', got %d", charset, res);
+  ck_assert_msg(res == TRUE, "Expected TRUE for '%s', got %d", charset, res);
 
   charset = "ascii";
   res = pr_encode_is_utf8(charset);
-  fail_unless(res == FALSE, "Expected FALSE for '%s', got %d", charset, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE for '%s', got %d", charset, res);
 
   res = pr_encode_set_charset_encoding(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   charset = "us-ascii";
   res = pr_encode_set_charset_encoding(charset, NULL);
-  fail_unless(res < 0, "Failed to handle null encoding");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null encoding");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   encoding = "utf-8";
   res = pr_encode_set_charset_encoding(charset, encoding);
-  fail_unless(res == 0, "Failed to set charset '%s', encoding '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set charset '%s', encoding '%s': %s",
     charset, encoding, strerror(errno));
 
   charset = "foo";
   res = pr_encode_set_charset_encoding(charset, encoding);
-  fail_unless(res < 0, "Failed to handle bad charset '%s'", charset);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad charset '%s'", charset);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   charset = "us-ascii";
   encoding = "foo";
   res = pr_encode_set_charset_encoding(charset, encoding);
-  fail_unless(res < 0, "Failed to handle bad encoding '%s'", encoding);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad encoding '%s'", encoding);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -211,36 +211,36 @@ START_TEST (encode_encoding_test) {
   const char *encoding;
 
   res = pr_encode_enable_encoding(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   encoding = "utf-8";
   res = pr_encode_enable_encoding(encoding);
-  fail_unless(res == 0, "Failed to enable encoding '%s': %s", encoding,
+  ck_assert_msg(res == 0, "Failed to enable encoding '%s': %s", encoding,
     strerror(errno));
 
   encoding = "iso-8859-1";
   res = pr_encode_enable_encoding(encoding);
-  fail_unless(res == 0, "Failed to enable encoding '%s': %s", encoding,
+  ck_assert_msg(res == 0, "Failed to enable encoding '%s': %s", encoding,
     strerror(errno));
 
   encoding = "foo";
   res = pr_encode_enable_encoding(encoding);
-  fail_unless(res < 0, "Failed to handle bad encoding '%s'", encoding);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad encoding '%s'", encoding);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_encode_disable_encoding();
 
   encoding = "utf-8";
   res = pr_encode_enable_encoding(encoding);
-  fail_unless(res == 0, "Failed to enable encoding '%s': %s", encoding,
+  ck_assert_msg(res == 0, "Failed to enable encoding '%s': %s", encoding,
     strerror(errno));
 
   encoding = pr_encode_get_encoding();
-  fail_unless(encoding != NULL, "Failed to get encoding: %s", strerror(errno));
-  fail_unless(strcasecmp(encoding, "utf-8") == 0,
+  ck_assert_msg(encoding != NULL, "Failed to get encoding: %s", strerror(errno));
+  ck_assert_msg(strcasecmp(encoding, "utf-8") == 0,
     "Expected 'utf-8', got '%s'", encoding);
 }
 END_TEST
@@ -249,13 +249,13 @@ START_TEST (encode_policy_test) {
   unsigned long res;
 
   res = pr_encode_get_policy();
-  fail_unless(res == 0, "Expected policy 0, got %lu", res);
+  ck_assert_msg(res == 0, "Expected policy 0, got %lu", res);
 
   res = pr_encode_set_policy(7);
-  fail_unless(res == 0, "Expected policy 0, got %lu", res);
+  ck_assert_msg(res == 0, "Expected policy 0, got %lu", res);
 
   res = pr_encode_get_policy();
-  fail_unless(res == 7, "Expected policy 7, got %lu", res);
+  ck_assert_msg(res == 7, "Expected policy 7, got %lu", res);
 
   (void) pr_encode_set_policy(0);
 }
@@ -275,7 +275,7 @@ START_TEST (encode_supports_telnet_iac_test) {
   };
 
   res = pr_encode_supports_telnet_iac();
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   charset = "us-ascii";
 
@@ -283,16 +283,16 @@ START_TEST (encode_supports_telnet_iac_test) {
     encoding = non_iac_encodings[i];
 
     res = pr_encode_set_charset_encoding(charset, encoding);
-    fail_unless(res == 0, "Failed to set charset '%s', encoding '%s': %s",
+    ck_assert_msg(res == 0, "Failed to set charset '%s', encoding '%s': %s",
       charset, encoding, strerror(errno));
 
     res = pr_encode_supports_telnet_iac();
-    fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+    ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
   }
 
   encoding = "utf-8";
   res = pr_encode_set_charset_encoding(charset, encoding);
-  fail_unless(res == 0, "Failed to set charset '%s', encoding '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set charset '%s', encoding '%s': %s",
     charset, encoding, strerror(errno));
 }
 END_TEST

--- a/tests/api/env.c
+++ b/tests/api/env.c
@@ -46,33 +46,33 @@ START_TEST (env_get_test) {
   char *res;
 
   res = pr_env_get(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_get(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_get(NULL, key);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
 #if defined(HAVE_GETENV)
   pr_env_unset(p, key);
 
   res = pr_env_get(p, key);
-  fail_unless(res == NULL, "Unexpectedly found value '%s' for key '%s'",
+  ck_assert_msg(res == NULL, "Unexpectedly found value '%s' for key '%s'",
     res, key);
 
   /* XXX PATH should always be set in the environment, right? */
   res = pr_env_get(p, "PATH");
-  fail_unless(res != NULL, "Failed to get value for 'PATH': %s",
+  ck_assert_msg(res != NULL, "Failed to get value for 'PATH': %s",
     strerror(errno));
 
 #else
   res = pr_env_get(p, key);
-  fail_unless(errno == ENOSYS, "Failed to set errno to ENOSYS");
-  fail_unless(res == NULL);
+  ck_assert_msg(errno == ENOSYS, "Failed to set errno to ENOSYS");
+  ck_assert_msg(res == NULL);
 #endif
 }
 END_TEST
@@ -83,38 +83,38 @@ START_TEST (env_set_test) {
   int res;
  
   res = pr_env_set(NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(p, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(NULL, key, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(NULL, NULL, value);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(p, key, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(p, NULL, value);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(NULL, key, value);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(p, key, value);
-  fail_unless(res == 0, "Failed to handle set '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle set '%s': %s", key, strerror(errno));
 
   v = pr_env_get(p, key);
-  fail_unless(strcmp(v, value) == 0, "Expected '%s', got '%s'", value, v);
+  ck_assert_msg(strcmp(v, value) == 0, "Expected '%s', got '%s'", value, v);
 }
 END_TEST
 
@@ -124,33 +124,33 @@ START_TEST (env_unset_test) {
   int res;
 
   res = pr_env_unset(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_unset(p, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_unset(NULL, key);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_env_set(p, key, value);
-  fail_unless(res == 0, "Failed to set '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set '%s': %s", key, strerror(errno));
 
   v = pr_env_get(p, key);
-  fail_unless(strcmp(v, value) == 0, "Expected '%s', got '%s'", value, v);
+  ck_assert_msg(strcmp(v, value) == 0, "Expected '%s', got '%s'", value, v);
 
 #if defined(HAVE_UNSETENV)
   res = pr_env_unset(p, key);
-  fail_unless(res == 0, "Failed to unset '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unset '%s': %s", key, strerror(errno));
 
   v = pr_env_get(p, key);
-  fail_unless(v == NULL, "Expected null, got '%s'", v);
+  ck_assert_msg(v == NULL, "Expected null, got '%s'", v);
 #else
   res = pr_env_unset(p, key);
-  fail_unless(errno == ENOSYS, "Failed to set errno to ENOSYS");
-  fail_unless(res == -1);
+  ck_assert_msg(errno == ENOSYS, "Failed to set errno to ENOSYS");
+  ck_assert_msg(res == -1);
 #endif
 }
 END_TEST

--- a/tests/api/error.c
+++ b/tests/api/error.c
@@ -75,17 +75,17 @@ START_TEST (error_create_test) {
   pr_error_t *err;
 
   err = pr_error_create(NULL, 0);
-  fail_unless(err == NULL, "Failed handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(err == NULL, "Failed handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   err = pr_error_create(p, -1);
-  fail_unless(err == NULL, "Failed handle negative errno");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(err == NULL, "Failed handle negative errno");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   err = pr_error_create(p, 0);
-  fail_unless(err != NULL, "Failed allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed allocate error: %s", strerror(errno));
   pr_error_destroy(err);
 }
 END_TEST
@@ -95,14 +95,14 @@ START_TEST (error_destroy_test) {
   int xerrno = 77;
 
   err = pr_error_create(p, 0);
-  fail_unless(err != NULL, "Failed allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed allocate error: %s", strerror(errno));
 
   /* Make sure that pr_error_destroy() preserves the existing errno value. */
   errno = xerrno;
   pr_error_destroy(NULL);
   pr_error_destroy(err);
 
-  fail_unless(errno == xerrno, "Expected errno %d, got %d", xerrno, errno);
+  ck_assert_msg(errno == xerrno, "Expected errno %d, got %d", xerrno, errno);
 }
 END_TEST
 
@@ -116,38 +116,38 @@ START_TEST (error_get_who_test) {
   gid = getegid();
 
   res = pr_error_get_who(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EACCES;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_get_who(err, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null uid_t pointer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null uid_t pointer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_error_get_who(err, &err_uid, NULL);
-  fail_unless(res == 0, "Failed to get error identity: %s", strerror(errno));
-  fail_unless(err_uid == uid, "Expected %lu, got %lu", (unsigned long) uid,
+  ck_assert_msg(res == 0, "Failed to get error identity: %s", strerror(errno));
+  ck_assert_msg(err_uid == uid, "Expected %lu, got %lu", (unsigned long) uid,
     (unsigned long) err_uid);
 
   err_uid = -1;
 
   res = pr_error_get_who(err, NULL, &err_gid);
-  fail_unless(res == 0, "Failed to get error identity: %s", strerror(errno));
-  fail_unless(err_gid == gid, "Expected %lu, got %lu", (unsigned long) gid,
+  ck_assert_msg(res == 0, "Failed to get error identity: %s", strerror(errno));
+  ck_assert_msg(err_gid == gid, "Expected %lu, got %lu", (unsigned long) gid,
     (unsigned long) err_gid);
 
   err_gid = -1;
 
   res = pr_error_get_who(err, &err_uid, &err_gid);
-  fail_unless(res == 0, "Failed to get error identity: %s", strerror(errno));
-  fail_unless(err_uid == uid, "Expected %lu, got %lu", (unsigned long) uid,
+  ck_assert_msg(res == 0, "Failed to get error identity: %s", strerror(errno));
+  ck_assert_msg(err_uid == uid, "Expected %lu, got %lu", (unsigned long) uid,
     (unsigned long) err_uid);
-  fail_unless(err_gid == gid, "Expected %lu, got %lu", (unsigned long) gid,
+  ck_assert_msg(err_gid == gid, "Expected %lu, got %lu", (unsigned long) gid,
     (unsigned long) err_gid);
 
   pr_error_destroy(err);
@@ -160,20 +160,20 @@ START_TEST (error_set_why_test) {
 
   mark_point();
   res = pr_error_set_why(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   err = pr_error_create(p, 1);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_set_why(err, NULL);
-  fail_unless(res < 0, "Failed to handle null why");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null why");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_error_set_why(err, "because I wanted to");
-  fail_unless(res == 0, "Failed to set why: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set why: %s", strerror(errno));
 
   pr_error_destroy(err);
 }
@@ -185,15 +185,15 @@ START_TEST (error_set_where_test) {
 
   mark_point();
   res = pr_error_set_where(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   err = pr_error_create(p, 1);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_set_where(err, NULL, NULL, 0);
-  fail_unless(res == 0, "Failed to set where: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set where: %s", strerror(errno));
 
   pr_error_destroy(err);
 }
@@ -205,20 +205,20 @@ START_TEST (error_set_what_test) {
 
   mark_point();
   res = pr_error_set_what(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   err = pr_error_create(p, 1);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_set_what(err, NULL);
-  fail_unless(res < 0, "Failed to handle null what");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null what");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_error_set_what(err, "testing");
-  fail_unless(res == 0, "Failed to set what: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set what: %s", strerror(errno));
 
   pr_error_destroy(err);
 }
@@ -234,105 +234,105 @@ START_TEST (error_explainer_test) {
 
   mark_point();
   res = pr_error_unregister_explainer(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "testing";
   res = pr_error_unregister_explainer(p, NULL, name);
-  fail_unless(res < 0, "Failed to handle no registered explainers");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no registered explainers");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
 
   res = pr_error_unregister_explainer(p, &m, NULL);
-  fail_unless(res < 0, "Failed to handle no registered explainers");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no registered explainers");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res < 0, "Failed to handle no registered explainers");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no registered explainers");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_error_use_explainer(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle no registered explainers");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle no registered explainers");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   explainer = pr_error_register_explainer(NULL, NULL, NULL);
-  fail_unless(explainer == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(explainer == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   explainer = pr_error_register_explainer(p, NULL, NULL);
-  fail_unless(explainer == NULL, "Failed to handle null name argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(explainer == NULL, "Failed to handle null name argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer == NULL, "Failed to handle duplicate registration");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(explainer == NULL, "Failed to handle duplicate registration");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to handle unregister '%s' explainer: %s",
+  ck_assert_msg(res == 0, "Failed to handle unregister '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res < 0, "Failed to handle no registered explainers");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no registered explainers");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_unregister_explainer(p, NULL, name);
-  fail_unless(res == 0, "Failed to handle unregister '%s' explainer: %s",
+  ck_assert_msg(res == 0, "Failed to handle unregister '%s' explainer: %s",
     name, strerror(errno));
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, NULL);
-  fail_unless(res == 0, "Failed to handle unregister module explainer: %s",
+  ck_assert_msg(res == 0, "Failed to handle unregister module explainer: %s",
     strerror(errno));
 
   /* Selecting the explainer to use. */
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_use_explainer(p, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null name argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_error_use_explainer(p, &m, "foobar");
-  fail_unless(res < 0, "Used 'foobar' explainer unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Used 'foobar' explainer unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_error_use_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to use '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to use '%s' explainer: %s", name,
     strerror(errno));
 
   /* Use already-selected explainers */
   res = pr_error_use_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to use '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to use '%s' explainer: %s", name,
     strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to handle unregister module explainer: %s",
+  ck_assert_msg(res == 0, "Failed to handle unregister module explainer: %s",
     strerror(errno));
 }
 END_TEST
@@ -347,44 +347,44 @@ START_TEST (error_strerror_minimal_test) {
   xerrno = errno = ENOENT;
   expected = strerror(xerrno);
   res = pr_error_strerror(NULL, format);
-  fail_unless(res != NULL, "Failed to handle null error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_strerror(err, -1);
-  fail_unless(res != NULL, "Failed to handle invalid format: %s",
+  ck_assert_msg(res != NULL, "Failed to handle invalid format: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = pstrcat(p, "No such file or directory [ENOENT (",
     get_errnum(p, xerrno), ")]", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_use_formats(format);
   expected = pstrcat(p, "No such file or directory [ENOENT (",
     get_errnum(p, xerrno), ")]", NULL);
   res = pr_error_strerror(err, 0);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
   xerrno = 0;
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   expected = "Success [EOK (0)]";
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
@@ -393,20 +393,20 @@ START_TEST (error_strerror_minimal_test) {
   xerrno = INT_MAX - 786;
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   expected = pstrcat(p, strerror(xerrno), " [<unknown/unsupported error> (",
     get_errnum(p, xerrno), ")]", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
   xerrno = ENOSYS;
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   what = "test";
   pr_error_set_what(err, what);
@@ -414,14 +414,14 @@ START_TEST (error_strerror_minimal_test) {
   expected = pstrcat(p, what, " failed with \"", strerror(xerrno), " [ENOSYS (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   what = "test2";
   pr_error_set_what(err, what);
@@ -429,8 +429,8 @@ START_TEST (error_strerror_minimal_test) {
   expected = pstrcat(p, what, " failed with \"", strerror(xerrno),
     " [ENOSYS (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
@@ -448,29 +448,29 @@ START_TEST (error_strerror_terse_test) {
   xerrno = errno = ENOENT;
   expected = strerror(xerrno);
   res = pr_error_strerror(NULL, format);
-  fail_unless(res != NULL, "Failed to handle null error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_strerror(err, -1);
-  fail_unless(res != NULL, "Failed to handle invalid format: %s",
+  ck_assert_msg(res != NULL, "Failed to handle invalid format: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = pstrdup(p, "No such file or directory");
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   what = "test2";
   pr_error_set_what(err, what);
@@ -478,8 +478,8 @@ START_TEST (error_strerror_terse_test) {
   expected = pstrcat(p, what, " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
@@ -497,17 +497,17 @@ START_TEST (error_strerror_detailed_test) {
   xerrno = errno = ENOENT;
   expected = strerror(xerrno);
   res = pr_error_strerror(NULL, format);
-  fail_unless(res != NULL, "Failed to handle null error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_strerror(err, -1);
-  fail_unless(res != NULL, "Failed to handle invalid format: %s",
+  ck_assert_msg(res != NULL, "Failed to handle invalid format: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* no what */
@@ -515,31 +515,31 @@ START_TEST (error_strerror_detailed_test) {
     " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Exercise the "lineno = 0" code path. */
   res2 = pr_error_set_where(err, NULL, __FILE__, 0);
-  fail_unless(res2 == 0, "Failed to set error where: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set error where: %s", strerror(errno));
 
   expected = pstrcat(p, "in API [api/error.c], UID ", get_uid(p),
     ", GID ", get_gid(p), " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   res2 = pr_error_set_where(err, NULL, __FILE__, __LINE__);
-  fail_unless(res2 == 0, "Failed to set error where: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set error where: %s", strerror(errno));
 
   expected = pstrcat(p, "in API [api/error.c:534], UID ", get_uid(p),
     ", GID ", get_gid(p), " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Disable use of the module name. */
@@ -551,8 +551,8 @@ START_TEST (error_strerror_detailed_test) {
     get_gid(p), " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Disable use of the file location. */
@@ -564,21 +564,21 @@ START_TEST (error_strerror_detailed_test) {
    */
   expected = strerror(xerrno);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   what = "test";
   res2 = pr_error_set_what(err, what);
-  fail_unless(res2 == 0, "Failed to set what '%s': %s", what,
+  ck_assert_msg(res2 == 0, "Failed to set what '%s': %s", what,
     strerror(errno));
 
   expected = pstrcat(p, "UID ", get_uid(p), ", GID ", get_gid(p),
     " attempting to ", what, " failed with \"", strerror(xerrno), " [ENOENT (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   session.user = "foo";
@@ -588,7 +588,7 @@ START_TEST (error_strerror_detailed_test) {
    */
   pr_error_destroy(err);
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   (void) pr_error_set_where(err, NULL, __FILE__, __LINE__);
   (void) pr_error_set_what(err, what);
@@ -598,8 +598,8 @@ START_TEST (error_strerror_detailed_test) {
     " failed with \"No such file or directory [ENOENT (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Disable use of names. */
@@ -612,8 +612,8 @@ START_TEST (error_strerror_detailed_test) {
     " failed with \"", strerror(xerrno), " [ENOENT (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Enable use of names, disable use of IDs. */
@@ -625,8 +625,8 @@ START_TEST (error_strerror_detailed_test) {
     " via ftp attempting to ", what, " failed with \"", strerror(xerrno),
     " [ENOENT (", get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Enable use of IDs, disable use of protocol. */
@@ -639,8 +639,8 @@ START_TEST (error_strerror_detailed_test) {
     " failed with \"", strerror(xerrno), " [ENOENT (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, format);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Enable everything */
@@ -649,15 +649,15 @@ START_TEST (error_strerror_detailed_test) {
 
   why = "test a function";
   res2 = pr_error_set_why(err, why);
-  fail_unless(res2 == 0, "Failed to set why: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set why: %s", strerror(errno));
 
   expected = pstrcat(p, "in API [api/error.c:593], user ", session.user,
     " (UID ", get_uid(p), ", GID ", get_gid(p), ") via ftp wanted to ", why,
     " but ", what, " failed with \"", strerror(xerrno), " [ENOENT (",
     get_errnum(p, xerrno), ")]\"", NULL);
   res = pr_error_strerror(err, 0);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   pr_error_destroy(err);
@@ -683,27 +683,27 @@ START_TEST (error_strerror_detailed_explained_test) {
 
   xerrno = ENOENT;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   what = "test";
   res2 = pr_error_set_what(err, what);
-  fail_unless(res2 == 0, "Failed to set what: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set what: %s", strerror(errno));
 
   why = "demonstrate an error explanation";
   res2 = pr_error_set_why(err, why);
-  fail_unless(res2 == 0, "Failed to set why: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set why: %s", strerror(errno));
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
 
   res2 = pr_error_set_where(err, &m, __FILE__, __LINE__);
-  fail_unless(res2 == 0, "Failed to set where: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to set where: %s", strerror(errno));
 
   explainer = pr_error_register_explainer(p, &m, "error");
   explainer->explain_open = test_explainer;
 
   res2 = pr_error_explain_open(err, "path", O_RDONLY, 0755);
-  fail_unless(res2 == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res2 == 0, "Failed to explain error: %s", strerror(errno));
 
   expected = pstrcat(p, "in mod_", m.name, " [api/error.c:699], user ",
     session.user, " (UID ", get_uid(p), ", GID ",
@@ -712,8 +712,8 @@ START_TEST (error_strerror_detailed_explained_test) {
     "failed with \"", strerror(xerrno), " [ENOENT (", get_errnum(p, xerrno),
     ")]\" because test mode is not real", NULL);
   res = pr_error_strerror(err, 0);
-  fail_unless(res != NULL, "Failed to format error: %s", strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to format error: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -743,17 +743,17 @@ START_TEST (error_explain_accept_test) {
   const char *name;
 
   res = pr_error_explain_accept(NULL, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_accept(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null explainer");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle null explainer");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -761,28 +761,28 @@ START_TEST (error_explain_accept_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_accept(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_accept = test_explain_accept;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_accept(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_accept(err, -1, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -809,17 +809,17 @@ START_TEST (error_explain_bind_test) {
   const char *name;
 
   res = pr_error_explain_bind(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_bind(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -827,28 +827,28 @@ START_TEST (error_explain_bind_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_bind(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_bind = test_explain_bind;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_bind(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_bind(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -875,17 +875,17 @@ START_TEST (error_explain_chdir_test) {
   const char *name;
 
   res = pr_error_explain_chdir(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_chdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -893,28 +893,28 @@ START_TEST (error_explain_chdir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_chdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_chdir = test_explain_chdir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_chdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_chdir(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -941,17 +941,17 @@ START_TEST (error_explain_chmod_test) {
   const char *name;
 
   res = pr_error_explain_chmod(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_chmod(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -959,28 +959,28 @@ START_TEST (error_explain_chmod_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_chmod(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_chmod = test_explain_chmod;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_chmod(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_chmod(err, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1007,17 +1007,17 @@ START_TEST (error_explain_chown_test) {
   const char *name;
 
   res = pr_error_explain_chown(NULL, NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_chown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1025,28 +1025,28 @@ START_TEST (error_explain_chown_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_chown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_chown = test_explain_chown;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_chown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_chown(err, NULL, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1073,17 +1073,17 @@ START_TEST (error_explain_chroot_test) {
   const char *name;
 
   res = pr_error_explain_chroot(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_chroot(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1091,28 +1091,28 @@ START_TEST (error_explain_chroot_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_chroot(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_chroot = test_explain_chroot;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_chroot(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_chroot(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1139,17 +1139,17 @@ START_TEST (error_explain_close_test) {
   const char *name;
 
   res = pr_error_explain_close(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_close(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1157,28 +1157,28 @@ START_TEST (error_explain_close_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_close(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_close = test_explain_close;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_close(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_close(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1205,17 +1205,17 @@ START_TEST (error_explain_closedir_test) {
   const char *name;
 
   res = pr_error_explain_closedir(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_closedir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1223,28 +1223,28 @@ START_TEST (error_explain_closedir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_closedir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_closedir = test_explain_closedir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_closedir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_closedir(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1271,17 +1271,17 @@ START_TEST (error_explain_connect_test) {
   const char *name;
 
   res = pr_error_explain_connect(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_connect(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1289,28 +1289,28 @@ START_TEST (error_explain_connect_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_connect(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_connect = test_explain_connect;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_connect(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_connect(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1337,17 +1337,17 @@ START_TEST (error_explain_fchmod_test) {
   const char *name;
 
   res = pr_error_explain_fchmod(NULL, -1, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fchmod(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1355,28 +1355,28 @@ START_TEST (error_explain_fchmod_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fchmod(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fchmod = test_explain_fchmod;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fchmod(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fchmod(err, -1, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1403,17 +1403,17 @@ START_TEST (error_explain_fchown_test) {
   const char *name;
 
   res = pr_error_explain_fchown(NULL, -1, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fchown(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1421,28 +1421,28 @@ START_TEST (error_explain_fchown_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fchown(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fchown = test_explain_fchown;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fchown(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fchown(err, -1, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1469,17 +1469,17 @@ START_TEST (error_explain_fclose_test) {
   const char *name;
 
   res = pr_error_explain_fclose(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fclose(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1487,28 +1487,28 @@ START_TEST (error_explain_fclose_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fclose(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fclose = test_explain_fclose;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fclose(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fclose(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1535,17 +1535,17 @@ START_TEST (error_explain_fcntl_test) {
   const char *name;
 
   res = pr_error_explain_fcntl(NULL, -1, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fcntl(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1553,28 +1553,28 @@ START_TEST (error_explain_fcntl_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fcntl(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fcntl = test_explain_fcntl;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fcntl(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fcntl(err, -1, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1601,17 +1601,17 @@ START_TEST (error_explain_fdopen_test) {
   const char *name;
 
   res = pr_error_explain_fdopen(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fdopen(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1619,28 +1619,28 @@ START_TEST (error_explain_fdopen_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fdopen(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fdopen = test_explain_fdopen;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fdopen(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fdopen(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1667,17 +1667,17 @@ START_TEST (error_explain_flock_test) {
   const char *name;
 
   res = pr_error_explain_flock(NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_flock(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1685,28 +1685,28 @@ START_TEST (error_explain_flock_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_flock(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_flock = test_explain_flock;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_flock(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_flock(err, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1733,17 +1733,17 @@ START_TEST (error_explain_fopen_test) {
   const char *name;
 
   res = pr_error_explain_fopen(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fopen(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1751,28 +1751,28 @@ START_TEST (error_explain_fopen_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fopen(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fopen = test_explain_fopen;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fopen(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fopen(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1799,17 +1799,17 @@ START_TEST (error_explain_fork_test) {
   const char *name;
 
   res = pr_error_explain_fork(NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fork(err);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1817,28 +1817,28 @@ START_TEST (error_explain_fork_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fork(err);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fork = test_explain_fork;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fork(err);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fork(err);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1865,17 +1865,17 @@ START_TEST (error_explain_fstat_test) {
   const char *name;
 
   res = pr_error_explain_fstat(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fstat(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1883,28 +1883,28 @@ START_TEST (error_explain_fstat_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fstat(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fstat = test_explain_fstat;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fstat(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fstat(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1931,17 +1931,17 @@ START_TEST (error_explain_fstatfs_test) {
   const char *name;
 
   res = pr_error_explain_fstatfs(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fstatfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -1949,28 +1949,28 @@ START_TEST (error_explain_fstatfs_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fstatfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fstatfs = test_explain_fstatfs;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fstatfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fstatfs(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -1997,17 +1997,17 @@ START_TEST (error_explain_fstatvfs_test) {
   const char *name;
 
   res = pr_error_explain_fstatvfs(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fstatvfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2015,28 +2015,28 @@ START_TEST (error_explain_fstatvfs_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fstatvfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fstatvfs = test_explain_fstatvfs;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fstatvfs(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fstatvfs(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2063,17 +2063,17 @@ START_TEST (error_explain_fsync_test) {
   const char *name;
 
   res = pr_error_explain_fsync(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_fsync(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2081,28 +2081,28 @@ START_TEST (error_explain_fsync_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_fsync(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_fsync = test_explain_fsync;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_fsync(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_fsync(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2129,17 +2129,17 @@ START_TEST (error_explain_ftruncate_test) {
   const char *name;
 
   res = pr_error_explain_ftruncate(NULL, -1, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_ftruncate(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2147,28 +2147,28 @@ START_TEST (error_explain_ftruncate_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_ftruncate(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_ftruncate = test_explain_ftruncate;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_ftruncate(err, -1, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_ftruncate(err, -1, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2195,17 +2195,17 @@ START_TEST (error_explain_futimes_test) {
   const char *name;
 
   res = pr_error_explain_futimes(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_futimes(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2213,28 +2213,28 @@ START_TEST (error_explain_futimes_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_futimes(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_futimes = test_explain_futimes;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_futimes(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_futimes(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2262,17 +2262,17 @@ START_TEST (error_explain_getaddrinfo_test) {
   const char *name;
 
   res = pr_error_explain_getaddrinfo(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getaddrinfo(err, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2280,28 +2280,28 @@ START_TEST (error_explain_getaddrinfo_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getaddrinfo(err, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getaddrinfo = test_explain_getaddrinfo;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getaddrinfo(err, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getaddrinfo(err, NULL, NULL, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2328,17 +2328,17 @@ START_TEST (error_explain_gethostbyname_test) {
   const char *name;
 
   res = pr_error_explain_gethostbyname(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_gethostbyname(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2346,28 +2346,28 @@ START_TEST (error_explain_gethostbyname_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_gethostbyname(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_gethostbyname = test_explain_gethostbyname;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_gethostbyname(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_gethostbyname(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2394,17 +2394,17 @@ START_TEST (error_explain_gethostbyname2_test) {
   const char *name;
 
   res = pr_error_explain_gethostbyname2(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_gethostbyname2(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2412,28 +2412,28 @@ START_TEST (error_explain_gethostbyname2_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_gethostbyname2(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_gethostbyname2 = test_explain_gethostbyname2;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_gethostbyname2(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_gethostbyname2(err, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2460,17 +2460,17 @@ START_TEST (error_explain_gethostname_test) {
   const char *name;
 
   res = pr_error_explain_gethostname(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_gethostname(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2478,28 +2478,28 @@ START_TEST (error_explain_gethostname_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_gethostname(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_gethostname = test_explain_gethostname;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_gethostname(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_gethostname(err, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2528,17 +2528,17 @@ START_TEST (error_explain_getnameinfo_test) {
   const char *name;
 
   res = pr_error_explain_getnameinfo(NULL, NULL, 0, NULL, 0, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getnameinfo(err, NULL, 0, NULL, 0, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2546,28 +2546,28 @@ START_TEST (error_explain_getnameinfo_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getnameinfo(err, NULL, 0, NULL, 0, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getnameinfo = test_explain_getnameinfo;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getnameinfo(err, NULL, 0, NULL, 0, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getnameinfo(err, NULL, 0, NULL, 0, NULL, 0, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2594,17 +2594,17 @@ START_TEST (error_explain_getpeername_test) {
   const char *name;
 
   res = pr_error_explain_getpeername(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getpeername(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2612,28 +2612,28 @@ START_TEST (error_explain_getpeername_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getpeername(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getpeername = test_explain_getpeername;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getpeername(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getpeername(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2660,17 +2660,17 @@ START_TEST (error_explain_getrlimit_test) {
   const char *name;
 
   res = pr_error_explain_getrlimit(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2678,28 +2678,28 @@ START_TEST (error_explain_getrlimit_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getrlimit = test_explain_getrlimit;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getrlimit(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2726,17 +2726,17 @@ START_TEST (error_explain_getsockname_test) {
   const char *name;
 
   res = pr_error_explain_getsockname(NULL, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getsockname(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2744,28 +2744,28 @@ START_TEST (error_explain_getsockname_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getsockname(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getsockname = test_explain_getsockname;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getsockname(err, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getsockname(err, -1, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2793,17 +2793,17 @@ START_TEST (error_explain_getsockopt_test) {
   const char *name;
 
   res = pr_error_explain_getsockopt(NULL, -1, -1, -1, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_getsockopt(err, -1, -1, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2811,28 +2811,28 @@ START_TEST (error_explain_getsockopt_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_getsockopt(err, -1, -1, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_getsockopt = test_explain_getsockopt;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_getsockopt(err, -1, -1, -1, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_getsockopt(err, -1, -1, -1, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2859,17 +2859,17 @@ START_TEST (error_explain_lchown_test) {
   const char *name;
 
   res = pr_error_explain_lchown(NULL, NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_lchown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2877,28 +2877,28 @@ START_TEST (error_explain_lchown_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_lchown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_lchown = test_explain_lchown;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_lchown(err, NULL, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_lchown(err, NULL, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2925,17 +2925,17 @@ START_TEST (error_explain_link_test) {
   const char *name;
 
   res = pr_error_explain_link(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_link(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -2943,28 +2943,28 @@ START_TEST (error_explain_link_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_link(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_link = test_explain_link;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_link(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_link(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -2991,17 +2991,17 @@ START_TEST (error_explain_listen_test) {
   const char *name;
 
   res = pr_error_explain_listen(NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_listen(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3009,28 +3009,28 @@ START_TEST (error_explain_listen_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_listen(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_listen = test_explain_listen;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_listen(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_listen(err, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3057,17 +3057,17 @@ START_TEST (error_explain_lseek_test) {
   const char *name;
 
   res = pr_error_explain_lseek(NULL, -1, 0, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_lseek(err, -1, 0, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3075,28 +3075,28 @@ START_TEST (error_explain_lseek_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_lseek(err, -1, 0, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_lseek = test_explain_lseek;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_lseek(err, -1, 0, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_lseek(err, -1, 0, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3123,17 +3123,17 @@ START_TEST (error_explain_lstat_test) {
   const char *name;
 
   res = pr_error_explain_lstat(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_lstat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3141,28 +3141,28 @@ START_TEST (error_explain_lstat_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_lstat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_lstat = test_explain_lstat;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_lstat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_lstat(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3189,17 +3189,17 @@ START_TEST (error_explain_mkdir_test) {
   const char *name;
 
   res = pr_error_explain_mkdir(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_mkdir(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3207,28 +3207,28 @@ START_TEST (error_explain_mkdir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_mkdir(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_mkdir = test_explain_mkdir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_mkdir(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_mkdir(err, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3255,17 +3255,17 @@ START_TEST (error_explain_mkdtemp_test) {
   const char *name;
 
   res = pr_error_explain_mkdtemp(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_mkdtemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3273,28 +3273,28 @@ START_TEST (error_explain_mkdtemp_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_mkdtemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_mkdtemp = test_explain_mkdtemp;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_mkdtemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_mkdtemp(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3321,17 +3321,17 @@ START_TEST (error_explain_mkstemp_test) {
   const char *name;
 
   res = pr_error_explain_mkstemp(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_mkstemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3339,28 +3339,28 @@ START_TEST (error_explain_mkstemp_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_mkstemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_mkstemp = test_explain_mkstemp;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_mkstemp(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_mkstemp(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3387,17 +3387,17 @@ START_TEST (error_explain_open_test) {
   const char *name;
 
   res = pr_error_explain_open(NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_open(err, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3405,28 +3405,28 @@ START_TEST (error_explain_open_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_open(err, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_open = test_explain_open;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_open(err, NULL, 0, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_open(err, NULL, 0, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3453,17 +3453,17 @@ START_TEST (error_explain_opendir_test) {
   const char *name;
 
   res = pr_error_explain_opendir(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_opendir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3471,28 +3471,28 @@ START_TEST (error_explain_opendir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_opendir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_opendir = test_explain_opendir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_opendir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_opendir(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3519,17 +3519,17 @@ START_TEST (error_explain_read_test) {
   const char *name;
 
   res = pr_error_explain_read(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_read(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3537,28 +3537,28 @@ START_TEST (error_explain_read_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_read(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_read = test_explain_read;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_read(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_read(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3585,17 +3585,17 @@ START_TEST (error_explain_readdir_test) {
   const char *name;
 
   res = pr_error_explain_readdir(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_readdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3603,28 +3603,28 @@ START_TEST (error_explain_readdir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_readdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_readdir = test_explain_readdir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_readdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_readdir(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3651,17 +3651,17 @@ START_TEST (error_explain_readlink_test) {
   const char *name;
 
   res = pr_error_explain_readlink(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_readlink(err, NULL, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3669,28 +3669,28 @@ START_TEST (error_explain_readlink_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_readlink(err, NULL, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_readlink = test_explain_readlink;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_readlink(err, NULL, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_readlink(err, NULL, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3717,17 +3717,17 @@ START_TEST (error_explain_readv_test) {
   const char *name;
 
   res = pr_error_explain_readv(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_readv(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3735,28 +3735,28 @@ START_TEST (error_explain_readv_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_readv(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_readv = test_explain_readv;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_readv(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_readv(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3783,17 +3783,17 @@ START_TEST (error_explain_rename_test) {
   const char *name;
 
   res = pr_error_explain_rename(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_rename(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3801,28 +3801,28 @@ START_TEST (error_explain_rename_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_rename(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_rename = test_explain_rename;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_rename(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_rename(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3849,17 +3849,17 @@ START_TEST (error_explain_rmdir_test) {
   const char *name;
 
   res = pr_error_explain_rmdir(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_rmdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3867,28 +3867,28 @@ START_TEST (error_explain_rmdir_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_rmdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_rmdir = test_explain_rmdir;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_rmdir(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_rmdir(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3915,17 +3915,17 @@ START_TEST (error_explain_setegid_test) {
   const char *name;
 
   res = pr_error_explain_setegid(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setegid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3933,28 +3933,28 @@ START_TEST (error_explain_setegid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setegid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setegid = test_explain_setegid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setegid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setegid(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -3981,17 +3981,17 @@ START_TEST (error_explain_seteuid_test) {
   const char *name;
 
   res = pr_error_explain_seteuid(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_seteuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -3999,28 +3999,28 @@ START_TEST (error_explain_seteuid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_seteuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_seteuid = test_explain_seteuid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_seteuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_seteuid(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4047,17 +4047,17 @@ START_TEST (error_explain_setgid_test) {
   const char *name;
 
   res = pr_error_explain_setgid(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setgid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4065,28 +4065,28 @@ START_TEST (error_explain_setgid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setgid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setgid = test_explain_setgid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setgid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setgid(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4113,17 +4113,17 @@ START_TEST (error_explain_setregid_test) {
   const char *name;
 
   res = pr_error_explain_setregid(NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setregid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4131,28 +4131,28 @@ START_TEST (error_explain_setregid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setregid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setregid = test_explain_setregid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setregid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setregid(err, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4179,17 +4179,17 @@ START_TEST (error_explain_setresgid_test) {
   const char *name;
 
   res = pr_error_explain_setresgid(NULL, -1, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setresgid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4197,28 +4197,28 @@ START_TEST (error_explain_setresgid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setresgid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setresgid = test_explain_setresgid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setresgid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setresgid(err, -1, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4245,17 +4245,17 @@ START_TEST (error_explain_setresuid_test) {
   const char *name;
 
   res = pr_error_explain_setresuid(NULL, -1, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setresuid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4263,28 +4263,28 @@ START_TEST (error_explain_setresuid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setresuid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setresuid = test_explain_setresuid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setresuid(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setresuid(err, -1, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4311,17 +4311,17 @@ START_TEST (error_explain_setreuid_test) {
   const char *name;
 
   res = pr_error_explain_setreuid(NULL, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setreuid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4329,28 +4329,28 @@ START_TEST (error_explain_setreuid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setreuid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setreuid = test_explain_setreuid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setreuid(err, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setreuid(err, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4377,17 +4377,17 @@ START_TEST (error_explain_setrlimit_test) {
   const char *name;
 
   res = pr_error_explain_setrlimit(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4395,28 +4395,28 @@ START_TEST (error_explain_setrlimit_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setrlimit = test_explain_setrlimit;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setrlimit(err, -1, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setrlimit(err, -1, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4444,17 +4444,17 @@ START_TEST (error_explain_setsockopt_test) {
   const char *name;
 
   res = pr_error_explain_setsockopt(NULL, -1, -1, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setsockopt(err, -1, -1, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4462,28 +4462,28 @@ START_TEST (error_explain_setsockopt_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setsockopt(err, -1, -1, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setsockopt = test_explain_setsockopt;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setsockopt(err, -1, -1, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setsockopt(err, -1, -1, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4510,17 +4510,17 @@ START_TEST (error_explain_setuid_test) {
   const char *name;
 
   res = pr_error_explain_setuid(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_setuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4528,28 +4528,28 @@ START_TEST (error_explain_setuid_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_setuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_setuid = test_explain_setuid;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_setuid(err, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_setuid(err, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4576,17 +4576,17 @@ START_TEST (error_explain_socket_test) {
   const char *name;
 
   res = pr_error_explain_socket(NULL, -1, -1, -1);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_socket(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4594,28 +4594,28 @@ START_TEST (error_explain_socket_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_socket(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_socket = test_explain_socket;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_socket(err, -1, -1, -1);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_socket(err, -1, -1, -1);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4642,17 +4642,17 @@ START_TEST (error_explain_stat_test) {
   const char *name;
 
   res = pr_error_explain_stat(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_stat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4660,28 +4660,28 @@ START_TEST (error_explain_stat_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_stat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_stat = test_explain_stat;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_stat(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_stat(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4708,17 +4708,17 @@ START_TEST (error_explain_statfs_test) {
   const char *name;
 
   res = pr_error_explain_statfs(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_statfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4726,28 +4726,28 @@ START_TEST (error_explain_statfs_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_statfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_statfs = test_explain_statfs;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_statfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_statfs(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4774,17 +4774,17 @@ START_TEST (error_explain_statvfs_test) {
   const char *name;
 
   res = pr_error_explain_statvfs(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_statvfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4792,28 +4792,28 @@ START_TEST (error_explain_statvfs_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_statvfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_statvfs = test_explain_statvfs;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_statvfs(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_statvfs(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4840,17 +4840,17 @@ START_TEST (error_explain_symlink_test) {
   const char *name;
 
   res = pr_error_explain_symlink(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_symlink(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4858,28 +4858,28 @@ START_TEST (error_explain_symlink_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_symlink(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_symlink = test_explain_symlink;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_symlink(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_symlink(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4906,17 +4906,17 @@ START_TEST (error_explain_truncate_test) {
   const char *name;
 
   res = pr_error_explain_truncate(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_truncate(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4924,28 +4924,28 @@ START_TEST (error_explain_truncate_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_truncate(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_truncate = test_explain_truncate;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_truncate(err, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_truncate(err, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -4972,17 +4972,17 @@ START_TEST (error_explain_unlink_test) {
   const char *name;
 
   res = pr_error_explain_unlink(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_unlink(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -4990,28 +4990,28 @@ START_TEST (error_explain_unlink_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_unlink(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_unlink = test_explain_unlink;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_unlink(err, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_unlink(err, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -5038,17 +5038,17 @@ START_TEST (error_explain_utimes_test) {
   const char *name;
 
   res = pr_error_explain_utimes(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_utimes(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -5056,28 +5056,28 @@ START_TEST (error_explain_utimes_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_utimes(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_utimes = test_explain_utimes;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_utimes(err, NULL, NULL);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_utimes(err, NULL, NULL);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -5104,17 +5104,17 @@ START_TEST (error_explain_write_test) {
   const char *name;
 
   res = pr_error_explain_write(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_write(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -5122,28 +5122,28 @@ START_TEST (error_explain_write_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_write(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_write = test_explain_write;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_write(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_write(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);
@@ -5170,17 +5170,17 @@ START_TEST (error_explain_writev_test) {
   const char *name;
 
   res = pr_error_explain_writev(NULL, -1, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   xerrno = EINVAL;
   err = pr_error_create(p, xerrno);
-  fail_unless(err != NULL, "Failed to allocate error: %s", strerror(errno));
+  ck_assert_msg(err != NULL, "Failed to allocate error: %s", strerror(errno));
 
   res = pr_error_explain_writev(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -5188,28 +5188,28 @@ START_TEST (error_explain_writev_test) {
   name = "testsuite";
 
   explainer = pr_error_register_explainer(p, &m, name);
-  fail_unless(explainer != NULL, "Failed to register '%s' explainer: %s",
+  ck_assert_msg(explainer != NULL, "Failed to register '%s' explainer: %s",
     name, strerror(errno));
 
   res = pr_error_explain_writev(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   explainer->explain_writev = test_explain_writev;
   test_explain_return_eperm = TRUE;
 
   res = pr_error_explain_writev(err, -1, NULL, 0);
-  fail_unless(res < 0, "Unexpectedly explained error");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly explained error");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   test_explain_return_eperm = FALSE;
   res = pr_error_explain_writev(err, -1, NULL, 0);
-  fail_unless(res == 0, "Failed to explain error: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to explain error: %s", strerror(errno));
 
   res = pr_error_unregister_explainer(p, &m, name);
-  fail_unless(res == 0, "Failed to unregister '%s' explainer: %s", name,
+  ck_assert_msg(res == 0, "Failed to unregister '%s' explainer: %s", name,
     strerror(errno));
 
   pr_error_destroy(err);

--- a/tests/api/event.c
+++ b/tests/api/event.c
@@ -75,23 +75,23 @@ START_TEST (event_register_test) {
   module m;
 
   res = pr_event_register(NULL, NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_event_register(NULL, event, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null callback");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null callback");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_event_register(NULL, NULL, event_cb, NULL);
-  fail_unless(res == -1, "Failed to handle null event");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null event");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to register event: %s", strerror(errno));
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == -1, "Failed to handle duplicate registration");
-  fail_unless(errno == EEXIST, "Failed to set errno to EEXIST");
+  ck_assert_msg(res == -1, "Failed to handle duplicate registration");
+  ck_assert_msg(errno == EEXIST, "Failed to set errno to EEXIST");
 
   memset(&m, 0, sizeof(m));
   m.name = "testsuite";
@@ -99,11 +99,11 @@ START_TEST (event_register_test) {
   (void) pr_event_unregister(NULL, event, NULL);
 
   res = pr_event_register(&m, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event with module: %s",
+  ck_assert_msg(res == 0, "Failed to register event with module: %s",
     strerror(errno));
 
   res = pr_event_register(&m, event, event_cb2, NULL);
-  fail_unless(res == 0, "Failed to register event with module: %s",
+  ck_assert_msg(res == 0, "Failed to register event with module: %s",
     strerror(errno));
 
   pr_event_unregister(&m, event, event_cb2);
@@ -117,33 +117,33 @@ START_TEST (event_unregister_test) {
   const char *event = "foo";
 
   res = pr_event_unregister(NULL, NULL, NULL);
-  fail_unless(res == 0, "Failed to handle empty event lists");
+  ck_assert_msg(res == 0, "Failed to handle empty event lists");
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to register event: %s", strerror(errno));
 
   res = pr_event_unregister(NULL, "bar", NULL);
-  fail_unless(res == -1, "Failed to handle unregistered event");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle unregistered event");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_event_unregister(NULL, event, event_cb2);
-  fail_unless(res == -1, "Failed to handle unregistered event");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle unregistered event");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_event_unregister(NULL, event, event_cb);
-  fail_unless(res == 0, "Failed to unregister event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unregister event: %s", strerror(errno));
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to register event: %s", strerror(errno));
 
   res = pr_event_unregister(NULL, event, NULL);
-  fail_unless(res == 0, "Failed to unregister event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unregister event: %s", strerror(errno));
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to register event: %s", strerror(errno));
 
   res = pr_event_unregister(NULL, NULL, NULL);
-  fail_unless(res == 0, "Failed to unregister event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unregister event: %s", strerror(errno));
 }
 END_TEST
 
@@ -152,49 +152,49 @@ START_TEST (event_listening_test) {
   int res;
 
   res = pr_event_listening(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_event_listening(event);
-  fail_unless(res == 0, "Failed to check for '%s' listeners: %s", event,
+  ck_assert_msg(res == 0, "Failed to check for '%s' listeners: %s", event,
     strerror(errno));
 
   res = pr_event_register(NULL, event, event_cb2, NULL);
-  fail_unless(res == 0, "Failed to register event '%s: %s", event,
+  ck_assert_msg(res == 0, "Failed to register event '%s: %s", event,
     strerror(errno));
 
   res = pr_event_register(NULL, event2, event_cb2, NULL);
-  fail_unless(res == 0, "Failed to register event '%s: %s", event2,
+  ck_assert_msg(res == 0, "Failed to register event '%s: %s", event2,
     strerror(errno));
 
   res = pr_event_listening(event);
-  fail_unless(res == 1, "Expected 1 listener, got %d", res);
+  ck_assert_msg(res == 1, "Expected 1 listener, got %d", res);
 
   res = pr_event_register(NULL, event, event_cb3, NULL);
-  fail_unless(res == 0, "Failed to register event '%s: %s", event,
+  ck_assert_msg(res == 0, "Failed to register event '%s: %s", event,
     strerror(errno));
 
   res = pr_event_listening(event);
-  fail_unless(res == 2, "Expected 2 listeners, got %d", res);
+  ck_assert_msg(res == 2, "Expected 2 listeners, got %d", res);
 
   /* Unregister our listener, and make sure that the API indicates there
    * are no more listeners.
    */
   res = pr_event_unregister(NULL, event, NULL);
-  fail_unless(res == 0, "Failed to unregister event '%s': %s", event,
+  ck_assert_msg(res == 0, "Failed to unregister event '%s': %s", event,
     strerror(errno));
 
   res = pr_event_listening(event);
-  fail_unless(res == 0, "Failed to check for '%s' listeners: %s", event,
+  ck_assert_msg(res == 0, "Failed to check for '%s' listeners: %s", event,
     strerror(errno));
 
   res = pr_event_unregister(NULL, event2, NULL);
-  fail_unless(res == 0, "Failed to unregister event '%s': %s", event2,
+  ck_assert_msg(res == 0, "Failed to unregister event '%s': %s", event2,
     strerror(errno));
 
   res = pr_event_listening(event);
-  fail_unless(res == 0, "Failed to check for '%s' listeners: %s", event,
+  ck_assert_msg(res == 0, "Failed to check for '%s' listeners: %s", event,
     strerror(errno));
 }
 END_TEST
@@ -204,33 +204,33 @@ START_TEST (event_generate_test) {
   const char *event = "foo";
 
   pr_event_generate(NULL, NULL);
-  fail_unless(event_triggered == 0, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 0, "Expected triggered count %u, got %u",
     0, event_triggered);
   
   pr_event_generate(event, NULL);
-  fail_unless(event_triggered == 0, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 0, "Expected triggered count %u, got %u",
     0, event_triggered);
 
   res = pr_event_register(NULL, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to register event: %s", strerror(errno));
 
   pr_event_generate("bar", NULL);
-  fail_unless(event_triggered == 0, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 0, "Expected triggered count %u, got %u",
     0, event_triggered);
 
   pr_event_generate(event, NULL);
-  fail_unless(event_triggered == 1, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 1, "Expected triggered count %u, got %u",
     1, event_triggered);
 
   pr_event_generate(event, NULL);
-  fail_unless(event_triggered == 2, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 2, "Expected triggered count %u, got %u",
     2, event_triggered);
 
   res = pr_event_unregister(NULL, NULL, NULL);
-  fail_unless(res == 0, "Failed to unregister events: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unregister events: %s", strerror(errno));
 
   pr_event_generate(event, NULL);
-  fail_unless(event_triggered == 2, "Expected triggered count %u, got %u",
+  ck_assert_msg(event_triggered == 2, "Expected triggered count %u, got %u",
     2, event_triggered);
 }
 END_TEST
@@ -241,35 +241,35 @@ START_TEST (event_dump_test) {
   module m;
 
   pr_event_dump(NULL);
-  fail_unless(event_dumped == 0, "Expected dumped count of %u, got %u",
+  ck_assert_msg(event_dumped == 0, "Expected dumped count of %u, got %u",
     0, event_dumped);
 
   pr_event_dump(event_dump);
-  fail_unless(event_dumped == 0, "Expected dumped count of %u, got %u",
+  ck_assert_msg(event_dumped == 0, "Expected dumped count of %u, got %u",
     0, event_dumped);
 
   memset(&m, 0, sizeof(m));
   m.name = "testsuite";
   res = pr_event_register(&m, event, event_cb, NULL);
-  fail_unless(res == 0, "Failed to register event '%s', callback %p: %s",
+  ck_assert_msg(res == 0, "Failed to register event '%s', callback %p: %s",
     event, event_cb, strerror(errno));
 
   pr_event_dump(event_dump);
-  fail_unless(event_dumped == 1, "Expected dumped count of %u, got %u",
+  ck_assert_msg(event_dumped == 1, "Expected dumped count of %u, got %u",
     1, event_dumped);
 
   event_dumped = 0;
 
   res = pr_event_register(NULL, event, event_cb2, NULL);
-  fail_unless(res == 0, "Failed to register event '%s', callback %p: %s",
+  ck_assert_msg(res == 0, "Failed to register event '%s', callback %p: %s",
     event, event_cb2, strerror(errno));
 
   res = pr_event_register(NULL, "bar", event_cb2, NULL);
-  fail_unless(res == 0, "Failed to register event 'bar', callback %p: %s",
+  ck_assert_msg(res == 0, "Failed to register event 'bar', callback %p: %s",
     event_cb2, strerror(errno));
 
   pr_event_dump(event_dump);
-  fail_unless(event_dumped == 3, "Expected dumped count of %u, got %u",
+  ck_assert_msg(event_dumped == 3, "Expected dumped count of %u, got %u",
     3, event_dumped);
 }
 END_TEST

--- a/tests/api/expr.c
+++ b/tests/api/expr.c
@@ -52,37 +52,37 @@ START_TEST (expr_create_test) {
   char **elts;
 
   res = pr_expr_create(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_expr_create(p, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null count, argv arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null count, argv arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_expr_create(p, &expr_argc, NULL);
-  fail_unless(res == NULL, "Failed to handle null argv argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argv argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_expr_create(p, NULL, expr_argv);
-  fail_unless(res == NULL, "Failed to handle null argc argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argc argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_expr_create(NULL, &expr_argc, expr_argv);
-  fail_unless(res == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_expr_create(p, &expr_argc, expr_argv);
-  fail_unless(res == NULL, "Failed to handle empty argv argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle empty argv argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   expr_argc = 0;
   expr_argv[0] = "foo";
   expr_argv[1] = "bar";
 
   res = pr_expr_create(p, &expr_argc, expr_argv);
-  fail_unless(res != NULL, "Failed to create expr: %s", strerror(errno));
-  fail_unless(expr_argc == 0, "Failed to set negative argc to zero");
-  fail_unless(res->nelts == expr_argc, "Expected %d, got %d", expr_argc,
+  ck_assert_msg(res != NULL, "Failed to create expr: %s", strerror(errno));
+  ck_assert_msg(expr_argc == 0, "Failed to set negative argc to zero");
+  ck_assert_msg(res->nelts == expr_argc, "Expected %d, got %d", expr_argc,
     res->nelts);
 
   expr_argc = 1;
@@ -90,31 +90,31 @@ START_TEST (expr_create_test) {
   expr_argv[1] = NULL;
 
   res = pr_expr_create(p, &expr_argc, expr_argv);
-  fail_unless(res != NULL, "Failed to create expr: %s", strerror(errno));
-  fail_unless(res->nelts == expr_argc, "Expected %d, got %d", expr_argc,
+  ck_assert_msg(res != NULL, "Failed to create expr: %s", strerror(errno));
+  ck_assert_msg(res->nelts == expr_argc, "Expected %d, got %d", expr_argc,
     res->nelts);
 
   elts = res->elts;
-  fail_unless(elts[0] == NULL, "Expected null, got '%s'", elts[0]);
+  ck_assert_msg(elts[0] == NULL, "Expected null, got '%s'", elts[0]);
 
   expr_argc = 2;
   expr_argv[0] = pstrdup(p, "foo");
   expr_argv[1] = pstrdup(p, "bar,baz,quxx");
 
   res = pr_expr_create(p, &expr_argc, expr_argv);
-  fail_unless(res != NULL, "Failed to create expr: %s", strerror(errno));
-  fail_unless(res->nelts == 3, "Expected %d, got %d", 3, res->nelts);
+  ck_assert_msg(res != NULL, "Failed to create expr: %s", strerror(errno));
+  ck_assert_msg(res->nelts == 3, "Expected %d, got %d", 3, res->nelts);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[0], "bar") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[0], "bar") == 0, "Expected '%s', got '%s'",
     "bar", elts[0]);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[1], "baz") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[1], "baz") == 0, "Expected '%s', got '%s'",
     "baz", elts[1]);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[2], "quxx") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[2], "quxx") == 0, "Expected '%s', got '%s'",
     "quxx", elts[2]);
 
   expr_argc = 3;
@@ -123,23 +123,23 @@ START_TEST (expr_create_test) {
   expr_argv[2] = pstrdup(p, "alef");
 
   res = pr_expr_create(p, &expr_argc, expr_argv);
-  fail_unless(res != NULL, "Failed to create expr: %s", strerror(errno));
-  fail_unless(res->nelts == 4, "Expected %d, got %d", 4, res->nelts);
+  ck_assert_msg(res != NULL, "Failed to create expr: %s", strerror(errno));
+  ck_assert_msg(res->nelts == 4, "Expected %d, got %d", 4, res->nelts);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[0], "bar") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[0], "bar") == 0, "Expected '%s', got '%s'",
     "bar", elts[0]);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[1], "baz") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[1], "baz") == 0, "Expected '%s', got '%s'",
     "baz", elts[1]);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[2], "quxx") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[2], "quxx") == 0, "Expected '%s', got '%s'",
     "quxx", elts[2]);
 
   elts = res->elts;
-  fail_unless(strcmp(elts[3], "alef") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(elts[3], "alef") == 0, "Expected '%s', got '%s'",
     "alef", elts[3]);
 }
 END_TEST
@@ -151,41 +151,41 @@ START_TEST (expr_eval_class_and_test) {
   int res;
 
   res = pr_expr_eval_class_and(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.conn_class = NULL;
 
   res = pr_expr_eval_class_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   init_netaddr();
   init_class();
 
   res = pr_class_open(p, "test");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   session.conn_class = pr_class_find("test");
-  fail_unless(session.conn_class != NULL, "Failed to find 'test' class: %s",
+  ck_assert_msg(session.conn_class != NULL, "Failed to find 'test' class: %s",
     strerror(errno));
 
   res = pr_expr_eval_class_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_expr_eval_class_and(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_class_and(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 }
 END_TEST
 
@@ -196,44 +196,44 @@ START_TEST (expr_eval_class_or_test) {
   int res;
 
   res = pr_expr_eval_class_or(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.conn_class = NULL;
 
   res = pr_expr_eval_class_or(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   init_netaddr();
   init_class();
 
   res = pr_class_open(p, "test");
-  fail_unless(res == 0, "Failed to open class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open class: %s", strerror(errno));
 
   acl = pr_netacl_create(p, "all");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_class_add_acl(acl);
-  fail_unless(res == 0, "Failed to add ACL to class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add ACL to class: %s", strerror(errno));
 
   res = pr_class_close();
-  fail_unless(res == 0, "Failed to close class: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close class: %s", strerror(errno));
 
   session.conn_class = pr_class_find("test");
-  fail_unless(session.conn_class != NULL, "Failed to find 'test' class: %s",
+  ck_assert_msg(session.conn_class != NULL, "Failed to find 'test' class: %s",
     strerror(errno));
 
   res = pr_expr_eval_class_or(names1);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_class_or(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_class_or(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_class_or(names4);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 }
 END_TEST
 
@@ -243,25 +243,25 @@ START_TEST (expr_eval_group_and_test) {
   int res;
 
   res = pr_expr_eval_group_and(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.group = NULL;
   session.groups = NULL;
 
   res = pr_expr_eval_group_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   session.group = "test";
 
   res = pr_expr_eval_group_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_expr_eval_group_and(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_and(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   session.group = NULL;
   session.groups = make_array(p, 2, sizeof(char *));
@@ -270,13 +270,13 @@ START_TEST (expr_eval_group_and_test) {
   *((char **) push_array(session.groups)) = "spank";
 
   res = pr_expr_eval_group_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_expr_eval_group_and(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_and(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 }
 END_TEST
 
@@ -286,44 +286,44 @@ START_TEST (expr_eval_group_or_test) {
   int res;
 
   res = pr_expr_eval_group_or(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.group = NULL;
   session.groups = NULL;
 
   res = pr_expr_eval_group_or(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   session.group = "test";
 
   res = pr_expr_eval_group_or(names1);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names4);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   session.group = NULL;
   session.groups = make_array(p, 1, sizeof(char *));
   *((char **) push_array(session.groups)) = "test";
 
   res = pr_expr_eval_group_or(names1);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_group_or(names4);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 }
 END_TEST
 
@@ -333,24 +333,24 @@ START_TEST (expr_eval_user_and_test) {
   int res;
 
   res = pr_expr_eval_user_and(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.user = NULL;
 
   res = pr_expr_eval_user_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   session.user = "test";
 
   res = pr_expr_eval_user_and(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_expr_eval_user_and(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_user_and(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 }
 END_TEST
 
@@ -360,27 +360,27 @@ START_TEST (expr_eval_user_or_test) {
   int res;
 
   res = pr_expr_eval_user_or(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   session.user = NULL;
 
   res = pr_expr_eval_user_or(names1);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   session.user = "test";
 
   res = pr_expr_eval_user_or(names1);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_user_or(names2);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_user_or(names3);
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_expr_eval_user_or(names4);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 }
 END_TEST
 

--- a/tests/api/feat.c
+++ b/tests/api/feat.c
@@ -51,17 +51,17 @@ START_TEST (feat_add_test) {
   const char *key;
 
   res = pr_feat_add(NULL);
-  fail_unless(res == -1, "Failed to handle null feat");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null feat");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "foo";
 
   res = pr_feat_add(key);
-  fail_unless(res == 0, "Failed to add feat: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add feat: %s", strerror(errno));
 
   res = pr_feat_add(key);
-  fail_unless(res == -1, "Failed to handle duplicate feat");
-  fail_unless(errno == EEXIST, "Failed to set errno to EEXIST");
+  ck_assert_msg(res == -1, "Failed to handle duplicate feat");
+  ck_assert_msg(errno == EEXIST, "Failed to set errno to EEXIST");
 }
 END_TEST
 
@@ -70,19 +70,19 @@ START_TEST (feat_get_test) {
   const char *res;
 
   res = pr_feat_get();
-  fail_unless(res == NULL, "Failed to handle empty feat");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle empty feat");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   ok = pr_feat_add("foo");
-  fail_unless(ok == 0, "Failed to add feat: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add feat: %s", strerror(errno));
 
   res = pr_feat_get();
-  fail_unless(res != NULL, "Failed to get feat: %s", strerror(errno));
-  fail_unless(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
+  ck_assert_msg(res != NULL, "Failed to get feat: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
 
   res = pr_feat_get();
-  fail_unless(res != NULL, "Failed to get feat: %s", strerror(errno));
-  fail_unless(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
+  ck_assert_msg(res != NULL, "Failed to get feat: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
 }
 END_TEST
 
@@ -91,18 +91,18 @@ START_TEST (feat_get_next_test) {
   const char *res;
 
   res = pr_feat_get_next();
-  fail_unless(res == NULL, "Failed to handle empty feat");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle empty feat");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   ok = pr_feat_add("foo");
-  fail_unless(ok == 0, "Failed to add feat: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add feat: %s", strerror(errno));
 
   res = pr_feat_get_next();
-  fail_unless(res != NULL, "Failed to get feat: %s", strerror(errno));
-  fail_unless(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
+  ck_assert_msg(res != NULL, "Failed to get feat: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "foo") == 0, "Expected '%s', got '%s'", "foo", res);
 
   res = pr_feat_get_next();
-  fail_unless(res == NULL, "Expected null, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected null, got '%s'", res);
 }
 END_TEST
 
@@ -111,23 +111,23 @@ START_TEST (feat_remove_test) {
   const char *feat;
 
   res = pr_feat_remove(NULL);
-  fail_unless(res == -1, "Failed to handle empty feat");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle empty feat");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   feat = "foo";
   res = pr_feat_add(feat);
-  fail_unless(res == 0, "Failed to add feat: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add feat: %s", strerror(errno));
 
   res = pr_feat_remove(NULL);
-  fail_unless(res == -1, "Failed to handle null feat");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null feat");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_feat_remove(feat);
-  fail_unless(res == 0, "Failed to remove feat: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove feat: %s", strerror(errno));
 
   res = pr_feat_remove(feat);
-  fail_unless(res == -1, "Failed to detected removed feat");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to detected removed feat");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 }
 END_TEST
 

--- a/tests/api/filter.c
+++ b/tests/api/filter.c
@@ -57,35 +57,35 @@ START_TEST (filter_parse_flags_test) {
   int res;
 
   res = pr_filter_parse_flags(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_filter_parse_flags(p, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_filter_parse_flags(NULL, flags_str);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   flags_str = "foo";
   res = pr_filter_parse_flags(p, flags_str);
-  fail_unless(res < 0, "Failed to handle badly formatted flags '%s'",
+  ck_assert_msg(res < 0, "Failed to handle badly formatted flags '%s'",
     flags_str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   flags_str = "[foo]";
   res = pr_filter_parse_flags(p, flags_str);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   flags_str = "[NC]";
   res = pr_filter_parse_flags(p, flags_str);
-  fail_unless(res == REG_ICASE, "Expected REG_ICASE (%d), got %d", REG_ICASE,
+  ck_assert_msg(res == REG_ICASE, "Expected REG_ICASE (%d), got %d", REG_ICASE,
     res);
 
   flags_str = "[nocase]";
   res = pr_filter_parse_flags(p, flags_str);
-  fail_unless(res == REG_ICASE, "Expected REG_ICASE (%d), got %d", REG_ICASE,
+  ck_assert_msg(res == REG_ICASE, "Expected REG_ICASE (%d), got %d", REG_ICASE,
     res);
 }
 END_TEST
@@ -98,8 +98,8 @@ START_TEST (filter_allow_path_test) {
   const char *path = NULL;
 
   res = pr_filter_allow_path(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   c = add_config_param_set(&set, "test", 1, "test");
@@ -107,33 +107,33 @@ START_TEST (filter_allow_path_test) {
 
   path = "/foo/bar";
   res = pr_filter_allow_path(set, path);
-  fail_unless(res == 0, "Failed to allow path '%s' with no configured filters",
+  ck_assert_msg(res == 0, "Failed to allow path '%s' with no configured filters",
     path);
 
   /* First, let's add a PathDenyFilter. */
   deny_pre = pr_regexp_alloc(NULL);
   res = pr_regexp_compile(deny_pre, "/bar$", 0);
-  fail_unless(res == 0, "Error compiling deny filter");
+  ck_assert_msg(res == 0, "Error compiling deny filter");
 
   c = add_config_param_set(&set, "PathDenyFilter", 1, deny_pre);
   fail_if(c == NULL, "Failed to add config param: %s", strerror(errno));
 
   mark_point();
   res = pr_filter_allow_path(set, path);
-  fail_unless(res == PR_FILTER_ERR_FAILS_DENY_FILTER,
+  ck_assert_msg(res == PR_FILTER_ERR_FAILS_DENY_FILTER,
     "Failed to reject path '%s' with matching PathDenyFilter", path);
 
   mark_point();
   path = "/foo/baz";
   res = pr_filter_allow_path(set, path);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to allow path '%s' with non-matching PathDenyFilter", path);
   pr_regexp_free(NULL, deny_pre);
 
   /* Now, let's add a PathAllowFilter. */
   allow_pre = pr_regexp_alloc(NULL);
   res = pr_regexp_compile(allow_pre, "/baz$", 0);
-  fail_unless(res == 0, "Error compiling allow filter");
+  ck_assert_msg(res == 0, "Error compiling allow filter");
 
   c = add_config_param_set(&set, "PathAllowFilter", 1, allow_pre);
   fail_if(c == NULL, "Failed to add config param: %s", strerror(errno));
@@ -141,7 +141,7 @@ START_TEST (filter_allow_path_test) {
   mark_point();
   path = "/foo/quxx";
   res = pr_filter_allow_path(set, path);
-  fail_unless(res == PR_FILTER_ERR_FAILS_ALLOW_FILTER,
+  ck_assert_msg(res == PR_FILTER_ERR_FAILS_ALLOW_FILTER,
     "Failed to allow path '%s' with matching PathAllowFilter", path);
   pr_regexp_free(NULL, allow_pre);
 }

--- a/tests/api/filter.c
+++ b/tests/api/filter.c
@@ -103,7 +103,7 @@ START_TEST (filter_allow_path_test) {
 
   mark_point();
   c = add_config_param_set(&set, "test", 1, "test");
-  fail_if(c == NULL, "Failed to add config param: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to add config param: %s", strerror(errno));
 
   path = "/foo/bar";
   res = pr_filter_allow_path(set, path);
@@ -116,7 +116,7 @@ START_TEST (filter_allow_path_test) {
   ck_assert_msg(res == 0, "Error compiling deny filter");
 
   c = add_config_param_set(&set, "PathDenyFilter", 1, deny_pre);
-  fail_if(c == NULL, "Failed to add config param: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to add config param: %s", strerror(errno));
 
   mark_point();
   res = pr_filter_allow_path(set, path);
@@ -136,7 +136,7 @@ START_TEST (filter_allow_path_test) {
   ck_assert_msg(res == 0, "Error compiling allow filter");
 
   c = add_config_param_set(&set, "PathAllowFilter", 1, allow_pre);
-  fail_if(c == NULL, "Failed to add config param: %s", strerror(errno));
+  ck_assert_msg(c != NULL, "Failed to add config param: %s", strerror(errno));
 
   mark_point();
   path = "/foo/quxx";

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -120,22 +120,22 @@ START_TEST (fsio_sys_open_test) {
   mark_point();
   flags = O_CREAT|O_EXCL|O_RDONLY;
   fh = pr_fsio_open(NULL, flags);
-  fail_unless(fh == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(fh == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   flags = O_RDONLY;
   fh = pr_fsio_open(fsio_test_path, flags);
-  fail_unless(fh == NULL, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(fh == NULL, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   flags = O_RDONLY;
   fh = pr_fsio_open("/etc/hosts", flags);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s", strerror(errno));
 
   (void) pr_fsio_close(fh);
 }
@@ -147,20 +147,20 @@ START_TEST (fsio_sys_open_canon_test) {
 
   flags = O_CREAT|O_EXCL|O_RDONLY;
   fh = pr_fsio_open_canon(NULL, flags);
-  fail_unless(fh == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(fh == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   flags = O_RDONLY;
   fh = pr_fsio_open_canon(fsio_test_path, flags);
-  fail_unless(fh == NULL, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(fh == NULL, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   flags = O_RDONLY;
   fh = pr_fsio_open_canon("/etc/hosts", flags);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s", strerror(errno));
 
   (void) pr_fsio_close(fh);
 }
@@ -172,7 +172,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   const char *path;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   path = "/etc/hosts";
   flags = O_CREAT|O_RDONLY;
@@ -182,7 +182,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
     fail("open(2) of %s succeeded unexpectedly", path);
   }
 
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   path = "/&Z";
@@ -193,7 +193,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
     fail("open(2) of %s succeeded unexpectedly", path);
   }
 
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno));
 
   path = "/etc";
@@ -203,7 +203,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
     fail("open(2) of %s succeeded unexpectedly", path);
   }
 
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno));
 
   path = "/lib";
@@ -213,7 +213,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
     fail("open(2) of %s succeeded unexpectedly", path);
   }
 
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno));
 
   (void) pr_fsio_guard_chroot(FALSE);
@@ -221,7 +221,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   path = "/etc/hosts";
   flags = O_RDONLY;
   fh = pr_fsio_open(path, flags);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
   (void) pr_fsio_close(fh);
 }
 END_TEST
@@ -231,16 +231,16 @@ START_TEST (fsio_sys_close_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_close(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s %d", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s %d", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open("/etc/hosts", O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s",
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s",
     strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to close file handle: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close file handle: %s", strerror(errno));
 }
 END_TEST
 
@@ -249,17 +249,17 @@ START_TEST (fsio_sys_unlink_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_unlink(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_unlink_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_unlink_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_unlink_path,
     strerror(errno));
   (void) pr_fsio_close(fh);
 
   res = pr_fsio_unlink(fsio_unlink_path);
-  fail_unless(res == 0, "Failed to unlink '%s': %s", fsio_unlink_path,
+  ck_assert_msg(res == 0, "Failed to unlink '%s': %s", fsio_unlink_path,
     strerror(errno));
 }
 END_TEST
@@ -268,18 +268,18 @@ START_TEST (fsio_sys_unlink_chroot_guard_test) {
   int res;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_unlink("/etc/hosts");
-  fail_unless(res < 0, "Deleted /etc/hosts unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Deleted /etc/hosts unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_unlink("/lib/foo.bar.baz");
-  fail_unless(res < 0, "Deleted /lib/foo.bar.baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Deleted /lib/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -290,57 +290,57 @@ START_TEST (fsio_sys_stat_test) {
   unsigned int cache_size = 3, max_age = 1, policy_flags = 0;
 
   res = pr_fsio_stat(NULL, &st);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_stat("/", NULL);
-  fail_unless(res < 0, "Failed to handle null struct stat");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null struct stat");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_stat("/", &st);
-  fail_unless(res == 0, "Unexpected stat(2) error on '/': %s",
+  ck_assert_msg(res == 0, "Unexpected stat(2) error on '/': %s",
     strerror(errno));
-  fail_unless(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
+  ck_assert_msg(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
 
   /* Now, do the stat(2) again, and make sure we get the same information
    * from the cache.
    */
   res = pr_fsio_stat("/", &st);
-  fail_unless(res == 0, "Unexpected stat(2) error on '/': %s",
+  ck_assert_msg(res == 0, "Unexpected stat(2) error on '/': %s",
     strerror(errno));
-  fail_unless(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
+  ck_assert_msg(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
 
   pr_fs_statcache_reset();
   res = pr_fs_statcache_set_policy(cache_size, max_age, policy_flags);
-  fail_unless(res == 0, "Failed to set statcache policy: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set statcache policy: %s", strerror(errno));
 
   res = pr_fsio_stat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_stat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   /* Now wait for longer than 1 second (our configured max age) */
   sleep(max_age + 1);
 
   res = pr_fsio_stat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   /* Stat a symlink path */
   res = pr_fsio_symlink("/tmp", fsio_link_path);
-  fail_unless(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
     strerror(errno));
 
   res = pr_fsio_stat(fsio_link_path, &st);
-  fail_unless(res == 0, "Failed to stat '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to stat '%s': %s", fsio_link_path,
     strerror(errno));
 
   (void) unlink(fsio_link_path);
@@ -353,16 +353,16 @@ START_TEST (fsio_sys_fstat_test) {
   struct stat st;
 
   res = pr_fsio_fstat(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open("/etc/hosts", O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s",
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s",
     strerror(errno));
 
   res = pr_fsio_fstat(fh, &st);
-  fail_unless(res == 0, "Failed to fstat /etc/hosts: %s",
+  ck_assert_msg(res == 0, "Failed to fstat /etc/hosts: %s",
     strerror(errno));
   (void) pr_fsio_close(fh);
 }
@@ -375,29 +375,29 @@ START_TEST (fsio_sys_read_test) {
   size_t buflen;
 
   res = pr_fsio_read(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open("/etc/hosts", O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s",
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s",
     strerror(errno));
 
   res = pr_fsio_read(fh, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = 32;
   buf = palloc(p, buflen);
 
   res = pr_fsio_read(fh, buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_read(fh, buf, 1);
-  fail_unless(res == 1, "Failed to read 1 byte: %s", strerror(errno));
+  ck_assert_msg(res == 1, "Failed to read 1 byte: %s", strerror(errno));
 
   (void) pr_fsio_close(fh);
 }
@@ -410,29 +410,29 @@ START_TEST (fsio_sys_pread_test) {
   size_t buflen;
 
   res = pr_fsio_pread(NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open("/etc/hosts", O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s",
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s",
     strerror(errno));
 
   res = pr_fsio_pread(fh, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = 32;
   buf = palloc(p, buflen);
 
   res = pr_fsio_pread(fh, buf, 0, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_pread(fh, buf, 1, 0);
-  fail_unless(res == 1, "Failed to read 1 byte: %s", strerror(errno));
+  ck_assert_msg(res == 1, "Failed to read 1 byte: %s", strerror(errno));
 
   (void) pr_fsio_close(fh);
 }
@@ -445,17 +445,17 @@ START_TEST (fsio_sys_write_test) {
   size_t buflen;
 
   res = pr_fsio_write(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", strerror(errno));
 
   /* XXX What happens if we use NULL buffer, zero length? */
   res = pr_fsio_write(fh, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = 32;
@@ -463,10 +463,10 @@ START_TEST (fsio_sys_write_test) {
   memset(buf, 'c', buflen);
 
   res = pr_fsio_write(fh, buf, 0);
-  fail_unless(res == 0, "Failed to handle zero buffer length");
+  ck_assert_msg(res == 0, "Failed to handle zero buffer length");
 
   res = pr_fsio_write(fh, buf, buflen);
-  fail_unless((size_t) res == buflen, "Failed to write %lu bytes: %s",
+  ck_assert_msg((size_t) res == buflen, "Failed to write %lu bytes: %s",
     (unsigned long) buflen, strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -481,17 +481,17 @@ START_TEST (fsio_sys_pwrite_test) {
   size_t buflen;
 
   res = pr_fsio_pwrite(NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", strerror(errno));
 
   /* XXX What happens if we use NULL buffer, zero length? */
   res = pr_fsio_pwrite(fh, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = 32;
@@ -499,10 +499,10 @@ START_TEST (fsio_sys_pwrite_test) {
   memset(buf, 'c', buflen);
 
   res = pr_fsio_pwrite(fh, buf, 0, 0);
-  fail_unless(res == 0, "Failed to handle zero buffer length");
+  ck_assert_msg(res == 0, "Failed to handle zero buffer length");
 
   res = pr_fsio_pwrite(fh, buf, buflen, 0);
-  fail_unless((size_t) res == buflen, "Failed to write %lu bytes: %s",
+  ck_assert_msg((size_t) res == buflen, "Failed to write %lu bytes: %s",
     (unsigned long) buflen, strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -515,16 +515,16 @@ START_TEST (fsio_sys_lseek_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_lseek(NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open("/etc/hosts", O_RDONLY);
-  fail_unless(fh != NULL, "Failed to open /etc/hosts: %s",
+  ck_assert_msg(fh != NULL, "Failed to open /etc/hosts: %s",
     strerror(errno));
 
   res = pr_fsio_lseek(fh, 0, 0);
-  fail_unless(res == 0, "Failed to seek to byte 0: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to seek to byte 0: %s", strerror(errno));
 
   (void) pr_fsio_close(fh);
 }
@@ -537,41 +537,41 @@ START_TEST (fsio_sys_link_test) {
 
   target_path = link_path = NULL;
   res = pr_fsio_link(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   target_path = fsio_test_path;
   link_path = NULL;
   res = pr_fsio_link(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null link_path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null link_path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   target_path = NULL;
   link_path = fsio_link_path;
   res = pr_fsio_link(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null target_path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null target_path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
   (void) pr_fsio_close(fh);
 
   /* Link a file (that exists) to itself */
   link_path = target_path = fsio_test_path;
   res = pr_fsio_link(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle same existing source/destination");
-  fail_unless(errno == EEXIST, "Expected EEXIST, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle same existing source/destination");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST, got %s (%d)", strerror(errno),
     errno);
 
   /* Create expected link */
   link_path = fsio_link_path;
   target_path = fsio_test_path;
   res = pr_fsio_link(target_path, link_path);
-  fail_unless(res == 0, "Failed to create link from '%s' to '%s': %s",
+  ck_assert_msg(res == 0, "Failed to create link from '%s' to '%s': %s",
     link_path, target_path, strerror(errno));
   (void) unlink(link_path);
   (void) pr_fsio_unlink(fsio_test_path);
@@ -582,19 +582,19 @@ START_TEST (fsio_sys_link_chroot_guard_test) {
   int res;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_link(fsio_link_path, "/etc/foo.bar.baz");
-  fail_unless(res < 0, "Linked /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Linked /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   (void) pr_fsio_unlink(fsio_link_path);
   res = pr_fsio_link(fsio_link_path, "/lib/foo/bar/baz");
-  fail_unless(res < 0, "Linked /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Linked /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -605,36 +605,36 @@ START_TEST (fsio_sys_symlink_test) {
 
   target_path = link_path = NULL;
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   target_path = "/tmp";
   link_path = NULL;
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null link_path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null link_path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   target_path = NULL;
   link_path = fsio_link_path;
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle null target_path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null target_path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   /* Symlink a file (that exists) to itself */
   link_path = target_path = "/tmp";
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res < 0, "Failed to handle same existing source/destination");
-  fail_unless(errno == EEXIST, "Expected EEXIST, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle same existing source/destination");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST, got %s (%d)", strerror(errno),
     errno);
 
   /* Create expected symlink */
   link_path = fsio_link_path;
   target_path = "/tmp";
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res == 0, "Failed to create symlink from '%s' to '%s': %s",
+  ck_assert_msg(res == 0, "Failed to create symlink from '%s' to '%s': %s",
     link_path, target_path, strerror(errno));
   (void) unlink(link_path);
 }
@@ -644,19 +644,19 @@ START_TEST (fsio_sys_symlink_chroot_guard_test) {
   int res;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_symlink(fsio_link_path, "/etc/foo.bar.baz");
-  fail_unless(res < 0, "Symlinked /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Symlinked /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
   (void) pr_fsio_unlink(fsio_link_path);
 
   res = pr_fsio_symlink(fsio_link_path, "/lib/foo/bar/baz");
-  fail_unless(res < 0, "Symlinked /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Symlinked /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -667,35 +667,35 @@ START_TEST (fsio_sys_readlink_test) {
   const char *link_path, *target_path, *path;
 
   res = pr_fsio_readlink(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   /* Read a non-symlink file */
   path = "/";
   res = pr_fsio_readlink(path, buf, sizeof(buf)-1);
-  fail_unless(res < 0, "Failed to handle non-symlink path");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle non-symlink path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   /* Read a symlink file */
   target_path = "/tmp";
   link_path = fsio_link_path;
   res = pr_fsio_symlink(target_path, link_path);
-  fail_unless(res == 0, "Failed to create symlink from '%s' to '%s': %s",
+  ck_assert_msg(res == 0, "Failed to create symlink from '%s' to '%s': %s",
     link_path, target_path, strerror(errno));
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fsio_readlink(link_path, buf, sizeof(buf)-1);
-  fail_unless(res > 0, "Failed to read symlink '%s': %s", link_path,
+  ck_assert_msg(res > 0, "Failed to read symlink '%s': %s", link_path,
     strerror(errno));
   buf[res] = '\0';
-  fail_unless(strcmp(buf, target_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, target_path) == 0, "Expected '%s', got '%s'",
     target_path, buf);
 
   /* Read a symlink file using a zero-length buffer */
   res = pr_fsio_readlink(link_path, buf, 0);
-  fail_unless(res <= 0, "Expected length <= 0, got %d", res);
+  ck_assert_msg(res <= 0, "Expected length <= 0, got %d", res);
 
   (void) unlink(link_path);
 }
@@ -707,57 +707,57 @@ START_TEST (fsio_sys_lstat_test) {
   unsigned int cache_size = 3, max_age = 1, policy_flags = 0;
 
   res = pr_fsio_lstat(NULL, &st);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_lstat("/", NULL);
-  fail_unless(res < 0, "Failed to handle null struct stat");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null struct stat");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_lstat("/", &st);
-  fail_unless(res == 0, "Unexpected lstat(2) error on '/': %s",
+  ck_assert_msg(res == 0, "Unexpected lstat(2) error on '/': %s",
     strerror(errno));
-  fail_unless(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
+  ck_assert_msg(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
 
   /* Now, do the lstat(2) again, and make sure we get the same information
    * from the cache.
    */
   res = pr_fsio_lstat("/", &st);
-  fail_unless(res == 0, "Unexpected lstat(2) error on '/': %s",
+  ck_assert_msg(res == 0, "Unexpected lstat(2) error on '/': %s",
     strerror(errno));
-  fail_unless(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
+  ck_assert_msg(S_ISDIR(st.st_mode), "'/' is not a directory as expected");
 
   pr_fs_statcache_reset();
   res = pr_fs_statcache_set_policy(cache_size, max_age, policy_flags);
-  fail_unless(res == 0, "Failed to set statcache policy: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set statcache policy: %s", strerror(errno));
 
   res = pr_fsio_lstat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_lstat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   /* Now wait for longer than 1 second (our configured max age) */
   sleep(max_age + 1);
 
   res = pr_fsio_lstat("/foo/bar/baz/quxx", &st);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT, got %s (%d)", strerror(errno),
     errno);
 
   /* lstat a symlink path */
   res = pr_fsio_symlink("/tmp", fsio_link_path);
-  fail_unless(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
     strerror(errno));
 
   res = pr_fsio_lstat(fsio_link_path, &st);
-  fail_unless(res == 0, "Failed to lstat '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to lstat '%s': %s", fsio_link_path,
     strerror(errno));
 
   (void) unlink(fsio_link_path);
@@ -772,13 +772,13 @@ START_TEST (fsio_sys_access_dir_test) {
   array_header *suppl_gids;
 
   res = pr_fsio_access(NULL, X_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL, got %s (%d)", strerror(errno),
     errno);
 
   res = pr_fsio_access("/baz/bar/foo", X_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Make the directory to check; we want it to have perms 771.*/
@@ -798,22 +798,22 @@ START_TEST (fsio_sys_access_dir_test) {
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, F_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for file access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for file access on directory: %s",
     strerror(errno));
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for read access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for read access on directory: %s",
     strerror(errno));
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for write access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for write access on directory: %s",
     strerror(errno));
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, X_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for execute access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for execute access on directory: %s",
     strerror(errno));
 
   suppl_gids = make_array(p, 1, sizeof(gid_t));
@@ -821,17 +821,17 @@ START_TEST (fsio_sys_access_dir_test) {
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, X_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for execute access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for execute access on directory: %s",
     strerror(errno));
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, R_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for read access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for read access on directory: %s",
     strerror(errno));
 
   pr_fs_clear_cache2(fsio_testdir_path);
   res = pr_fsio_access(fsio_testdir_path, W_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for write access on directory: %s",
+  ck_assert_msg(res == 0, "Failed to check for write access on directory: %s",
     strerror(errno));
 
   if (getenv("CI") == NULL &&
@@ -848,30 +848,30 @@ START_TEST (fsio_sys_access_dir_test) {
     pr_fs_clear_cache2(fsio_testdir_path);
     res = pr_fsio_access(fsio_testdir_path, F_OK, other_uid, other_gid,
       NULL);
-    fail_unless(res == 0,
+    ck_assert_msg(res == 0,
       "Failed to check for other file access on directory: %s",
       strerror(errno));
 
     pr_fs_clear_cache2(fsio_testdir_path);
     res = pr_fsio_access(fsio_testdir_path, R_OK, other_uid, other_gid,
       NULL);
-    fail_unless(res < 0,
+    ck_assert_msg(res < 0,
       "other read access on directory succeeded unexpectedly");
-    fail_unless(errno == EACCES, "Expected EACCES, got %s (%d)",
+    ck_assert_msg(errno == EACCES, "Expected EACCES, got %s (%d)",
       strerror(errno), errno);
 
     pr_fs_clear_cache2(fsio_testdir_path);
     res = pr_fsio_access(fsio_testdir_path, W_OK, other_uid, other_gid,
       NULL);
-    fail_unless(res < 0,
+    ck_assert_msg(res < 0,
       "other write access on directory succeeded unexpectedly");
-    fail_unless(errno == EACCES, "Expected EACCES, got %s (%d)",
+    ck_assert_msg(errno == EACCES, "Expected EACCES, got %s (%d)",
       strerror(errno), errno);
 
     pr_fs_clear_cache2(fsio_testdir_path);
     res = pr_fsio_access(fsio_testdir_path, X_OK, other_uid, other_gid,
       NULL);
-    fail_unless(res == 0, "Failed to check for execute access on directory: %s",
+    ck_assert_msg(res == 0, "Failed to check for execute access on directory: %s",
       strerror(errno));
   }
 
@@ -902,22 +902,22 @@ START_TEST (fsio_sys_access_file_test) {
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, F_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for file access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for file access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for read access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for read access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for write access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for write access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, X_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for execute access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for execute access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   suppl_gids = make_array(p, 1, sizeof(gid_t));
@@ -925,17 +925,17 @@ START_TEST (fsio_sys_access_file_test) {
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, X_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for execute access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for execute access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, R_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for read access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for read access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_access(fsio_test_path, W_OK, uid, gid, suppl_gids);
-  fail_unless(res == 0, "Failed to check for write access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for write access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   (void) unlink(fsio_test_path);
@@ -950,12 +950,12 @@ START_TEST (fsio_sys_faccess_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_faccess(NULL, F_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Unable to create file '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Unable to create file '%s': %s", fsio_test_path,
     strerror(errno));
 
   /* Use chmod(2) to ensure that the file has the perms we want,
@@ -969,22 +969,22 @@ START_TEST (fsio_sys_faccess_test) {
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_faccess(fh, F_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for file access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for file access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_faccess(fh, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for read access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for read access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_faccess(fh, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to check for write access on '%s': %s",
+  ck_assert_msg(res == 0, "Failed to check for write access on '%s': %s",
     fsio_test_path, strerror(errno));
 
   pr_fs_clear_cache2(fsio_test_path);
   res = pr_fsio_faccess(fh, X_OK, uid, gid, NULL);
-  fail_unless(res < 0,
+  ck_assert_msg(res < 0,
     "Check for execute access on '%s' succeeded unexpectedly", fsio_test_path);
 
   (void) pr_fsio_close(fh);
@@ -998,21 +998,21 @@ START_TEST (fsio_sys_truncate_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_truncate(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_truncate(fsio_test_path, 0);
-  fail_unless(res < 0, "Truncated '%s' unexpectedly", fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Truncated '%s' unexpectedly", fsio_test_path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_truncate(fsio_test_path, len);
-  fail_unless(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1024,18 +1024,18 @@ START_TEST (fsio_sys_truncate_chroot_guard_test) {
   int res;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_truncate("/etc/foo.bar.baz", 0);
-  fail_unless(res < 0, "Truncated /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Truncated /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_truncate("/lib/foo/bar/baz", 0);
-  fail_unless(res < 0, "Truncated /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Truncated /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -1047,17 +1047,17 @@ START_TEST (fsio_sys_ftruncate_test) {
   pr_buffer_t *buf;
 
   res = pr_fsio_ftruncate(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   mark_point();
   res = pr_fsio_ftruncate(fh, len);
-  fail_unless(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
     strerror(errno));
 
   /* Attach a read buffer to the handle, make sure it is cleared. */
@@ -1069,9 +1069,9 @@ START_TEST (fsio_sys_ftruncate_test) {
 
   mark_point();
   res = pr_fsio_ftruncate(fh, len);
-  fail_unless(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to truncate '%s': %s", fsio_test_path,
     strerror(errno));
-  fail_unless(buf->remaining == buf->buflen,
+  ck_assert_msg(buf->remaining == buf->buflen,
     "Expected %lu, got %lu", (unsigned long) buf->buflen,
     (unsigned long) buf->remaining);
 
@@ -1086,21 +1086,21 @@ START_TEST (fsio_sys_chmod_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_chmod(NULL, mode);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_chmod(fsio_test_path, 0);
-  fail_unless(res < 0, "Changed perms of '%s' unexpectedly", fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Changed perms of '%s' unexpectedly", fsio_test_path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_chmod(fsio_test_path, mode);
-  fail_unless(res == 0, "Failed to set perms of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set perms of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1113,18 +1113,18 @@ START_TEST (fsio_sys_chmod_chroot_guard_test) {
   mode_t mode = 0644;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_chmod("/etc/foo.bar.baz", mode);
-  fail_unless(res < 0, "Set mode on /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Set mode on /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_chmod("/lib/foo/bar/baz", mode);
-  fail_unless(res < 0, "Set mode on /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Set mode on /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -1135,16 +1135,16 @@ START_TEST (fsio_sys_fchmod_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_fchmod(NULL, mode);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fchmod(fh, mode);
-  fail_unless(res == 0, "Failed to set perms of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set perms of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1159,22 +1159,22 @@ START_TEST (fsio_sys_chown_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_chown(NULL, uid, gid);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_chown(fsio_test_path, uid, gid);
-  fail_unless(res < 0, "Changed ownership of '%s' unexpectedly",
+  ck_assert_msg(res < 0, "Changed ownership of '%s' unexpectedly",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_chown(fsio_test_path, uid, gid);
-  fail_unless(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1188,18 +1188,18 @@ START_TEST (fsio_sys_chown_chroot_guard_test) {
   gid_t gid = getgid();
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_chown("/etc/foo.bar.baz", uid, gid);
-  fail_unless(res < 0, "Set ownership on /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Set ownership on /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_chown("/lib/foo/bar/baz", uid, gid);
-  fail_unless(res < 0, "Set ownership on /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Set ownership on /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -1211,16 +1211,16 @@ START_TEST (fsio_sys_fchown_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_fchown(NULL, uid, gid);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fchown(fh, uid, gid);
-  fail_unless(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1235,22 +1235,22 @@ START_TEST (fsio_sys_lchown_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_lchown(NULL, uid, gid);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_lchown(fsio_test_path, uid, gid);
-  fail_unless(res < 0, "Changed ownership of '%s' unexpectedly",
+  ck_assert_msg(res < 0, "Changed ownership of '%s' unexpectedly",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_lchown(fsio_test_path, uid, gid);
-  fail_unless(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set ownership of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1264,18 +1264,18 @@ START_TEST (fsio_sys_lchown_chroot_guard_test) {
   gid_t gid = getgid();
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_lchown("/etc/foo.bar.baz", uid, gid);
-  fail_unless(res < 0, "Set ownership on /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Set ownership on /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_lchown("/lib/foo/bar/baz", uid, gid);
-  fail_unless(res < 0, "Set ownership on /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Set ownership on /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -1285,27 +1285,27 @@ START_TEST (fsio_sys_rename_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_rename(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_rename(fsio_test_path, NULL);
-  fail_unless(res < 0, "Failed to handle null dst argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dst argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_rename(fsio_test_path, fsio_test2_path);
-  fail_unless(res < 0, "Failed to handle non-existent files");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle non-existent files");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
   (void) pr_fsio_close(fh);
 
   res = pr_fsio_rename(fsio_test_path, fsio_test2_path);
-  fail_unless(res == 0, "Failed to rename '%s' to '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to rename '%s' to '%s': %s", fsio_test_path,
     fsio_test2_path, strerror(errno));
 
   (void) pr_fsio_unlink(fsio_test_path);
@@ -1318,28 +1318,28 @@ START_TEST (fsio_sys_rename_chroot_guard_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
   (void) pr_fsio_close(fh);
 
   res = pr_fsio_rename(fsio_test_path, "/etc/foo.bar.baz");
-  fail_unless(res < 0, "Renamed '%s' unexpectedly", fsio_test_path);
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Renamed '%s' unexpectedly", fsio_test_path);
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   res = pr_fsio_rename("/etc/foo.bar.baz", fsio_test_path);
-  fail_unless(res < 0, "Renamed '/etc/foo.bar.baz' unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Renamed '/etc/foo.bar.baz' unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_rename("/etc/foo/bar/baz", "/lib/quxx/quzz");
-  fail_unless(res < 0, "Renamed '/etc/foo/bar/baz' unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Renamed '/etc/foo/bar/baz' unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) pr_fsio_unlink(fsio_test_path);
@@ -1354,23 +1354,23 @@ START_TEST (fsio_sys_utimes_test) {
   memset(tvs, 0, sizeof(tvs));
 
   res = pr_fsio_utimes(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_utimes(fsio_test_path, (struct timeval *) &tvs);
-  fail_unless(res < 0, "Changed times of '%s' unexpectedly", fsio_test_path);
-  fail_unless(errno == ENOENT || errno == EINVAL,
+  ck_assert_msg(res < 0, "Changed times of '%s' unexpectedly", fsio_test_path);
+  ck_assert_msg(errno == ENOENT || errno == EINVAL,
     "Expected ENOENT (%d) or EINVAL (%d), got %s (%d)", ENOENT, EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   memset(&tvs, 0, sizeof(tvs));
   res = pr_fsio_utimes(fsio_test_path, (struct timeval *) &tvs);
-  fail_unless(res == 0, "Failed to set times of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set times of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1385,18 +1385,18 @@ START_TEST (fsio_sys_utimes_chroot_guard_test) {
   memset(tvs, 0, sizeof(tvs));
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
  
   res = pr_fsio_utimes("/etc/foo.bar.baz", (struct timeval *) &tvs);
-  fail_unless(res < 0, "Set times on /etc/foo.bar.baz unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Set times on /etc/foo.bar.baz unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_utimes("/lib/foo/bar/baz", (struct timeval *) &tvs);
-  fail_unless(res < 0, "Set times on /lib/foo/bar/baz unexpectedly");
-  fail_unless(errno == ENOENT || errno == EINVAL,
+  ck_assert_msg(res < 0, "Set times on /lib/foo/bar/baz unexpectedly");
+  ck_assert_msg(errno == ENOENT || errno == EINVAL,
     "Expected ENOENT (%d) or EINVAL (%d), got %s %d", ENOENT, EINVAL,
     strerror(errno), errno);
 }
@@ -1410,17 +1410,17 @@ START_TEST (fsio_sys_futimes_test) {
   memset(tvs, 0, sizeof(tvs));
 
   res = pr_fsio_futimes(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to create '%s': %s", fsio_test_path,
     strerror(errno));
 
   memset(&tvs, 0, sizeof(tvs));
   res = pr_fsio_futimes(fh, (struct timeval *) &tvs);
-  fail_unless(res == 0, "Failed to set times of '%s': %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to set times of '%s': %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);
@@ -1433,21 +1433,21 @@ START_TEST (fsio_sys_fsync_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_fsync(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fsync(fh);
 #ifdef HAVE_FSYNC
-  fail_unless(res == 0, "fsync of '%s' failed: %s", fsio_test_path,
+  ck_assert_msg(res == 0, "fsync of '%s' failed: %s", fsio_test_path,
     strerror(errno));
 #else
-  fail_unless(res < 0, "fsync of '%s' succeeded unexpectedly", fsio_test_path);
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "fsync of '%s' succeeded unexpectedly", fsio_test_path);
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* HAVE_FSYNC */
 
@@ -1462,40 +1462,40 @@ START_TEST (fsio_sys_getxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_getxattr(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_getxattr(p, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_getxattr(p, path, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_getxattr(p, path, name, NULL, 0);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   (void) pr_fsio_set_options(fsio_opts);
   res = pr_fsio_getxattr(p, path, name, NULL, 0);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexist attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexist attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1507,40 +1507,40 @@ START_TEST (fsio_sys_lgetxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_lgetxattr(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_lgetxattr(p, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_lgetxattr(p, path, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null xattr name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null xattr name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_lgetxattr(p, path, name, NULL, 0);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_lgetxattr(p, path, name, NULL, 0);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexist attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexist attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1553,44 +1553,44 @@ START_TEST (fsio_sys_fgetxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_fgetxattr(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_fgetxattr(p, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fgetxattr(p, fh, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null xattr name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null xattr name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_fgetxattr(p, fh, name, NULL, 0);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_fgetxattr(p, fh, name, NULL, 0);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexist attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexist attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 
@@ -1607,37 +1607,37 @@ START_TEST (fsio_sys_listxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_listxattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_listxattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_listxattr(p, path, NULL);
-  fail_unless(res < 0, "Failed to handle null array");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null array");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_listxattr(p, path, &names);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_listxattr(p, path, &names);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent path '%s'", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path '%s'", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
   pr_fsio_close(fh);
 
@@ -1647,8 +1647,8 @@ START_TEST (fsio_sys_listxattr_test) {
   (void) unlink(fsio_test_path);
 #else
   (void) fh;
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1662,37 +1662,37 @@ START_TEST (fsio_sys_llistxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_llistxattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_llistxattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_llistxattr(p, path, NULL);
-  fail_unless(res < 0, "Failed to handle null array");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null array");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_llistxattr(p, path, &names);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_llistxattr(p, path, &names);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent path '%s'", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path '%s'", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
   pr_fsio_close(fh);
 
@@ -1702,8 +1702,8 @@ START_TEST (fsio_sys_llistxattr_test) {
   (void) unlink(fsio_test_path);
 #else
   (void) fh;
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1716,29 +1716,29 @@ START_TEST (fsio_sys_flistxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_flistxattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_flistxattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_flistxattr(p, fh, NULL);
-  fail_unless(res < 0, "Failed to handle null array");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null array");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_flistxattr(p, fh, &names);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
@@ -1748,8 +1748,8 @@ START_TEST (fsio_sys_flistxattr_test) {
     strerror(errno));
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 
@@ -1764,40 +1764,40 @@ START_TEST (fsio_sys_removexattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_removexattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_removexattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_removexattr(p, path, NULL);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_removexattr(p, path, name);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_removexattr(p, path, name);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1809,40 +1809,40 @@ START_TEST (fsio_sys_lremovexattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_lremovexattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_lremovexattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_lremovexattr(p, path, NULL);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_lremovexattr(p, path, name);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_lremovexattr(p, path, name);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1855,44 +1855,44 @@ START_TEST (fsio_sys_fremovexattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_fremovexattr(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_fremovexattr(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fremovexattr(p, fh, NULL);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_fremovexattr(p, fh, name);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_fremovexattr(p, fh, name);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent attribute '%s'", name);
-  fail_unless(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent attribute '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == ENOATTR || errno == ENOTSUP,
     "Expected ENOENT (%d), ENOATTR (%d) or ENOTSUP (%d), got %s (%d)",
     ENOENT, ENOATTR, ENOTSUP, strerror(errno), errno);
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 
@@ -1908,19 +1908,19 @@ START_TEST (fsio_sys_setxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_setxattr(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_setxattr(p, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_setxattr(p, path, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
@@ -1928,34 +1928,34 @@ START_TEST (fsio_sys_setxattr_test) {
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_setxattr(p, path, name, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_setxattr(p, path, name, NULL, 0, flags);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent file '%s'", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file '%s'", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
   pr_fsio_close(fh);
 
   res = pr_fsio_setxattr(p, path, name, NULL, 0, flags);
   if (res < 0) {
-    fail_unless(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
+    ck_assert_msg(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
       strerror(errno), errno);
   }
 
   (void) unlink(fsio_test_path);
 #else
   (void) fh;
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -1968,19 +1968,19 @@ START_TEST (fsio_sys_lsetxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_lsetxattr(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_lsetxattr(p, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_test_path;
   res = pr_fsio_lsetxattr(p, path, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
@@ -1988,34 +1988,34 @@ START_TEST (fsio_sys_lsetxattr_test) {
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_lsetxattr(p, path, name, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_lsetxattr(p, path, name, NULL, 0, flags);
 #ifdef PR_USE_XATTR
-  fail_unless(res < 0, "Failed to handle nonexistent file '%s'", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file '%s'", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
   pr_fsio_close(fh);
 
   res = pr_fsio_lsetxattr(p, path, name, NULL, 0, flags);
   if (res < 0) {
-    fail_unless(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
+    ck_assert_msg(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
       strerror(errno), errno);
   }
 
   (void) unlink(fsio_test_path);
 #else
   (void) fh;
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 }
@@ -2028,23 +2028,23 @@ START_TEST (fsio_sys_fsetxattr_test) {
   unsigned long fsio_opts;
 
   res = pr_fsio_fsetxattr(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_fsetxattr(p, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(fsio_test_path);
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_fsetxattr(p, fh, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null attribute name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null attribute name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
@@ -2052,21 +2052,21 @@ START_TEST (fsio_sys_fsetxattr_test) {
 
   fsio_opts = pr_fsio_set_options(PR_FSIO_OPT_IGNORE_XATTR);
   res = pr_fsio_fsetxattr(p, fh, name, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle disabled xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle disabled xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_fsetxattr(p, fh, name, NULL, 0, flags);
 #ifdef PR_USE_XATTR
   if (res < 0) {
-    fail_unless(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
+    ck_assert_msg(errno == ENOTSUP, "Expected ENOTSUP (%d), got %s (%d)", ENOTSUP,
       strerror(errno), errno);
   }
 
 #else
-  fail_unless(res < 0, "Failed to handle --disable-xattr");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle --disable-xattr");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_XATTR */
 
@@ -2080,12 +2080,12 @@ START_TEST (fsio_sys_mkdir_test) {
   mode_t mode = 0755;
 
   res = pr_fsio_mkdir(NULL, mode);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_mkdir(fsio_testdir_path, mode);
-  fail_unless(res == 0, "Failed to create '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res == 0, "Failed to create '%s': %s", fsio_testdir_path,
     strerror(errno));
 
   (void) pr_fsio_rmdir(fsio_testdir_path);
@@ -2097,18 +2097,18 @@ START_TEST (fsio_sys_mkdir_chroot_guard_test) {
   mode_t mode = 0755;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
   
   res = pr_fsio_mkdir("/etc/foo.bar.baz.d", mode);
-  fail_unless(res < 0, "Created /etc/foo.bar.baz.d unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Created /etc/foo.bar.baz.d unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_mkdir("/lib/foo/bar/baz.d", mode);
-  fail_unless(res < 0, "Created /lib/foo/bar/baz.d unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Created /lib/foo/bar/baz.d unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -2118,21 +2118,21 @@ START_TEST (fsio_sys_rmdir_test) {
   mode_t mode = 0755;
 
   res = pr_fsio_rmdir(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_rmdir(fsio_testdir_path);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_fsio_mkdir(fsio_testdir_path, mode);
-  fail_unless(res == 0, "Failed to create '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res == 0, "Failed to create '%s': %s", fsio_testdir_path,
     strerror(errno));
 
   res = pr_fsio_rmdir(fsio_testdir_path);
-  fail_unless(res == 0, "Failed to remove '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res == 0, "Failed to remove '%s': %s", fsio_testdir_path,
     strerror(errno));
 }
 END_TEST
@@ -2141,18 +2141,18 @@ START_TEST (fsio_sys_rmdir_chroot_guard_test) {
   int res;
 
   res = pr_fsio_guard_chroot(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
+  ck_assert_msg(res == FALSE, "Expected FALSE (%d), got %d", FALSE, res);
 
   res = pr_fsio_rmdir("/etc/foo.bar.baz.d");
-  fail_unless(res < 0, "Removed /etc/foo.bar.baz.d unexpectedly");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
+  ck_assert_msg(res < 0, "Removed /etc/foo.bar.baz.d unexpectedly");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s %d", EACCES,
     strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
   res = pr_fsio_rmdir("/lib/foo/bar/baz.d");
-  fail_unless(res < 0, "Removed /lib/etc/foo.bar.baz.d unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
+  ck_assert_msg(res < 0, "Removed /lib/etc/foo.bar.baz.d unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s %d", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -2161,22 +2161,22 @@ START_TEST (fsio_sys_chdir_test) {
   int res;
 
   res = pr_fsio_chdir(NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_chdir("/etc/hosts", FALSE);
-  fail_unless(res < 0, "Failed to handle file argument");
-  fail_unless(errno == EINVAL || errno == ENOTDIR,
+  ck_assert_msg(res < 0, "Failed to handle file argument");
+  ck_assert_msg(errno == EINVAL || errno == ENOTDIR,
     "Expected EINVAL (%d) or ENOTDIR (%d), got %s (%d)", EINVAL, ENOTDIR,
     strerror(errno), errno);
 
   res = pr_fsio_chdir("/tmp", FALSE);
-  fail_unless(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
+  ck_assert_msg(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
     strerror(errno));
 
   res = pr_fsio_chdir(fsio_cwd, FALSE);
-  fail_unless(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
+  ck_assert_msg(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
     strerror(errno));
 }
 END_TEST
@@ -2185,16 +2185,16 @@ START_TEST (fsio_sys_chdir_canon_test) {
   int res;
 
   res = pr_fsio_chdir_canon(NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_chdir_canon("/tmp", FALSE);
-  fail_unless(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
+  ck_assert_msg(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
     strerror(errno));
 
   res = pr_fsio_chdir_canon(fsio_cwd, FALSE);
-  fail_unless(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
+  ck_assert_msg(res == 0, "Failed to chdir to '%s': %s", fsio_cwd,
     strerror(errno));
 }
 END_TEST
@@ -2203,14 +2203,14 @@ START_TEST (fsio_sys_chroot_test) {
   int res;
 
   res = pr_fsio_chroot(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   if (getuid() != 0) {
     res = pr_fsio_chroot("/tmp");
-    fail_unless(res < 0, "Failed to chroot without root privs");
-    fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+    ck_assert_msg(res < 0, "Failed to chroot without root privs");
+    ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
       strerror(errno), errno);
   }
 }
@@ -2222,26 +2222,26 @@ START_TEST (fsio_sys_opendir_test) {
 
   mark_point();
   res = pr_fsio_opendir(NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno); 
 
   mark_point();
   path = "/etc/hosts";
   res = pr_fsio_opendir(path);
-  fail_unless(res == NULL, "Failed to handle file argument");
-  fail_unless(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
+  ck_assert_msg(res == NULL, "Failed to handle file argument");
+  ck_assert_msg(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
     strerror(errno), errno);
 
   mark_point();
   path = "/tmp/";
   res = pr_fsio_opendir(path);
-  fail_unless(res != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to open '%s': %s", path, strerror(errno));
 
   mark_point();
   path = "/usr/";
   res2 = pr_fsio_opendir(path);
-  fail_unless(res != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to open '%s': %s", path, strerror(errno));
 
   (void) pr_fsio_closedir(res);
   (void) pr_fsio_closedir(res2);
@@ -2253,21 +2253,21 @@ START_TEST (fsio_sys_readdir_test) {
   struct dirent *dent;
 
   dent = pr_fsio_readdir(NULL);
-  fail_unless(dent == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(dent == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   dent = pr_fsio_readdir("/etc/hosts");
-  fail_unless(dent == NULL, "Failed to handle file argument");
-  fail_unless(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
+  ck_assert_msg(dent == NULL, "Failed to handle file argument");
+  ck_assert_msg(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
     strerror(errno), errno);
 
   mark_point();
   dirh = pr_fsio_opendir("/tmp/");
-  fail_unless(dirh != NULL, "Failed to open '/tmp/': %s", strerror(errno));
+  ck_assert_msg(dirh != NULL, "Failed to open '/tmp/': %s", strerror(errno));
 
   dent = pr_fsio_readdir(dirh);
-  fail_unless(dent != NULL, "Failed to read directory entry: %s",
+  ck_assert_msg(dent != NULL, "Failed to read directory entry: %s",
     strerror(errno));
 
   (void) pr_fsio_closedir(dirh);
@@ -2279,20 +2279,20 @@ START_TEST (fsio_sys_closedir_test) {
   int res;
 
   res = pr_fsio_closedir(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   dirh = pr_fsio_opendir("/tmp/");
-  fail_unless(dirh != NULL, "Failed to open '/tmp/': %s", strerror(errno));
+  ck_assert_msg(dirh != NULL, "Failed to open '/tmp/': %s", strerror(errno));
 
   res = pr_fsio_closedir(dirh);
-  fail_unless(res == 0, "Failed to close '/tmp/': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close '/tmp/': %s", strerror(errno));
 
   /* Closing an already-closed directory descriptor should fail. */
   res = pr_fsio_closedir(dirh);
-  fail_unless(res < 0, "Failed to handle already-closed directory handle");
-  fail_unless(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
+  ck_assert_msg(res < 0, "Failed to handle already-closed directory handle");
+  ck_assert_msg(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
     strerror(errno), errno);
 }
 END_TEST
@@ -2312,18 +2312,18 @@ START_TEST (fsio_sys_chmod_with_error_test) {
 
   mark_point();
   res = pr_fsio_chmod_with_error(NULL, fsio_test_path, 0755, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_chmod_with_error(p, fsio_test_path, 0755, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2333,17 +2333,17 @@ START_TEST (fsio_sys_chmod_with_error_test) {
 
   mark_point();
   res = pr_fsio_chmod_with_error(p, fsio_test_path, 0755, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "chmod() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2366,18 +2366,18 @@ START_TEST (fsio_sys_chown_with_error_test) {
 
   mark_point();
   res = pr_fsio_chown_with_error(NULL, fsio_test_path, 1, 1, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_chown_with_error(p, fsio_test_path, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2387,17 +2387,17 @@ START_TEST (fsio_sys_chown_with_error_test) {
 
   mark_point();
   res = pr_fsio_chown_with_error(p, fsio_test_path, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "chown() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2420,21 +2420,21 @@ START_TEST (fsio_sys_chroot_with_error_test) {
 
   mark_point();
   res = pr_fsio_chroot_with_error(NULL, fsio_testdir_path, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == EPERM || errno == ENOENT,
+  ck_assert_msg(errno == EPERM || errno == ENOENT,
     "Expected EPERM (%d) or ENOENT (%d), %s (%d)", EPERM, ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_chroot_with_error(p, fsio_testdir_path, &err);
   xerrno = errno;
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == EPERM || errno == ENOENT,
+  ck_assert_msg(errno == EPERM || errno == ENOENT,
     "Expected EPERM (%d) or ENOENT (%d), %s (%d)", EPERM, ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2445,19 +2445,19 @@ START_TEST (fsio_sys_chroot_with_error_test) {
   mark_point();
   res = pr_fsio_chroot_with_error(p, fsio_testdir_path, &err);
   xerrno = errno;
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == EPERM || errno == ENOENT,
+  ck_assert_msg(errno == EPERM || errno == ENOENT,
     "Expected EPERM (%d) or ENOENT (%d), %s (%d)", EPERM, ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "chroot() failed with \"", strerror(xerrno), " [",
     xerrno == ENOENT ? "ENOENT" : "EPERM", " (",
     get_errnum(p, xerrno), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2480,16 +2480,16 @@ START_TEST (fsio_sys_close_with_error_test) {
 
   mark_point();
   res = pr_fsio_close_with_error(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_close_with_error(p, NULL, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2499,16 +2499,16 @@ START_TEST (fsio_sys_close_with_error_test) {
 
   mark_point();
   res = pr_fsio_close_with_error(p, NULL, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "close() failed with \"Invalid argument [EINVAL (",
     get_errnum(p, EINVAL), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2531,16 +2531,16 @@ START_TEST (fsio_sys_fchmod_with_error_test) {
 
   mark_point();
   res = pr_fsio_fchmod_with_error(NULL, NULL, 0755, NULL);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_fchmod_with_error(p, NULL, 0755, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2550,16 +2550,16 @@ START_TEST (fsio_sys_fchmod_with_error_test) {
 
   mark_point();
   res = pr_fsio_fchmod_with_error(p, NULL, 0755, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "fchmod() failed with \"Invalid argument [EINVAL (",
     get_errnum(p, EINVAL), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2582,16 +2582,16 @@ START_TEST (fsio_sys_fchown_with_error_test) {
 
   mark_point();
   res = pr_fsio_fchown_with_error(NULL, NULL, 1, 1, NULL);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_fchown_with_error(p, NULL, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2601,16 +2601,16 @@ START_TEST (fsio_sys_fchown_with_error_test) {
 
   mark_point();
   res = pr_fsio_fchown_with_error(p, NULL, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "fchown() failed with \"Invalid argument [EINVAL (",
     get_errnum(p, EINVAL), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2633,18 +2633,18 @@ START_TEST (fsio_sys_lchown_with_error_test) {
 
   mark_point();
   res = pr_fsio_lchown_with_error(NULL, fsio_test_path, 1, 1, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_lchown_with_error(p, fsio_test_path, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2654,17 +2654,17 @@ START_TEST (fsio_sys_lchown_with_error_test) {
 
   mark_point();
   res = pr_fsio_lchown_with_error(p, fsio_test_path, 1, 1, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "lchown() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2688,18 +2688,18 @@ START_TEST (fsio_sys_lstat_with_error_test) {
 
   mark_point();
   res = pr_fsio_lstat_with_error(NULL, fsio_test_path, &st, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_lstat_with_error(p, fsio_test_path, &st, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2709,17 +2709,17 @@ START_TEST (fsio_sys_lstat_with_error_test) {
 
   mark_point();
   res = pr_fsio_lstat_with_error(p, fsio_test_path, &st, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "lstat() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2744,18 +2744,18 @@ START_TEST (fsio_sys_mkdir_with_error_test) {
 
   mark_point();
   res = pr_fsio_mkdir_with_error(NULL, path, 0755, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_mkdir_with_error(p, path, 0755, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2765,17 +2765,17 @@ START_TEST (fsio_sys_mkdir_with_error_test) {
 
   mark_point();
   res = pr_fsio_mkdir_with_error(p, path, 0755, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "mkdir() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2798,18 +2798,18 @@ START_TEST (fsio_sys_open_with_error_test) {
 
   mark_point();
   fh = pr_fsio_open_with_error(NULL, fsio_test_path, O_RDONLY, NULL);
-  fail_unless(fh == NULL, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(fh == NULL, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   fh = pr_fsio_open_with_error(p, fsio_test_path, O_RDONLY, &err);
-  fail_unless(fh == NULL, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(fh == NULL, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2819,17 +2819,17 @@ START_TEST (fsio_sys_open_with_error_test) {
 
   mark_point();
   fh = pr_fsio_open_with_error(p, fsio_test_path, O_RDONLY, &err);
-  fail_unless(fh == NULL, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(fh == NULL, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "open() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2852,16 +2852,16 @@ START_TEST (fsio_sys_read_with_error_test) {
 
   mark_point();
   res = pr_fsio_read_with_error(NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_read_with_error(p, NULL, NULL, 0, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2871,16 +2871,16 @@ START_TEST (fsio_sys_read_with_error_test) {
 
   mark_point();
   res = pr_fsio_read_with_error(p, NULL, NULL, 0, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "read() failed with \"Invalid argument [EINVAL (",
     get_errnum(p, EINVAL), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2903,18 +2903,18 @@ START_TEST (fsio_sys_rename_with_error_test) {
 
   mark_point();
   res = pr_fsio_rename_with_error(NULL, fsio_test_path, fsio_test2_path, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_rename_with_error(p, fsio_test_path, fsio_test2_path, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2924,17 +2924,17 @@ START_TEST (fsio_sys_rename_with_error_test) {
 
   mark_point();
   res = pr_fsio_rename_with_error(p, fsio_test_path, fsio_test2_path, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "rename() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -2957,11 +2957,11 @@ START_TEST (fsio_sys_rmdir_with_error_test) {
 
   mark_point();
   res = pr_fsio_rmdir_with_error(NULL, fsio_testdir_path, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -2971,17 +2971,17 @@ START_TEST (fsio_sys_rmdir_with_error_test) {
 
   mark_point();
   res = pr_fsio_rmdir_with_error(p, fsio_testdir_path, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_testdir_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "rmdir() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -3005,18 +3005,18 @@ START_TEST (fsio_sys_stat_with_error_test) {
 
   mark_point();
   res = pr_fsio_stat_with_error(NULL, fsio_test_path, &st, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_stat_with_error(p, fsio_test_path, &st, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -3026,17 +3026,17 @@ START_TEST (fsio_sys_stat_with_error_test) {
 
   mark_point();
   res = pr_fsio_stat_with_error(p, fsio_test_path, &st, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "stat() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -3059,18 +3059,18 @@ START_TEST (fsio_sys_unlink_with_error_test) {
 
   mark_point();
   res = pr_fsio_unlink_with_error(NULL, fsio_test_path, NULL);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_unlink_with_error(p, fsio_test_path, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -3080,17 +3080,17 @@ START_TEST (fsio_sys_unlink_with_error_test) {
 
   mark_point();
   res = pr_fsio_unlink_with_error(p, fsio_test_path, &err);
-  fail_unless(res < 0, "Failed to handle non-existent file '%s'",
+  ck_assert_msg(res < 0, "Failed to handle non-existent file '%s'",
     fsio_test_path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "unlink() failed with \"No such file or directory [ENOENT (",
     get_errnum(p, ENOENT), ")]\"", NULL);
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -3113,16 +3113,16 @@ START_TEST (fsio_sys_write_with_error_test) {
 
   mark_point();
   res = pr_fsio_write_with_error(NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fsio_write_with_error(p, NULL, NULL, 0, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err == NULL, "Unexpectedly populated error");
+  ck_assert_msg(err == NULL, "Unexpectedly populated error");
 
   memset(&m, 0, sizeof(m));
   m.name = "error";
@@ -3132,17 +3132,17 @@ START_TEST (fsio_sys_write_with_error_test) {
 
   mark_point();
   res = pr_fsio_write_with_error(p, NULL, NULL, 0, &err);
-  fail_unless(res < 0, "Failed to handle null fh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), %s (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(err != NULL, "Failed to populate error");
+  ck_assert_msg(err != NULL, "Failed to populate error");
 
   expected = pstrcat(p,
     "write() failed with \"Invalid argument [EINVAL (",
     get_errnum(p, EINVAL), ")]\"", NULL);
   expected = "write() failed with \"Invalid argument [EINVAL (22)]\"";
   errstr = pr_error_strerror(err, PR_ERROR_FORMAT_USE_MINIMAL);
-  fail_unless(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(errstr, expected) == 0, "Expected '%s', got '%s'",
     expected, errstr);
 
   (void) pr_error_unregister_explainer(p, &m, NULL);
@@ -3159,47 +3159,47 @@ START_TEST (fsio_statcache_clear_cache_test) {
   pr_fs_clear_cache();
 
   res = pr_fs_clear_cache2("/testsuite");
-  fail_unless(res == 0, "Failed to clear cache: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to clear cache: %s", strerror(errno));
 
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   res = pr_fs_clear_cache2("/tmp");
   expected = 1;
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 
   res = pr_fs_clear_cache2("/testsuite");
   expected = 0;
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   res = pr_fsio_lstat("/tmp", &st);
-  fail_unless(res == 0, "Failed to lstat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lstat '/tmp': %s", strerror(errno));
 
   res = pr_fs_clear_cache2("/tmp");
   expected = 2;
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   res = pr_fsio_lstat("/tmp", &st);
-  fail_unless(res == 0, "Failed to lstat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lstat '/tmp': %s", strerror(errno));
 
   cwd = getcwd(NULL, 0);
-  fail_unless(cwd != NULL, "Failed to get cwd: %s", strerror(errno));
+  ck_assert_msg(cwd != NULL, "Failed to get cwd: %s", strerror(errno));
 
   res = pr_fs_setcwd("/");
-  fail_unless(res == 0, "Failed to set cwd to '/': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set cwd to '/': %s", strerror(errno));
 
   res = pr_fs_clear_cache2("tmp");
   expected = 2;
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 
   res = pr_fs_setcwd(cwd);
-  fail_unless(res == 0, "Failed to set cwd to '%s': %s", cwd, strerror(errno)); 
+  ck_assert_msg(res == 0, "Failed to set cwd to '%s': %s", cwd, strerror(errno)); 
 
   free(cwd);
 }
@@ -3211,11 +3211,11 @@ START_TEST (fsio_statcache_cache_hit_test) {
 
   /* First is a cache miss...*/
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   /* This is a cache hit, hopefully. */
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   pr_fs_clear_cache();
 }
@@ -3227,14 +3227,14 @@ START_TEST (fsio_statcache_negative_cache_test) {
 
   /* First is a cache miss...*/
   res = pr_fsio_stat("/foo.bar.baz.d", &st);
-  fail_unless(res < 0, "Check of '/foo.bar.baz.d' succeeded unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Check of '/foo.bar.baz.d' succeeded unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* This is a cache hit, hopefully. */
   res = pr_fsio_stat("/foo.bar.baz.d", &st);
-  fail_unless(res < 0, "Check of '/foo.bar.baz.d' succeeded unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Check of '/foo.bar.baz.d' succeeded unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pr_fs_clear_cache();
@@ -3252,7 +3252,7 @@ START_TEST (fsio_statcache_expired_test) {
   /* First is a cache miss...*/
   mark_point();
   res = pr_fsio_stat("/tmp", &st);
-  fail_unless(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat '/tmp': %s", strerror(errno));
 
   /* Wait for that cached data to expire...*/
   sleep(max_age + 1);
@@ -3260,8 +3260,8 @@ START_TEST (fsio_statcache_expired_test) {
   /* This is another cache miss, hopefully. */
   mark_point();
   res = pr_fsio_stat("/tmp2", &st);
-  fail_unless(res < 0, "Check of '/tmp2' succeeded unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Check of '/tmp2' succeeded unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
@@ -3279,17 +3279,17 @@ START_TEST (fs_create_fs_test) {
   pr_fs_t *fs;
 
   fs = pr_create_fs(NULL, NULL);
-  fail_unless(fs == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_create_fs(p, NULL);
-  fail_unless(fs == NULL, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_create_fs(p, "testsuite");
-  fail_unless(fs != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to create FS: %s", strerror(errno));
 }
 END_TEST
 
@@ -3298,40 +3298,40 @@ START_TEST (fs_insert_fs_test) {
   int res;
 
   res = pr_insert_fs(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_create_fs(p, "testsuite");
-  fail_unless(fs != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs, NULL);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_insert_fs(fs, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs, "/testsuite");
-  fail_unless(res == FALSE, "Failed to handle duplicate paths");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res == FALSE, "Failed to handle duplicate paths");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   fs2 = pr_create_fs(p, "testsuite2");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite2");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs2 = pr_create_fs(p, "testsuite3");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   /* Push this FS on top of the previously registered path; FSes can be
    * stacked like this.
    */
   res = pr_insert_fs(fs2, "/testsuite2");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   (void) pr_remove_fs("/testsuite");
   (void) pr_remove_fs("/testsuite2");
@@ -3344,32 +3344,32 @@ START_TEST (fs_get_fs_test) {
   int exact_match = FALSE, res;
 
   fs = pr_get_fs(NULL, NULL);
-  fail_unless(fs == NULL, "Failed to handle null arguments");
+  ck_assert_msg(fs == NULL, "Failed to handle null arguments");
 
   fs = pr_get_fs("/testsuite", &exact_match);
-  fail_unless(fs != NULL, "Failed to get FS: %s", strerror(errno));
-  fail_unless(exact_match == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(fs != NULL, "Failed to get FS: %s", strerror(errno));
+  ck_assert_msg(exact_match == FALSE, "Expected FALSE, got TRUE");
 
   fs2 = pr_create_fs(p, "testsuite");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs = pr_get_fs("/testsuite", &exact_match);
-  fail_unless(fs != NULL, "Failed to get FS: %s", strerror(errno));
-  fail_unless(exact_match == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(fs != NULL, "Failed to get FS: %s", strerror(errno));
+  ck_assert_msg(exact_match == TRUE, "Expected TRUE, got FALSE");
 
   fs3 = pr_create_fs(p, "testsuite2");
-  fail_unless(fs3 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs3 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs3, "/testsuite2/");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   exact_match = FALSE;
   fs = pr_get_fs("/testsuite2/foo/bar/baz", &exact_match);
-  fail_unless(fs != NULL, "Failed to get FS: %s", strerror(errno));
-  fail_unless(exact_match == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(fs != NULL, "Failed to get FS: %s", strerror(errno));
+  ck_assert_msg(exact_match == FALSE, "Expected FALSE, got TRUE");
 
   (void) pr_remove_fs("/testsuite2");
   (void) pr_remove_fs("/testsuite");
@@ -3381,53 +3381,53 @@ START_TEST (fs_unmount_fs_test) {
   int res;
 
   fs = pr_unmount_fs(NULL, NULL);
-  fail_unless(fs == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_unmount_fs("/testsuite", NULL);
-  fail_unless(fs == NULL, "Failed to handle absent FS");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(fs == NULL, "Failed to handle absent FS");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   fs2 = pr_create_fs(p, "testsuite");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs = pr_unmount_fs("/testsuite", "foo bar");
-  fail_unless(fs == NULL, "Failed to mismatched path AND name");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(fs == NULL, "Failed to mismatched path AND name");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fs = pr_unmount_fs("/testsuite2", NULL);
-  fail_unless(fs == NULL, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(fs == NULL, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fs2 = pr_unmount_fs("/testsuite", NULL);
-  fail_unless(fs2 != NULL, "Failed to unmount '/testsuite': %s",
+  ck_assert_msg(fs2 != NULL, "Failed to unmount '/testsuite': %s",
     strerror(errno));
 
   fs2 = pr_create_fs(p, "testsuite");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs2 = pr_create_fs(p, "testsuite2");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs2 = pr_unmount_fs("/testsuite", NULL);
-  fail_unless(fs2 != NULL, "Failed to unmount '/testsuite': %s",
+  ck_assert_msg(fs2 != NULL, "Failed to unmount '/testsuite': %s",
     strerror(errno));
 
   fs2 = pr_unmount_fs("/testsuite", NULL);
-  fail_unless(fs2 != NULL, "Failed to unmount '/testsuite': %s",
+  ck_assert_msg(fs2 != NULL, "Failed to unmount '/testsuite': %s",
     strerror(errno));
 
   (void) pr_remove_fs("/testsuite");
@@ -3440,28 +3440,28 @@ START_TEST (fs_remove_fs_test) {
   int res;
 
   fs = pr_remove_fs(NULL);
-  fail_unless(fs == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_remove_fs("/testsuite");
-  fail_unless(fs == NULL, "Failed to handle absent FS");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(fs == NULL, "Failed to handle absent FS");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   fs2 = pr_create_fs(p, "testsuite");
-  fail_unless(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
+  ck_assert_msg(fs2 != NULL, "Failed to create FS: %s", strerror(errno));
 
   res = pr_insert_fs(fs2, "/testsuite");
-  fail_unless(res == TRUE, "Failed to insert FS: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to insert FS: %s", strerror(errno));
 
   fs = pr_remove_fs("/testsuite2");
-  fail_unless(fs == NULL, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(fs == NULL, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fs2 = pr_remove_fs("/testsuite");
-  fail_unless(fs2 != NULL, "Failed to remove '/testsuite': %s",
+  ck_assert_msg(fs2 != NULL, "Failed to remove '/testsuite': %s",
     strerror(errno));
 }
 END_TEST
@@ -3470,26 +3470,26 @@ START_TEST (fs_register_fs_test) {
   pr_fs_t *fs, *fs2;
 
   fs = pr_register_fs(NULL, NULL, NULL);
-  fail_unless(fs == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_register_fs(p, NULL, NULL);
-  fail_unless(fs == NULL, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_register_fs(p, "testsuite", NULL);
-  fail_unless(fs == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(fs == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fs = pr_register_fs(p, "testsuite", "/testsuite");
-  fail_unless(fs != NULL, "Failed to register FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register FS: %s", strerror(errno));
 
   fs2 = pr_register_fs(p, "testsuite", "/testsuite");
-  fail_unless(fs2 == NULL, "Failed to handle duplicate names");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(fs2 == NULL, "Failed to handle duplicate names");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   (void) pr_remove_fs("/testsuite");
@@ -3501,20 +3501,20 @@ START_TEST (fs_unregister_fs_test) {
   int res;
 
   res = pr_unregister_fs(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_unregister_fs("/testsuite");
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fs = pr_register_fs(p, "testsuite", "/testsuite");
-  fail_unless(fs != NULL, "Failed to register FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register FS: %s", strerror(errno));
 
   res = pr_unregister_fs("/testsuite");
-  fail_unless(res == 0, "Failed to unregister '/testsuite': %s",
+  ck_assert_msg(res == 0, "Failed to unregister '/testsuite': %s",
     strerror(errno));
 }
 END_TEST
@@ -3527,13 +3527,13 @@ START_TEST (fs_resolve_fs_map_test) {
   pr_resolve_fs_map();
 
   fs = pr_register_fs(p, "testsuite", "/testsuite");
-  fail_unless(fs != NULL, "Failed to register FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register FS: %s", strerror(errno));
 
   mark_point();
   pr_resolve_fs_map();
 
   res = pr_unregister_fs("/testsuite");
-  fail_unless(res == 0, "Failed to unregister '/testsuite': %s",
+  ck_assert_msg(res == 0, "Failed to unregister '/testsuite': %s",
     strerror(errno));
 
   mark_point();
@@ -3605,7 +3605,7 @@ START_TEST (fsio_custom_chroot_test) {
   const char *path;
 
   fs = pr_register_fs(p, "custom", "/testsuite/");
-  fail_unless(fs != NULL, "Failed to register custom FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register custom FS: %s", strerror(errno));
 
   fs->chroot = fsio_chroot_cb;
 
@@ -3614,7 +3614,7 @@ START_TEST (fsio_custom_chroot_test) {
 
   path = "/testsuite/foo/bar";
   res = pr_fsio_chroot(path);
-  fail_unless(res == 0, "Failed to chroot (via custom FS) to '%s': %s", path,
+  ck_assert_msg(res == 0, "Failed to chroot (via custom FS) to '%s': %s", path,
     strerror(errno));
 
   pr_unregister_fs("/testsuite");
@@ -3626,14 +3626,14 @@ START_TEST (fs_clean_path_test) {
 
   mark_point();
   pr_fs_clean_path(NULL, NULL, 0);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
 
   mark_point();
   pr_fs_clean_path(path, NULL, 0);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res[sizeof(res)-1] = '\0';
@@ -3642,33 +3642,33 @@ START_TEST (fs_clean_path_test) {
   pr_fs_clean_path(path, res, 0);
 
   pr_fs_clean_path(path, res, sizeof(res)-1);
-  fail_unless(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
+  ck_assert_msg(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
     path, res);
 
   res[sizeof(res)-1] = '\0';
   path = "/test.txt";
   pr_fs_clean_path(path, res, sizeof(res)-1);
-  fail_unless(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
+  ck_assert_msg(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
     path, res);
 
   res[sizeof(res)-1] = '\0';
   path = "/test.txt";
   pr_fs_clean_path(path, res, sizeof(res)-1);
-  fail_unless(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
+  ck_assert_msg(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
     path, res);
 
   res[sizeof(res)-1] = '\0';
   path = "/./test.txt";
   pr_fs_clean_path(path, res, sizeof(res)-1);
   expected = "/test.txt";
-  fail_unless(strcmp(res, expected) == 0,
+  ck_assert_msg(strcmp(res, expected) == 0,
     "Expected cleaned path '%s', got '%s'", expected, res);
 
   res[sizeof(res)-1] = '\0';
   path = "test.txt";
   pr_fs_clean_path(path, res, sizeof(res)-1);
   expected = "/test.txt";
-  fail_unless(strcmp(res, expected) == 0,
+  ck_assert_msg(strcmp(res, expected) == 0,
     "Expected cleaned path '%s', got '%s'", path, res);
 }
 END_TEST
@@ -3679,59 +3679,59 @@ START_TEST (fs_clean_path2_test) {
 
   mark_point();
   code = pr_fs_clean_path2(NULL, NULL, 0, 0);
-  fail_unless(code < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(code < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
 
   mark_point();
   code = pr_fs_clean_path2(path, NULL, 0, 0);
-  fail_unless(code < 0, "Failed to handle null buf");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(code < 0, "Failed to handle null buf");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res[sizeof(res)-1] = '\0';
 
   mark_point();
   code = pr_fs_clean_path2(path, res, 0, 0);
-  fail_unless(code == 0, "Failed to handle zero length buf: %s",
+  ck_assert_msg(code == 0, "Failed to handle zero length buf: %s",
     strerror(errno));
 
   res[sizeof(res)-1] = '\0';
   path = "test.txt";
   code = pr_fs_clean_path2(path, res, sizeof(res)-1, 0);
-  fail_unless(code == 0, "Failed to clean path '%s': %s", path,
+  ck_assert_msg(code == 0, "Failed to clean path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
+  ck_assert_msg(strcmp(res, path) == 0, "Expected cleaned path '%s', got '%s'",
     path, res);
 
   res[sizeof(res)-1] = '\0';
   path = "/./test.txt";
   code = pr_fs_clean_path2(path, res, sizeof(res)-1, 0);
-  fail_unless(code == 0, "Failed to clean path '%s': %s", path,
+  ck_assert_msg(code == 0, "Failed to clean path '%s': %s", path,
     strerror(errno));
   expected = "/test.txt";
-  fail_unless(strcmp(res, expected) == 0,
+  ck_assert_msg(strcmp(res, expected) == 0,
     "Expected cleaned path '%s', got '%s'", expected, res);
 
   res[sizeof(res)-1] = '\0';
   path = "test.d///test.txt";
   code = pr_fs_clean_path2(path, res, sizeof(res)-1, 0);
-  fail_unless(code == 0, "Failed to clean path '%s': %s", path,
+  ck_assert_msg(code == 0, "Failed to clean path '%s': %s", path,
     strerror(errno));
   expected = "test.d/test.txt";
-  fail_unless(strcmp(res, expected) == 0,
+  ck_assert_msg(strcmp(res, expected) == 0,
     "Expected cleaned path '%s', got '%s'", expected, res);
 
   res[sizeof(res)-1] = '\0';
   path = "/test.d///test.txt";
   code = pr_fs_clean_path2(path, res, sizeof(res)-1,
     PR_FSIO_CLEAN_PATH_FL_MAKE_ABS_PATH);
-  fail_unless(code == 0, "Failed to clean path '%s': %s", path,
+  ck_assert_msg(code == 0, "Failed to clean path '%s': %s", path,
     strerror(errno));
   expected = "/test.d/test.txt";
-  fail_unless(strcmp(res, expected) == 0,
+  ck_assert_msg(strcmp(res, expected) == 0,
     "Expected cleaned path '%s', got '%s'", expected, res);
 }
 END_TEST
@@ -3741,18 +3741,18 @@ START_TEST (fs_dircat_test) {
   int res;
 
   res = pr_fs_dircat(NULL, 0, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL,
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL,
     "Failed to set errno to EINVAL for null arguments");
 
   res = pr_fs_dircat(buf, 0, "foo", "bar");
-  fail_unless(res == -1, "Failed to handle zero-length buffer");
-  fail_unless(errno == EINVAL,
+  ck_assert_msg(res == -1, "Failed to handle zero-length buffer");
+  ck_assert_msg(errno == EINVAL,
     "Failed to set errno to EINVAL for zero-length buffer");
 
   res = pr_fs_dircat(buf, -1, "foo", "bar");
-  fail_unless(res == -1, "Failed to handle negative-length buffer");
-  fail_unless(errno == EINVAL,
+  ck_assert_msg(res == -1, "Failed to handle negative-length buffer");
+  ck_assert_msg(errno == EINVAL,
     "Failed to set errno to EINVAL for negative-length buffer");
 
   a = pcalloc(p, PR_TUNABLE_PATH_MAX);
@@ -3761,56 +3761,56 @@ START_TEST (fs_dircat_test) {
   b = "foo";
 
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == -1, "Failed to handle too-long paths");
-  fail_unless(errno == ENAMETOOLONG,
+  ck_assert_msg(res == -1, "Failed to handle too-long paths");
+  ck_assert_msg(errno == ENAMETOOLONG,
     "Failed to set errno to ENAMETOOLONG for too-long paths");
 
   a = "foo";
   b = "/bar";
   ok = b;
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate abs-path path second dir");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate abs-path path second dir");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
  
   a = "foo";
   b = "bar";
   ok = "foo/bar";
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate two normal paths");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate two normal paths");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
  
   a = "foo/";
   b = "bar";
   ok = "foo/bar";
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate first dir with trailing slash");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate first dir with trailing slash");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
 
   a = "";
   b = "";
   ok = "/";
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate two empty paths");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate two empty paths");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
 
   a = "/foo";
   b = "";
   ok = "/foo/";
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate two empty paths");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate two empty paths");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
 
   a = "";
   b = "/bar";
   ok = "/bar/";
   res = pr_fs_dircat(buf, sizeof(buf)-1, a, b);
-  fail_unless(res == 0, "Failed to concatenate two empty paths");
-  fail_unless(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
+  ck_assert_msg(res == 0, "Failed to concatenate two empty paths");
+  ck_assert_msg(strcmp(buf, ok) == 0, "Expected concatenated dir '%s', got '%s'",
     ok, buf);
 }
 END_TEST
@@ -3823,19 +3823,19 @@ START_TEST (fs_setcwd_test) {
    * buffer that it is already using.
    */
   res = pr_fs_setcwd(pr_fs_getcwd());
-  fail_unless(res == 0, "Failed to set cwd to '%s': %s", pr_fs_getcwd(),
+  ck_assert_msg(res == 0, "Failed to set cwd to '%s': %s", pr_fs_getcwd(),
     strerror(errno));
 
   wd = pr_fs_getcwd();
-  fail_unless(wd != NULL, "Failed to get working directory: %s",
+  ck_assert_msg(wd != NULL, "Failed to get working directory: %s",
     strerror(errno));
-  fail_unless(strcmp(wd, fsio_cwd) == 0,
+  ck_assert_msg(strcmp(wd, fsio_cwd) == 0,
     "Expected '%s', got '%s'", fsio_cwd, wd);
 
   wd = pr_fs_getvwd();
-  fail_unless(wd != NULL, "Failed to get working directory: %s",
+  ck_assert_msg(wd != NULL, "Failed to get working directory: %s",
     strerror(errno));
-  fail_unless(strcmp(wd, "/") == 0, "Expected '/', got '%s'", wd);
+  ck_assert_msg(strcmp(wd, "/") == 0, "Expected '/', got '%s'", wd);
 }
 END_TEST
 
@@ -3844,20 +3844,20 @@ START_TEST (fs_glob_test) {
   int res;
 
   res = pr_fs_glob(NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_glob(NULL, 0, NULL, &pglob);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&pglob, 0, sizeof(pglob));
   res = pr_fs_glob("*", 0, NULL, &pglob);
-  fail_unless(res == 0, "Failed to glob: glob(3) returned %d: %s", res,
+  ck_assert_msg(res == 0, "Failed to glob: glob(3) returned %d: %s", res,
     strerror(errno));
-  fail_unless(pglob.gl_pathc > 0, "Expected >0, got %lu",
+  ck_assert_msg(pglob.gl_pathc > 0, "Expected >0, got %lu",
     (unsigned long) pglob.gl_pathc);
 
   mark_point();
@@ -3874,30 +3874,30 @@ START_TEST (fs_copy_file_test) {
   pr_fh_t *fh;
 
   res = pr_fs_copy_file(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   src_path = (char *) fsio_copy_src_path;
   res = pr_fs_copy_file(src_path, NULL);
-  fail_unless(res < 0, "Failed to handle null destination path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null destination path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   dst_path = (char *) fsio_copy_dst_path;
   res = pr_fs_copy_file(src_path, dst_path);
-  fail_unless(res < 0, "Failed to handle nonexistent source path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent source path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_fs_copy_file("/tmp", dst_path);
-  fail_unless(res < 0, "Failed to handle directory source path");
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle directory source path");
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   (void) unlink(src_path);
   fh = pr_fsio_open(src_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", src_path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", src_path, strerror(errno));
 
   text = "Hello, World!\n";
   res = pr_fsio_write(fh, text, strlen(text));
@@ -3905,27 +3905,27 @@ START_TEST (fs_copy_file_test) {
     strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to close '%s': %s", src_path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close '%s': %s", src_path, strerror(errno));
 
   res = pr_fs_copy_file(src_path, "/tmp");
-  fail_unless(res < 0, "Failed to handle directory destination path");
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle directory destination path");
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   res = pr_fs_copy_file(src_path, "/tmp/foo/bar/baz/quxx/quzz.dat");
-  fail_unless(res < 0, "Failed to handle nonexistent destination path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent destination path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_copy_file(src_path, src_path);
-  fail_unless(res == 0, "Failed to copy file to itself: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy file to itself: %s", strerror(errno));
 
   (void) unlink(dst_path);
 
   mark_point();
   res = pr_fs_copy_file(src_path, dst_path);
-  fail_unless(res == 0, "Failed to copy file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy file: %s", strerror(errno));
 
   (void) pr_fsio_unlink(src_path);
   (void) pr_fsio_unlink(dst_path);
@@ -3950,7 +3950,7 @@ START_TEST (fs_copy_file2_test) {
   (void) unlink(dst_path);
 
   fh = pr_fsio_open(src_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", src_path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", src_path, strerror(errno));
 
   text = "Hello, World!\n";
   res = pr_fsio_write(fh, text, strlen(text));
@@ -3958,18 +3958,18 @@ START_TEST (fs_copy_file2_test) {
     strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to close '%s': %s", src_path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close '%s': %s", src_path, strerror(errno));
 
   copy_progress_iter = 0;
 
   mark_point();
   res = pr_fs_copy_file2(src_path, dst_path, flags, copy_progress_cb);
-  fail_unless(res == 0, "Failed to copy file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to copy file: %s", strerror(errno));
 
   (void) pr_fsio_unlink(src_path);
   (void) pr_fsio_unlink(dst_path);
 
-  fail_unless(copy_progress_iter > 0, "Unexpected progress callback count (%u)",
+  ck_assert_msg(copy_progress_iter > 0, "Unexpected progress callback count (%u)",
     copy_progress_iter);
 }
 END_TEST
@@ -3981,58 +3981,58 @@ START_TEST (fs_interpolate_test) {
   memset(buf, '\0', sizeof(buf));
 
   res = pr_fs_interpolate(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_interpolate(path, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_interpolate(path, buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res == 1, "Failed to interpolate path '%s': %s", path,
+  ck_assert_msg(res == 1, "Failed to interpolate path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(buf, path) == 0, "Expected '%s', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, path) == 0, "Expected '%s', got '%s'", path, buf);
 
   path = "~/foo/bar/baz/quzz/quzz.d";
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res == 1, "Failed to interpolate path '%s': %s", path,
+  ck_assert_msg(res == 1, "Failed to interpolate path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(buf, path+1) == 0, "Expected '%s', got '%s'", path+1, buf);
+  ck_assert_msg(strcmp(buf, path+1) == 0, "Expected '%s', got '%s'", path+1, buf);
 
   path = "~";
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res == 1, "Failed to interpolate path '%s': %s", path,
+  ck_assert_msg(res == 1, "Failed to interpolate path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(buf, "/") == 0, "Expected '/', got '%s'", buf);
+  ck_assert_msg(strcmp(buf, "/") == 0, "Expected '/', got '%s'", buf);
 
   session.chroot_path = "/tmp";
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res == 1, "Failed to interpolate path '%s': %s", path,
+  ck_assert_msg(res == 1, "Failed to interpolate path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(buf, session.chroot_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, session.chroot_path) == 0, "Expected '%s', got '%s'",
     session.chroot_path, buf);
 
   session.chroot_path = NULL;
 
   path = "~foo.bar.baz.quzz";
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res < 0, "Interpolated '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Interpolated '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   session.user = "testsuite";
   path = "~/tmp.d/test.d/foo.d/bar.d";
   res = pr_fs_interpolate(path, buf, sizeof(buf)-1);
-  fail_unless(res < 0, "Interpolated '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Interpolated '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
   session.user = NULL;
 }
@@ -4043,24 +4043,24 @@ START_TEST (fs_resolve_partial_test) {
   char buf[PR_TUNABLE_PATH_MAX], *path;
 
   res = pr_fs_resolve_partial(NULL, NULL, 0, op);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_resolve_partial(path, NULL, 0, op);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fs_resolve_partial(path, buf, 0, op);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
   if (strcmp(buf, path) != 0) {
     /* Mac-specific hack */
     const char *prefix = "/private";
@@ -4072,7 +4072,7 @@ START_TEST (fs_resolve_partial_test) {
 
   path = "/tmp/.////./././././.";
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
   if (strcmp(buf, path) != 0) {
     /* Mac-specific hack */
     const char *prefix = "/private";
@@ -4085,7 +4085,7 @@ START_TEST (fs_resolve_partial_test) {
 
   path = "/../../../.././..///../";
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to resolve '%s': %s", path, strerror(errno));
   if (strcmp(buf, "/") != 0) {
     /* Mac-specific hack */
     const char *prefix = "/private";
@@ -4097,29 +4097,29 @@ START_TEST (fs_resolve_partial_test) {
 
   path = "/tmp/.///../../..../";
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res < 0, "Resolved '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Resolved '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   path = "~foo/.///../../..../";
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res < 0, "Resolved '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Resolved '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   path = "../../..../";
   res = pr_fs_resolve_partial(path, buf, sizeof(buf)-1, op);
-  fail_unless(res < 0, "Resolved '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Resolved '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Resolve a symlink path */
   res = pr_fsio_symlink("/tmp", fsio_link_path);
-  fail_unless(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
     strerror(errno));
 
   res = pr_fs_resolve_partial(fsio_link_path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to resolve '%s': %s", fsio_link_path,
     strerror(errno));
 
   (void) unlink(fsio_link_path);
@@ -4133,23 +4133,23 @@ START_TEST (fs_resolve_path_test) {
   memset(buf, '\0', sizeof(buf));
 
   res = pr_fs_resolve_path(NULL, NULL, 0, op);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_resolve_path(path, NULL, 0, op);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_resolve_path(path, buf, 0, op);
-  fail_unless(res < 0, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_resolve_path(path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve path '%s': %s", path,
+  ck_assert_msg(res == 0, "Failed to resolve path '%s': %s", path,
     strerror(errno));
   if (strcmp(buf, path) != 0) {
     /* Mac-specific hack */
@@ -4162,11 +4162,11 @@ START_TEST (fs_resolve_path_test) {
 
   /* Resolve a symlink path */
   res = pr_fsio_symlink("/tmp", fsio_link_path);
-  fail_unless(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to create symlink to '%s': %s", fsio_link_path,
     strerror(errno));
 
   res = pr_fs_resolve_path(fsio_link_path, buf, sizeof(buf)-1, op);
-  fail_unless(res == 0, "Failed to resolve '%s': %s", fsio_link_path,
+  ck_assert_msg(res == 0, "Failed to resolve '%s': %s", fsio_link_path,
     strerror(errno));
 
   (void) unlink(fsio_link_path);
@@ -4177,18 +4177,18 @@ START_TEST (fs_use_encoding_test) {
   int res;
 
   res = pr_fs_use_encoding(-1);
-  fail_unless(res < 0, "Failed to handle invalid setting");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid setting");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_use_encoding(TRUE);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   res = pr_fs_use_encoding(FALSE);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   res = pr_fs_use_encoding(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 }
 END_TEST
 
@@ -4198,30 +4198,30 @@ START_TEST (fs_decode_path2_test) {
   const char *path;
 
   res = pr_fs_decode_path(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_decode_path(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_decode_path2(p, path, flags);
-  fail_unless(res != NULL, "Failed to decode path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to decode path '%s': %s", path,
     strerror(errno));
 
   path = "/tmp";
   res = pr_fs_decode_path2(p, path, flags);
-  fail_unless(res != NULL, "Failed to decode path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to decode path '%s': %s", path,
     strerror(errno));
 
   /* Test a path that cannot be decoded, using junk data from the stack */
   junk[sizeof(junk)-1] = '\0';
   path = junk;
   res = pr_fs_decode_path2(p, path, flags);
-  fail_unless(res != NULL, "Failed to decode path: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to decode path: %s", strerror(errno));
 
   /* XXX Use the FSIO_DECODE_FL_TELL_ERRORS flags, AND set the encode
    * policy to use PR_ENCODE_POLICY_FL_REQUIRE_VALID_ENCODING.
@@ -4234,25 +4234,25 @@ START_TEST (fs_encode_path_test) {
   const char *path;
 
   res = pr_fs_encode_path(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_encode_path(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_encode_path(p, path);
-  fail_unless(res != NULL, "Failed to encode path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to encode path '%s': %s", path,
     strerror(errno));
 
   /* Test a path that cannot be encoded, using junk data from the stack */
   junk[sizeof(junk)-1] = '\0';
   path = junk;
   res = pr_fs_encode_path(p, path);
-  fail_unless(res != NULL, "Failed to encode path: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to encode path: %s", strerror(errno));
 }
 END_TEST
 
@@ -4262,120 +4262,120 @@ START_TEST (fs_split_path_test) {
 
   mark_point();
   res = pr_fs_split_path(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_split_path(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res == NULL, "Failed to handle empty path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle empty path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = ".";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 1, "Expected 1, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 1, "Expected 1, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
 
   /* Note: pr_fs_split_path() cleans the path into an absolute path.  And
    * the default "cwd" test setting is "/", so yes, this is surprising but
    * expected.  Subject to change in the future.
    */
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
 
   path = "/";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 1, "Expected 1, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 1, "Expected 1, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
 
   path = "///";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 1, "Expected 1, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 1, "Expected 1, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
 
   path = "/foo/bar/baz/";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 4, "Expected 4, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 4, "Expected 4, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
   elt = ((char **) res->elts)[1];
-  fail_unless(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
   elt = ((char **) res->elts)[2];
-  fail_unless(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
   elt = ((char **) res->elts)[3];
-  fail_unless(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
 
   path = "/foo//bar//baz//";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 4, "Expected 4, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 4, "Expected 4, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
   elt = ((char **) res->elts)[1];
-  fail_unless(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
   elt = ((char **) res->elts)[2];
-  fail_unless(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
   elt = ((char **) res->elts)[3];
-  fail_unless(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
 
   path = "/foo/bar/baz";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 4, "Expected 4, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 4, "Expected 4, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "/") == 0, "Expected '/', got '%s'", elt);
   elt = ((char **) res->elts)[1];
-  fail_unless(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
   elt = ((char **) res->elts)[2];
-  fail_unless(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
   elt = ((char **) res->elts)[3];
-  fail_unless(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
 
   path = "foo/bar/baz";
 
   mark_point();
   res = pr_fs_split_path(p, path);
-  fail_unless(res != NULL, "Failed to split path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to split path '%s': %s", path,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "foo") == 0, "Expected 'foo', got '%s'", elt);
   elt = ((char **) res->elts)[1];
-  fail_unless(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "bar") == 0, "Expected 'bar', got '%s'", elt);
   elt = ((char **) res->elts)[2];
-  fail_unless(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
+  ck_assert_msg(strcmp(elt, "baz") == 0, "Expected 'baz', got '%s'", elt);
 }
 END_TEST
 
@@ -4385,42 +4385,42 @@ START_TEST (fs_join_path_test) {
 
   mark_point();
   path = pr_fs_join_path(NULL, NULL, 0);
-  fail_unless(path == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(path == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = pr_fs_join_path(p, NULL, 0);
-  fail_unless(path == NULL, "Failed to handle null components");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(path == NULL, "Failed to handle null components");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   components = make_array(p, 0, sizeof(char **));
 
   mark_point();
   path = pr_fs_join_path(p, components, 0);
-  fail_unless(path == NULL, "Failed to handle empty components");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(path == NULL, "Failed to handle empty components");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((char **) push_array(components)) = pstrdup(p, "/");
 
   mark_point();
   path = pr_fs_join_path(p, components, 0);
-  fail_unless(path == NULL, "Failed to handle empty count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(path == NULL, "Failed to handle empty count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = pr_fs_join_path(p, components, 3);
-  fail_unless(path == NULL, "Failed to handle invalid count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(path == NULL, "Failed to handle invalid count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = pr_fs_join_path(p, components, 1);
-  fail_unless(path != NULL, "Failed to join path: %s", strerror(errno));
-  fail_unless(strcmp(path, "/") == 0, "Expected '/', got '%s'", path);
+  ck_assert_msg(path != NULL, "Failed to join path: %s", strerror(errno));
+  ck_assert_msg(strcmp(path, "/") == 0, "Expected '/', got '%s'", path);
 
   *((char **) push_array(components)) = pstrdup(p, "foo");
   *((char **) push_array(components)) = pstrdup(p, "bar");
@@ -4428,14 +4428,14 @@ START_TEST (fs_join_path_test) {
 
   mark_point();
   path = pr_fs_join_path(p, components, 4);
-  fail_unless(path != NULL, "Failed to join path: %s", strerror(errno));
-  fail_unless(strcmp(path, "/foo/bar/baz") == 0,
+  ck_assert_msg(path != NULL, "Failed to join path: %s", strerror(errno));
+  ck_assert_msg(strcmp(path, "/foo/bar/baz") == 0,
     "Expected '/foo/bar/baz', got '%s'", path);
 
   mark_point();
   path = pr_fs_join_path(p, components, 3);
-  fail_unless(path != NULL, "Failed to join path: %s", strerror(errno));
-  fail_unless(strcmp(path, "/foo/bar") == 0, "Expected '/foo/bar', got '%s'",
+  ck_assert_msg(path != NULL, "Failed to join path: %s", strerror(errno));
+  ck_assert_msg(strcmp(path, "/foo/bar") == 0, "Expected '/foo/bar', got '%s'",
     path);
 
   mark_point();
@@ -4446,8 +4446,8 @@ START_TEST (fs_join_path_test) {
   *((char **) push_array(components)) = pstrdup(p, "baz");
 
   path = pr_fs_join_path(p, components, components->nelts);
-  fail_unless(path != NULL, "Failed to join path: %s", strerror(errno));
-  fail_unless(strcmp(path, "foo/bar/baz") == 0,
+  ck_assert_msg(path != NULL, "Failed to join path: %s", strerror(errno));
+  ck_assert_msg(strcmp(path, "foo/bar/baz") == 0,
     "Expected 'foo/bar/baz', got '%s'", path);
 }
 END_TEST
@@ -4466,31 +4466,31 @@ START_TEST (fs_virtual_path_test) {
   mark_point();
   memset(buf, '\0', sizeof(buf));
   pr_fs_virtual_path(path, buf, 0);
-  fail_unless(*buf == '\0', "Expected empty buffer, got '%s'", buf);
+  ck_assert_msg(*buf == '\0', "Expected empty buffer, got '%s'", buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  fail_unless(strcmp(buf, path) == 0, "Expected '%s', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, path) == 0, "Expected '%s', got '%s'", path, buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   path = "tmp";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  fail_unless(strcmp(buf, "/tmp") == 0, "Expected '/tmp', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, "/tmp") == 0, "Expected '/tmp', got '%s'", path, buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   path = "/tmp/././";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  fail_unless(strcmp(buf, "/tmp") == 0 || strcmp(buf, "/tmp/") == 0,
+  ck_assert_msg(strcmp(buf, "/tmp") == 0 || strcmp(buf, "/tmp/") == 0,
     "Expected '/tmp', got '%s'", path, buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   path = "tmp/../../";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  fail_unless(strcmp(buf, "/") == 0, "Expected '/', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, "/") == 0, "Expected '/', got '%s'", path, buf);
 }
 END_TEST
 
@@ -4511,18 +4511,18 @@ START_TEST (fs_get_usable_fd_test) {
 
   fd = -1;
   res = pr_fs_get_usable_fd(fd);
-  fail_unless(res < 0, "Failed to handle bad fd");
-  fail_unless(errno == EBADF || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad fd");
+  ck_assert_msg(errno == EBADF || errno == EINVAL,
     "Expected EBADF (%d) or EINVAL (%d), got %s (%d)", EBADF, EINVAL,
     strerror(errno), errno);
 
   fd = STDERR_FILENO + 1;
   res = pr_fs_get_usable_fd(fd);
-  fail_unless(res == fd, "Expected %d, got %d", fd, res);
+  ck_assert_msg(res == fd, "Expected %d, got %d", fd, res);
 
   fd = STDERR_FILENO - 1;
   res = pr_fs_get_usable_fd(fd);
-  fail_unless(res > STDERR_FILENO, "Failed to get usable fd for %d: %s", fd,
+  ck_assert_msg(res > STDERR_FILENO, "Failed to get usable fd for %d: %s", fd,
     strerror(errno));
   (void) close(res);
 }
@@ -4532,27 +4532,27 @@ START_TEST (fs_get_usable_fd2_test) {
   int fd, res;
 
   res = pr_fs_get_usable_fd2(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fd = -1;
   res = pr_fs_get_usable_fd2(&fd);
-  fail_unless(res < 0, "Failed to handle bad fd");
-  fail_unless(errno == EBADF || errno == EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad fd");
+  ck_assert_msg(errno == EBADF || errno == EINVAL,
     "Expected EBADF (%d) or EINVAL (%d), got %s (%d)", EBADF, EINVAL,
     strerror(errno), errno);
 
   fd = STDERR_FILENO + 1;
   res = pr_fs_get_usable_fd2(&fd);
-  fail_unless(res == 0, "Failed to handle fd: %s", strerror(errno));
-  fail_unless(fd == (STDERR_FILENO + 1), "Expected %d, got %d",
+  ck_assert_msg(res == 0, "Failed to handle fd: %s", strerror(errno));
+  ck_assert_msg(fd == (STDERR_FILENO + 1), "Expected %d, got %d",
     STDERR_FILENO + 1, fd);
 
   fd = STDERR_FILENO - 1;
   res = pr_fs_get_usable_fd2(&fd);
-  fail_unless(res == 0, "Failed to handle fd: %s", strerror(errno));
-  fail_unless(fd > STDERR_FILENO, "Expected >%d, got %d", STDERR_FILENO, fd);
+  ck_assert_msg(res == 0, "Failed to handle fd: %s", strerror(errno));
+  ck_assert_msg(fd > STDERR_FILENO, "Expected >%d, got %d", STDERR_FILENO, fd);
   (void) close(fd);
 }
 END_TEST
@@ -4562,13 +4562,13 @@ START_TEST (fs_getsize_test) {
   char *path;
 
   res = pr_fs_getsize(NULL);
-  fail_unless(res == (off_t) -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == (off_t) -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_getsize(path);
-  fail_unless(res != (off_t) -1, "Failed to get fs size for '%s': %s", path,
+  ck_assert_msg(res != (off_t) -1, "Failed to get fs size for '%s': %s", path,
     strerror(errno));
 }
 END_TEST
@@ -4579,18 +4579,18 @@ START_TEST (fs_getsize2_test) {
   off_t sz = 0;
 
   res = pr_fs_getsize2(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_fs_getsize2(path, NULL);
-  fail_unless(res < 0, "Failed to handle null size argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null size argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_getsize2(path, &sz);
-  fail_unless(res == 0, "Failed to get fs size for '%s': %s", path,
+  ck_assert_msg(res == 0, "Failed to get fs size for '%s': %s", path,
     strerror(errno));
 }
 END_TEST
@@ -4601,23 +4601,23 @@ START_TEST (fs_fgetsize_test) {
 
   mark_point();
   res = pr_fs_fgetsize(fd, &fs_sz);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   fd = 0;
   fs_sz = 0;
   res = pr_fs_fgetsize(fd, NULL);
-  fail_unless(res < 0, "Failed to handle null size argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null size argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   fd = 0;
   fs_sz = 0;
   res = pr_fs_fgetsize(fd, &fs_sz);
-  fail_unless(res == 0, "Failed to get fs size for fd %d: %s", fd,
+  ck_assert_msg(res == 0, "Failed to get fs size for fd %d: %s", fd,
     strerror(errno));
 }
 END_TEST
@@ -4659,15 +4659,15 @@ START_TEST (fs_have_access_test) {
 
   mark_point();
   res = pr_fs_have_access(NULL, R_OK, 0, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null stat");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stat");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&st, 0, sizeof(struct stat));
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, 0, 0, NULL);
-  fail_unless(res == 0, "Failed to handle root access: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle root access: %s", strerror(errno));
 
   /* Use cases: no matching UID or GID; R_OK, W_OK, X_OK. */
   memset(&st, 0, sizeof(struct stat));
@@ -4676,37 +4676,37 @@ START_TEST (fs_have_access_test) {
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing other R_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing other R_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing other W_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing other W_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing other X_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing other X_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   st.st_mode = S_IFMT|S_IROTH|S_IWOTH|S_IXOTH;
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle other R_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle other R_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle other W_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle other W_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle other X_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle other X_OK access: %s",
     strerror(errno));
 
   /* Use cases: matching UID, not GID; R_OK, W_OK, X_OK. */
@@ -4716,37 +4716,37 @@ START_TEST (fs_have_access_test) {
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing user R_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing user R_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing user W_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing user W_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing user X_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing user X_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   st.st_mode = S_IFMT|S_IRUSR|S_IWUSR|S_IXUSR;
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle user R_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle user R_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle user W_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle user W_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle user X_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle user X_OK access: %s",
     strerror(errno));
 
   /* Use cases: matching GID, not UID; R_OK, W_OK, X_OK. */
@@ -4756,37 +4756,37 @@ START_TEST (fs_have_access_test) {
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing group R_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group R_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing group W_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group W_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res < 0, "Failed to handle missing group X_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group X_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   st.st_mode = S_IFMT|S_IRGRP|S_IWGRP|S_IXGRP;
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle group R_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group R_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle group W_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group W_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, gid, NULL);
-  fail_unless(res == 0, "Failed to handle group X_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group X_OK access: %s",
     strerror(errno));
 
   /* Use cases: matching suppl GID, not UID; R_OK, W_OK, X_OK. */
@@ -4799,37 +4799,37 @@ START_TEST (fs_have_access_test) {
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, 0, suppl_gids);
-  fail_unless(res < 0, "Failed to handle missing group R_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group R_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, 0, suppl_gids);
-  fail_unless(res < 0, "Failed to handle missing group W_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group W_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, 0, suppl_gids);
-  fail_unless(res < 0, "Failed to handle missing group X_OK access");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle missing group X_OK access");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   st.st_mode = S_IFMT|S_IRGRP|S_IWGRP|S_IXGRP;
 
   mark_point();
   res = pr_fs_have_access(&st, R_OK, uid, 0, suppl_gids);
-  fail_unless(res == 0, "Failed to handle group R_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group R_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, W_OK, uid, 0, suppl_gids);
-  fail_unless(res == 0, "Failed to handle group W_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group W_OK access: %s",
     strerror(errno));
 
   mark_point();
   res = pr_fs_have_access(&st, X_OK, uid, 0, suppl_gids);
-  fail_unless(res == 0, "Failed to handle group X_OK access: %s",
+  ck_assert_msg(res == 0, "Failed to handle group X_OK access: %s",
     strerror(errno));
 }
 END_TEST
@@ -4838,12 +4838,12 @@ START_TEST (fs_is_nfs_test) {
   int res;
 
   res = pr_fs_is_nfs(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fs_is_nfs("/tmp");
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 }
 END_TEST
 
@@ -4853,28 +4853,28 @@ START_TEST (fs_valid_path_test) {
   pr_fs_t *fs;
 
   res = pr_fs_valid_path(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
   res = pr_fs_valid_path(path);
-  fail_unless(res == 0, "'%s' is not a valid path: %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "'%s' is not a valid path: %s", path, strerror(errno));
 
   path = ":tmp";
   res = pr_fs_valid_path(path);
-  fail_unless(res < 0, "Failed to handle invalid path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle invalid path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   fs = pr_register_fs(p, "testsuite", "&");
-  fail_unless(fs != NULL, "Failed to register FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register FS: %s", strerror(errno));
 
   fs = pr_register_fs(p, "testsuite2", ":");
-  fail_unless(fs != NULL, "Failed to register FS: %s", strerror(errno));
+  ck_assert_msg(fs != NULL, "Failed to register FS: %s", strerror(errno));
 
   res = pr_fs_valid_path(path);
-  fail_unless(res == 0, "Failed to handle valid path: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle valid path: %s", strerror(errno));
 
   (void) pr_remove_fs("/testsuite2");
   (void) pr_remove_fs("/testsuite");
@@ -4889,43 +4889,43 @@ START_TEST (fsio_smkdir_test) {
   gid_t gid = getgid();
 
   res = pr_fsio_smkdir(NULL, NULL, mode, uid, gid);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_smkdir(p, NULL, mode, uid, gid);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = fsio_testdir_path;
   res = pr_fsio_smkdir(p, path, mode, uid, gid);
-  fail_unless(res == 0, "Failed to securely create '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res == 0, "Failed to securely create '%s': %s", fsio_testdir_path,
     strerror(errno));
   (void) pr_fsio_rmdir(fsio_testdir_path);
 
   res = pr_fsio_set_use_mkdtemp(-1);
-  fail_unless(res < 0, "Failed to handle invalid setting");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid setting");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
 #ifdef HAVE_MKDTEMP
   res = pr_fsio_set_use_mkdtemp(FALSE);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   res = pr_fsio_smkdir(p, path, mode, uid, gid);
-  fail_unless(res == 0, "Failed to securely create '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res == 0, "Failed to securely create '%s': %s", fsio_testdir_path,
     strerror(errno));
   (void) pr_fsio_rmdir(fsio_testdir_path);
 
   res = pr_fsio_set_use_mkdtemp(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 #else
   res = pr_fsio_set_use_mkdtemp(TRUE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_fsio_set_use_mkdtemp(FALSE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 #endif /* HAVE_MKDTEMP */
 
   (void) pr_fsio_rmdir(fsio_testdir_path);
@@ -4938,24 +4938,24 @@ START_TEST (fsio_getpipebuf_test) {
   long bufsz = 0;
 
   res = pr_fsio_getpipebuf(NULL, fd, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_getpipebuf(p, fd, NULL);
-  fail_unless(res == NULL, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res == NULL, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   fd = 0;
   res = pr_fsio_getpipebuf(p, fd, NULL);
-  fail_unless(res != NULL, "Failed to get pipebuf for fd %d: %s", fd,
+  ck_assert_msg(res != NULL, "Failed to get pipebuf for fd %d: %s", fd,
     strerror(errno));
 
   res = pr_fsio_getpipebuf(p, fd, &bufsz);
-  fail_unless(res != NULL, "Failed to get pipebuf for fd %d: %s", fd,
+  ck_assert_msg(res != NULL, "Failed to get pipebuf for fd %d: %s", fd,
     strerror(errno));
-  fail_unless(bufsz > 0, "Expected >0, got %ld", bufsz);
+  ck_assert_msg(bufsz > 0, "Expected >0, got %ld", bufsz);
 }
 END_TEST
 
@@ -4965,22 +4965,22 @@ START_TEST (fsio_gets_test) {
   int res2;
 
   res = pr_fsio_gets(NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_gets(buf, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_gets(buf, 0, fh);
-  fail_unless(res == NULL, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "Hello, World!\n";
@@ -4994,7 +4994,7 @@ START_TEST (fsio_gets_test) {
   res = pr_fsio_gets(buf, sizeof(buf)-1, fh);
   fail_if(res == NULL, "Failed reading from '%s': %s", fsio_test_path,
     strerror(errno));
-  fail_unless(strcmp(res, text) == 0, "Expected '%s', got '%s'", text, res);
+  ck_assert_msg(strcmp(res, text) == 0, "Expected '%s', got '%s'", text, res);
 
   (void) pr_fsio_close(fh);
   (void) pr_fsio_unlink(fsio_test_path);
@@ -5008,26 +5008,26 @@ START_TEST (fsio_getline_test) {
   int res2;
 
   res = pr_fsio_getline(NULL, 0, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_getline(buf, 0, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_RDWR);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_getline(buf, 0, fh, NULL);
-  fail_unless(res == NULL, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_fsio_getline(buf, sizeof(buf)-1, fh, &lineno);
-  fail_unless(res == NULL, "Failed to read empty '%s' file", fsio_test_path);
+  ck_assert_msg(res == NULL, "Failed to read empty '%s' file", fsio_test_path);
 
   text = "Hello, World!\n";
   res2 = pr_fsio_puts(text, fh);
@@ -5046,17 +5046,17 @@ START_TEST (fsio_getline_test) {
   res = pr_fsio_getline(buf, sizeof(buf)-1, fh, &lineno);
   fail_if(res == NULL, "Failed to read line from '%s': %s", fsio_test_path,
     strerror(errno));
-  fail_unless(strcmp(res, "Hello, World!\n") == 0,
+  ck_assert_msg(strcmp(res, "Hello, World!\n") == 0,
     "Expected 'Hello, World!\n', got '%s'", res);
-  fail_unless(lineno == 1, "Expected 1, got %u", lineno);
+  ck_assert_msg(lineno == 1, "Expected 1, got %u", lineno);
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fsio_getline(buf, sizeof(buf)-1, fh, &lineno);
   fail_if(res == NULL, "Failed to read line from '%s': %s", fsio_test_path,
     strerror(errno));
-  fail_unless(strcmp(res, "How are you?\n") == 0,
+  ck_assert_msg(strcmp(res, "How are you?\n") == 0,
     "Expected 'How are you?\n', got '%s'", res);
-  fail_unless(lineno == 3, "Expected 3, got %u", lineno);
+  ck_assert_msg(lineno == 3, "Expected 3, got %u", lineno);
 
   (void) pr_fsio_close(fh);
   (void) pr_fsio_unlink(fsio_test_path);
@@ -5069,23 +5069,23 @@ START_TEST (fsio_puts_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_puts(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "Hello, World!\n";
   res = pr_fsio_puts(text, NULL);
-  fail_unless(res < 0, "Failed to handle null file handle");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null file handle");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   res = pr_fsio_puts(NULL, fh);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_fsio_close(fh);
@@ -5098,25 +5098,25 @@ START_TEST (fsio_blocking_test) {
   pr_fh_t *fh;
 
   res = pr_fsio_set_block(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
     strerror(errno));
 
   fd = fh->fh_fd;
   fh->fh_fd = -1;
 
   res = pr_fsio_set_block(fh);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   fh->fh_fd = fd;
   res = pr_fsio_set_block(fh);
-  fail_unless(res == 0, "Failed to make '%s' blocking: %s", fsio_test_path,
+  ck_assert_msg(res == 0, "Failed to make '%s' blocking: %s", fsio_test_path,
     strerror(errno));
 
   (void) pr_fsio_close(fh);

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -179,7 +179,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   fh = pr_fsio_open(path, flags);
   if (fh != NULL) {
     (void) pr_fsio_close(fh);
-    fail("open(2) of %s succeeded unexpectedly", path);
+    ck_abort_msg("open(2) of %s succeeded unexpectedly", path);
   }
 
   ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
@@ -190,7 +190,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   fh = pr_fsio_open(path, flags);
   if (fh != NULL) {
     (void) pr_fsio_close(fh);
-    fail("open(2) of %s succeeded unexpectedly", path);
+    ck_abort_msg("open(2) of %s succeeded unexpectedly", path);
   }
 
   ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
@@ -200,7 +200,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   fh = pr_fsio_open(path, flags);
   if (fh != NULL) {
     (void) pr_fsio_close(fh);
-    fail("open(2) of %s succeeded unexpectedly", path);
+    ck_abort_msg("open(2) of %s succeeded unexpectedly", path);
   }
 
   ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
@@ -210,7 +210,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   fh = pr_fsio_open(path, flags);
   if (fh != NULL) {
     (void) pr_fsio_close(fh);
-    fail("open(2) of %s succeeded unexpectedly", path);
+    ck_abort_msg("open(2) of %s succeeded unexpectedly", path);
   }
 
   ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
@@ -4068,7 +4068,7 @@ START_TEST (fs_resolve_partial_test) {
     const char *prefix = "/private";
 
     if (strncmp(buf, prefix, strlen(prefix)) != 0) {
-      fail("Expected '%s', got '%s'", path, buf);
+      ck_abort_msg("Expected '%s', got '%s'", path, buf);
     }
   }
 
@@ -4081,7 +4081,7 @@ START_TEST (fs_resolve_partial_test) {
 
     if (strncmp(buf, prefix, strlen(prefix)) != 0 &&
         strcmp(buf, "/tmp/") != 0) {
-      fail("Expected '%s', got '%s'", path, buf);
+      ck_abort_msg("Expected '%s', got '%s'", path, buf);
     }
   }
 
@@ -4093,7 +4093,7 @@ START_TEST (fs_resolve_partial_test) {
     const char *prefix = "/private";
 
     if (strncmp(buf, prefix, strlen(prefix)) != 0) {
-      fail("Expected '%s', got '%s'", path, buf);
+      ck_abort_msg("Expected '%s', got '%s'", path, buf);
     }
   }
 
@@ -4158,7 +4158,7 @@ START_TEST (fs_resolve_path_test) {
     const char *prefix = "/private";
 
     if (strncmp(buf, prefix, strlen(prefix)) != 0) {
-      fail("Expected '%s', got '%s'", path, buf);
+      ck_abort_msg("Expected '%s', got '%s'", path, buf);
     }
   }
 

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -194,7 +194,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   }
 
   ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
-    strerror(errno));
+    strerror(errno), errno);
 
   path = "/etc";
   fh = pr_fsio_open(path, flags);
@@ -204,7 +204,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   }
 
   ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
-    strerror(errno));
+    strerror(errno), errno);
 
   path = "/lib";
   fh = pr_fsio_open(path, flags);
@@ -214,7 +214,7 @@ START_TEST (fsio_sys_open_chroot_guard_test) {
   }
 
   ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
-    strerror(errno));
+    strerror(errno), errno);
 
   (void) pr_fsio_guard_chroot(FALSE);
 
@@ -450,7 +450,8 @@ START_TEST (fsio_sys_write_test) {
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+    strerror(errno));
 
   /* XXX What happens if we use NULL buffer, zero length? */
   res = pr_fsio_write(fh, NULL, 0);
@@ -486,7 +487,8 @@ START_TEST (fsio_sys_pwrite_test) {
     strerror(errno), errno);
 
   fh = pr_fsio_open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY);
-  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", fsio_test_path,
+    strerror(errno));
 
   /* XXX What happens if we use NULL buffer, zero length? */
   res = pr_fsio_pwrite(fh, NULL, 0, 0);
@@ -4477,20 +4479,20 @@ START_TEST (fs_virtual_path_test) {
   memset(buf, '\0', sizeof(buf));
   path = "tmp";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  ck_assert_msg(strcmp(buf, "/tmp") == 0, "Expected '/tmp', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, "/tmp") == 0, "Expected '/tmp', got '%s'", buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   path = "/tmp/././";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
   ck_assert_msg(strcmp(buf, "/tmp") == 0 || strcmp(buf, "/tmp/") == 0,
-    "Expected '/tmp', got '%s'", path, buf);
+    "Expected '/tmp', got '%s'", buf);
 
   mark_point();
   memset(buf, '\0', sizeof(buf));
   path = "tmp/../../";
   pr_fs_virtual_path(path, buf, sizeof(buf)-1);
-  ck_assert_msg(strcmp(buf, "/") == 0, "Expected '/', got '%s'", path, buf);
+  ck_assert_msg(strcmp(buf, "/") == 0, "Expected '/', got '%s'", buf);
 }
 END_TEST
 

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -784,14 +784,14 @@ START_TEST (fsio_sys_access_dir_test) {
   /* Make the directory to check; we want it to have perms 771.*/
   perms = (mode_t) 0771;
   res = mkdir(fsio_testdir_path, perms);
-  fail_if(res < 0, "Unable to create directory '%s': %s", fsio_testdir_path,
+  ck_assert_msg(res >= 0, "Unable to create directory '%s': %s", fsio_testdir_path,
     strerror(errno));
 
   /* Use chmod(2) to ensure that the directory has the perms we want,
    * regardless of any umask settings.
    */
   res = chmod(fsio_testdir_path, perms);
-  fail_if(res < 0, "Unable to set perms %04o on directory '%s': %s", perms,
+  ck_assert_msg(res >= 0, "Unable to set perms %04o on directory '%s': %s", perms,
     fsio_testdir_path, strerror(errno));
 
   /* First, check that we ourselves can access our own directory. */
@@ -888,14 +888,14 @@ START_TEST (fsio_sys_access_file_test) {
 
   /* Make the file to check; we want it to have perms 664.*/
   fd = open(fsio_test_path, O_CREAT|O_EXCL|O_WRONLY, S_IRUSR|S_IWUSR);
-  fail_if(fd < 0, "Unable to create file '%s': %s", fsio_test_path,
+  ck_assert_msg(fd >= 0, "Unable to create file '%s': %s", fsio_test_path,
     strerror(errno));
 
   /* Use chmod(2) to ensure that the file has the perms we want,
    * regardless of any umask settings.
    */
   res = chmod(fsio_test_path, perms);
-  fail_if(res < 0, "Unable to set perms %04o on file '%s': %s", perms,
+  ck_assert_msg(res >= 0, "Unable to set perms %04o on file '%s': %s", perms,
     fsio_test_path, strerror(errno));
 
   /* First, check that we ourselves can access our own file. */
@@ -962,7 +962,7 @@ START_TEST (fsio_sys_faccess_test) {
    * regardless of any umask settings.
    */
   res = chmod(fsio_test_path, perms);
-  fail_if(res < 0, "Unable to set perms %04o on file '%s': %s", perms,
+  ck_assert_msg(res >= 0, "Unable to set perms %04o on file '%s': %s", perms,
     fsio_test_path, strerror(errno));
 
   /* First, check that we ourselves can access our own file. */
@@ -1642,7 +1642,7 @@ START_TEST (fsio_sys_listxattr_test) {
   pr_fsio_close(fh);
 
   res = pr_fsio_listxattr(p, path, &names);
-  fail_if(res < 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
 
   (void) unlink(fsio_test_path);
 #else
@@ -1697,7 +1697,7 @@ START_TEST (fsio_sys_llistxattr_test) {
   pr_fsio_close(fh);
 
   res = pr_fsio_listxattr(p, path, &names);
-  fail_if(res < 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to list xattrs for '%s': %s", path, strerror(errno));
 
   (void) unlink(fsio_test_path);
 #else
@@ -1744,7 +1744,7 @@ START_TEST (fsio_sys_flistxattr_test) {
   pr_fsio_set_options(fsio_opts);
   res = pr_fsio_flistxattr(p, fh, &names);
 #ifdef PR_USE_XATTR
-  fail_if(res < 0, "Failed to list xattrs for '%s': %s", fsio_test_path,
+  ck_assert_msg(res >= 0, "Failed to list xattrs for '%s': %s", fsio_test_path,
     strerror(errno));
 
 #else
@@ -3901,7 +3901,7 @@ START_TEST (fs_copy_file_test) {
 
   text = "Hello, World!\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s' to '%s': %s", text, src_path,
+  ck_assert_msg(res >= 0, "Failed to write '%s' to '%s': %s", text, src_path,
     strerror(errno));
 
   res = pr_fsio_close(fh);
@@ -3954,7 +3954,7 @@ START_TEST (fs_copy_file2_test) {
 
   text = "Hello, World!\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s' to '%s': %s", text, src_path,
+  ck_assert_msg(res >= 0, "Failed to write '%s' to '%s': %s", text, src_path,
     strerror(errno));
 
   res = pr_fsio_close(fh);
@@ -4985,14 +4985,14 @@ START_TEST (fsio_gets_test) {
 
   text = "Hello, World!\n";
   res2 = pr_fsio_puts(text, fh);
-  fail_if(res2 < 0, "Error writing to '%s': %s", fsio_test_path,
+  ck_assert_msg(res2 >= 0, "Error writing to '%s': %s", fsio_test_path,
     strerror(errno));
   pr_fsio_fsync(fh);
   pr_fsio_lseek(fh, 0, SEEK_SET);
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fsio_gets(buf, sizeof(buf)-1, fh);
-  fail_if(res == NULL, "Failed reading from '%s': %s", fsio_test_path,
+  ck_assert_msg(res != NULL, "Failed reading from '%s': %s", fsio_test_path,
     strerror(errno));
   ck_assert_msg(strcmp(res, text) == 0, "Expected '%s', got '%s'", text, res);
 
@@ -5031,12 +5031,12 @@ START_TEST (fsio_getline_test) {
 
   text = "Hello, World!\n";
   res2 = pr_fsio_puts(text, fh);
-  fail_if(res2 < 0, "Error writing to '%s': %s", fsio_test_path,
+  ck_assert_msg(res2 >= 0, "Error writing to '%s': %s", fsio_test_path,
     strerror(errno));
 
   text = "How\\\n are you?\n";
   res2 = pr_fsio_puts(text, fh);
-  fail_if(res2 < 0, "Error writing to '%s': %s", fsio_test_path,
+  ck_assert_msg(res2 >= 0, "Error writing to '%s': %s", fsio_test_path,
     strerror(errno));
 
   pr_fsio_fsync(fh);
@@ -5044,7 +5044,7 @@ START_TEST (fsio_getline_test) {
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fsio_getline(buf, sizeof(buf)-1, fh, &lineno);
-  fail_if(res == NULL, "Failed to read line from '%s': %s", fsio_test_path,
+  ck_assert_msg(res != NULL, "Failed to read line from '%s': %s", fsio_test_path,
     strerror(errno));
   ck_assert_msg(strcmp(res, "Hello, World!\n") == 0,
     "Expected 'Hello, World!\n', got '%s'", res);
@@ -5052,7 +5052,7 @@ START_TEST (fsio_getline_test) {
 
   memset(buf, '\0', sizeof(buf));
   res = pr_fsio_getline(buf, sizeof(buf)-1, fh, &lineno);
-  fail_if(res == NULL, "Failed to read line from '%s': %s", fsio_test_path,
+  ck_assert_msg(res != NULL, "Failed to read line from '%s': %s", fsio_test_path,
     strerror(errno));
   ck_assert_msg(strcmp(res, "How are you?\n") == 0,
     "Expected 'How are you?\n', got '%s'", res);

--- a/tests/api/help.c
+++ b/tests/api/help.c
@@ -85,16 +85,16 @@ START_TEST (help_add_response_test) {
   cmd_rec *cmd;
 
   res = pr_help_add_response(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   mark_point();
 
   cmd = pr_cmd_alloc(p, 2, C_HELP, "FOO");
   res = pr_help_add_response(cmd, NULL);
-  fail_unless(res == -1, "Failed to handle empty help list");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle empty help list");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %s (%d)",
     strerror(errno), errno);
 
   mark_point();
@@ -105,36 +105,36 @@ START_TEST (help_add_response_test) {
   mark_point();
 
   res = pr_help_add_response(cmd, NULL);
-  fail_unless(res == 0, "Failed to add help response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add help response: %s", strerror(errno));
 
   mark_point();
 
   resp_code = resp_msg = NULL;
   res = pr_response_get_last(p, &resp_code, &resp_msg);
-  fail_unless(res == 0, "Failed to get last response: %s", strerror(errno));
-  fail_unless(resp_code != NULL, "Expected non-null response code");
-  fail_unless(strcmp(resp_code, R_214) == 0,
+  ck_assert_msg(res == 0, "Failed to get last response: %s", strerror(errno));
+  ck_assert_msg(resp_code != NULL, "Expected non-null response code");
+  ck_assert_msg(strcmp(resp_code, R_214) == 0,
     "Expected response code %s, got %s", R_214, resp_code);
-  fail_unless(resp_msg != NULL, "Expected non-null response message");
-  fail_unless(strcmp(resp_msg, "Direct comments to ftp-admin") == 0,
+  ck_assert_msg(resp_msg != NULL, "Expected non-null response message");
+  ck_assert_msg(strcmp(resp_msg, "Direct comments to ftp-admin") == 0,
     "Expected response message '%s', got '%s'", "Direct comments to ftp-admin",
     resp_msg);
 
   mark_point();
 
   res = pr_help_add_response(cmd, "FOO");
-  fail_unless(res == 0, "Failed to add help response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add help response: %s", strerror(errno));
 
   mark_point();
 
   resp_code = resp_msg = NULL;
   res = pr_response_get_last(p, &resp_code, &resp_msg);
-  fail_unless(res == 0, "Failed to get last response: %s", strerror(errno));
-  fail_unless(resp_code != NULL, "Expected non-null response code");
-  fail_unless(strcmp(resp_code, R_214) == 0,
+  ck_assert_msg(res == 0, "Failed to get last response: %s", strerror(errno));
+  ck_assert_msg(resp_code != NULL, "Expected non-null response code");
+  ck_assert_msg(strcmp(resp_code, R_214) == 0,
     "Expected response code %s, got %s", R_214, resp_code);
-  fail_unless(resp_msg != NULL, "Expected non-null response message");
-  fail_unless(strcmp(resp_msg, "Syntax: FOO ") == 0,
+  ck_assert_msg(resp_msg != NULL, "Expected non-null response message");
+  ck_assert_msg(strcmp(resp_msg, "Syntax: FOO ") == 0,
     "Expected response message '%s', got '%s'", "Syntax: FOO ", resp_msg);
 
   /* Now add an unimplemented command, and test that one. */
@@ -144,18 +144,18 @@ START_TEST (help_add_response_test) {
   pr_help_add("BAR", "<path>", FALSE);
 
   res = pr_help_add_response(cmd, "BAR");
-  fail_unless(res == 0, "Failed to add help response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add help response: %s", strerror(errno));
 
   mark_point();
 
   resp_code = resp_msg = NULL;
   res = pr_response_get_last(p, &resp_code, &resp_msg);
-  fail_unless(res == 0, "Failed to get last response: %s", strerror(errno));
-  fail_unless(resp_code != NULL, "Expected non-null response code");
-  fail_unless(strcmp(resp_code, R_214) == 0,
+  ck_assert_msg(res == 0, "Failed to get last response: %s", strerror(errno));
+  ck_assert_msg(resp_code != NULL, "Expected non-null response code");
+  ck_assert_msg(strcmp(resp_code, R_214) == 0,
     "Expected response code %s, got %s", R_214, resp_code);
-  fail_unless(resp_msg != NULL, "Expected non-null response message");
-  fail_unless(strcmp(resp_msg, "Syntax: BAR <path>") == 0,
+  ck_assert_msg(resp_msg != NULL, "Expected non-null response message");
+  ck_assert_msg(strcmp(resp_msg, "Syntax: BAR <path>") == 0,
     "Expected response message '%s', got '%s'", "Syntax: BAR <path>", resp_msg);
 }
 END_TEST

--- a/tests/api/inet.c
+++ b/tests/api/inet.c
@@ -88,10 +88,10 @@ START_TEST (inet_family_test) {
   pr_inet_set_default_family(p, 0);
 
   res = pr_inet_set_default_family(p, AF_INET);
-  fail_unless(res == 0, "Expected previous family 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected previous family 0, got %d", res);
 
   res = pr_inet_set_default_family(p, 0);
-  fail_unless(res == AF_INET, "Expected previous family %d, got %d", AF_INET,
+  ck_assert_msg(res == AF_INET, "Expected previous family %d, got %d", AF_INET,
     res);
 
   /* Restore the default family to AF_INET, for other tests. */
@@ -104,17 +104,17 @@ START_TEST (inet_getservport_test) {
 
   mark_point();
   res = pr_inet_getservport(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null service");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d) got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null service");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d) got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_inet_getservport(p, "ftp", NULL);
-  fail_unless(res > 0, "Failed to handle known service");
+  ck_assert_msg(res > 0, "Failed to handle known service");
 
   mark_point();
   res = pr_inet_getservport(p, "ftp", "tcp");
-  fail_unless(res > 0, "Failed to handle service 'ftp', proto 'tcp': %s",
+  ck_assert_msg(res > 0, "Failed to handle service 'ftp', proto 'tcp': %s",
     strerror(errno));
 
   mark_point();
@@ -123,7 +123,7 @@ START_TEST (inet_getservport_test) {
   /* Different platforms/implementations handle this differently. */
   if (res < 0 &&
       errno != 0) {
-    fail_unless(errno == EINVAL || errno == ENOENT,
+    ck_assert_msg(errno == EINVAL || errno == ENOENT,
       "Expected EINVAL (%d) or ENOENT (%d), got %s (%d)", EINVAL, ENOENT,
       strerror(errno), errno);
   }
@@ -145,29 +145,29 @@ START_TEST (inet_create_conn_test) {
 
   mark_point();
   conn = pr_inet_create_conn(NULL, sockfd, NULL, port, FALSE);
-  fail_unless(conn == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL,
     "Failed to set errno to EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
-  fail_unless(conn->listen_fd == sockfd, "Expected listen_fd %d, got %d",
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn->listen_fd == sockfd, "Expected listen_fd %d, got %d",
     sockfd, conn->listen_fd);
   pr_inet_close(p, conn);
 
   sockfd = -1;
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
-  fail_unless(conn->listen_fd != sockfd,
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn->listen_fd != sockfd,
     "Expected listen_fd other than %d, got %d",
     sockfd, conn->listen_fd);
 
   /* Create another conn, with the same port, make sure it fails. */
   conn2 = pr_inet_create_conn(p, sockfd, NULL, conn->local_port, FALSE);
   if (conn2 == NULL) {
-    fail_unless(errno == EADDRINUSE, "Expected EADDRINUSE (%d), got %s (%d)",
+    ck_assert_msg(errno == EADDRINUSE, "Expected EADDRINUSE (%d), got %s (%d)",
       EADDRINUSE, strerror(errno), errno);
     pr_inet_close(p, conn2);
   }
@@ -180,17 +180,17 @@ START_TEST (inet_create_conn_portrange_test) {
   conn_t *conn;
 
   conn = pr_inet_create_conn_portrange(NULL, NULL, -1, -1);
-  fail_unless(conn == NULL, "Failed to handle negative ports");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle negative ports");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn_portrange(NULL, NULL, 10, 1);
-  fail_unless(conn == NULL, "Failed to handle bad ports");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(conn == NULL, "Failed to handle bad ports");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn_portrange(p, NULL, 49152, 65534);
-  fail_unless(conn != NULL, "Failed to create conn in portrange: %s",
+  ck_assert_msg(conn != NULL, "Failed to create conn in portrange: %s",
     strerror(errno));
   pr_inet_lingering_close(p, conn, 0L);
 }
@@ -202,41 +202,41 @@ START_TEST (inet_copy_conn_test) {
   const char *name;
 
   conn = pr_inet_copy_conn(NULL, NULL);
-  fail_unless(conn == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_copy_conn(p, NULL);
-  fail_unless(conn == NULL, "Failed to handle null conn argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle null conn argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn2 = pr_inet_copy_conn(p, conn);
-  fail_unless(conn2 != NULL, "Failed to copy conn: %s", strerror(errno));
+  ck_assert_msg(conn2 != NULL, "Failed to copy conn: %s", strerror(errno));
 
   pr_inet_close(p, conn);
   pr_inet_close(p, conn2);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   name = "127.0.0.1";
   conn->remote_addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(conn->remote_addr != NULL, "Failed to resolve '%s': %s",
+  ck_assert_msg(conn->remote_addr != NULL, "Failed to resolve '%s': %s",
     name, strerror(errno));
   conn->remote_name = pstrdup(p, name);
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
   conn->outstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_WR);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl writing stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl writing stream: %s",
     strerror(errno));
 
   conn2 = pr_inet_copy_conn(p, conn);
-  fail_unless(conn2 != NULL, "Failed to copy conn: %s", strerror(errno));
+  ck_assert_msg(conn2 != NULL, "Failed to copy conn: %s", strerror(errno));
 
   mark_point();
   pr_inet_lingering_close(NULL, NULL, 0L);
@@ -245,13 +245,13 @@ START_TEST (inet_copy_conn_test) {
   pr_inet_close(p, conn2);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
   conn->outstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_WR);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl writing stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl writing stream: %s",
     strerror(errno));
 
   mark_point();
@@ -266,35 +266,35 @@ START_TEST (inet_set_async_test) {
   conn_t *conn;
 
   res = pr_inet_set_async(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
     EINVAL, strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_set_async(p, conn);
-  fail_unless(res == 0, "Failed to set conn %p async: %s", conn,
+  ck_assert_msg(res == 0, "Failed to set conn %p async: %s", conn,
     strerror(errno));
 
   fd = conn->rfd;
   conn->rfd = 77;
   res = pr_inet_set_async(p, conn);
-  fail_unless(res == 0, "Failed to set conn %p async: %s", conn,
+  ck_assert_msg(res == 0, "Failed to set conn %p async: %s", conn,
     strerror(errno));
   conn->rfd = fd;
 
   fd = conn->wfd;
   conn->wfd = 78;
   res = pr_inet_set_async(p, conn);
-  fail_unless(res == 0, "Failed to set conn %p async: %s", conn,
+  ck_assert_msg(res == 0, "Failed to set conn %p async: %s", conn,
     strerror(errno));
   conn->wfd = fd;
 
   fd = conn->listen_fd;
   conn->listen_fd = 79;
   res = pr_inet_set_async(p, conn);
-  fail_unless(res == 0, "Failed to set conn %p async: %s", conn,
+  ck_assert_msg(res == 0, "Failed to set conn %p async: %s", conn,
     strerror(errno));
   conn->listen_fd = fd;
 
@@ -308,28 +308,28 @@ START_TEST (inet_set_block_test) {
 
   mark_point();
   res = pr_inet_set_block(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
     EINVAL, strerror(errno), errno);
 
   mark_point();
   res = pr_inet_set_nonblock(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected errno EINVAL (%d), got '%s' (%d)",
     EINVAL, strerror(errno), errno);
 
   mark_point();
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_set_nonblock(p, conn);
-  fail_unless(res < 0, "Failed to handle bad socket");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad socket");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   res = pr_inet_set_block(p, conn);
-  fail_unless(res < 0, "Failed to handle bad socket");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad socket");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
@@ -342,7 +342,7 @@ START_TEST (inet_set_block_test) {
   conn->listen_fd = sockfd;
   conn->mode = CM_LISTEN;
   res = pr_inet_set_nonblock(p, conn);
-  fail_unless(res == 0, "Failed to set nonblock on listen fd: %s",
+  ck_assert_msg(res == 0, "Failed to set nonblock on listen fd: %s",
     strerror(errno));
   conn->listen_fd = fd;
 
@@ -351,7 +351,7 @@ START_TEST (inet_set_block_test) {
   conn->rfd = sockfd;
   conn->mode = CM_NONE;
   res = pr_inet_set_nonblock(p, conn);
-  fail_unless(res == 0, "Failed to set nonblock on rfd: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set nonblock on rfd: %s", strerror(errno));
   conn->rfd = fd;
 
   mark_point();
@@ -359,7 +359,7 @@ START_TEST (inet_set_block_test) {
   conn->wfd = sockfd;
   conn->mode = CM_NONE;
   res = pr_inet_set_nonblock(p, conn);
-  fail_unless(res == 0, "Failed to set nonblock on wfd: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set nonblock on wfd: %s", strerror(errno));
   conn->wfd = fd;
 
   (void) close(sockfd);
@@ -372,8 +372,8 @@ START_TEST (inet_set_proto_cork_test) {
 
   mark_point();
   res = pr_inet_set_proto_cork(fd, TRUE);
-  fail_unless(res < 0, "Failed to handle bad socket descriptor");
-  fail_unless(errno == EBADF, "Expectedl EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad socket descriptor");
+  ck_assert_msg(errno == EBADF, "Expectedl EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
@@ -384,8 +384,8 @@ START_TEST (inet_set_proto_cork_test) {
 
   mark_point();
   res = pr_inet_set_proto_cork(fd, TRUE);
-  fail_unless(res < 0, "Failed to handle bad socket descriptor");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got '%s' (%d)",
+  ck_assert_msg(res < 0, "Failed to handle bad socket descriptor");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got '%s' (%d)",
     ENOTSOCK, strerror(errno), errno);
 
   (void) close(fd);
@@ -399,24 +399,24 @@ START_TEST (inet_set_proto_keepalive_test) {
 
   mark_point();
   res = pr_inet_set_proto_keepalive(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_inet_set_proto_keepalive(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_proto_keepalive(p, conn, NULL);
-  fail_unless(res < 0, "Failed to handle null keepalive");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null keepalive");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -426,8 +426,8 @@ START_TEST (inet_set_proto_keepalive_test) {
   keepalive.keepalive_count = 2;
   keepalive.keepalive_intvl = 3;
   res = pr_inet_set_proto_keepalive(p, conn, &keepalive);
-  fail_unless(res < 0, "Failed to handle bad listen fd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad listen fd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -439,7 +439,7 @@ START_TEST (inet_set_proto_keepalive_test) {
   fd = conn->listen_fd;
   conn->listen_fd = sockfd;
   res = pr_inet_set_proto_keepalive(p, conn, &keepalive);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   (void) close(sockfd);
@@ -453,25 +453,25 @@ START_TEST (inet_set_proto_nodelay_test) {
 
   mark_point();
   res = pr_inet_set_proto_nodelay(NULL, NULL, 1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_proto_nodelay(p, conn, 1);
-  fail_unless(res == 0, "Failed to enable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to enable nodelay: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
 
   fd = conn->rfd;
   conn->rfd = 8;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->rfd = fd;
 
   mark_point();
@@ -483,32 +483,32 @@ START_TEST (inet_set_proto_nodelay_test) {
   fd = conn->rfd;
   conn->rfd = sockfd;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->rfd = fd;
 
   fd = conn->rfd;
   conn->rfd = -2;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->rfd = fd;
 
   fd = conn->wfd;
   conn->wfd = 9;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->wfd = fd;
 
   fd = conn->wfd;
   conn->wfd = -3;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->wfd = fd;
 
   mark_point();
   fd = conn->wfd;
   conn->wfd = sockfd;
   res = pr_inet_set_proto_nodelay(p, conn, 0);
-  fail_unless(res == 0, "Failed to disable nodelay: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable nodelay: %s", strerror(errno));
   conn->wfd = fd;
 
   (void) close(sockfd);
@@ -522,22 +522,22 @@ START_TEST (inet_set_proto_opts_test) {
 
   mark_point();
   res = pr_inet_set_proto_opts(NULL, NULL, 1, 1, 1, 1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
 
   mark_point();
   fd = conn->rfd;
   conn->rfd = 8;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->rfd = fd;
 
   mark_point();
@@ -549,35 +549,35 @@ START_TEST (inet_set_proto_opts_test) {
   fd = conn->rfd;
   conn->rfd = sockfd;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->rfd = sockfd;
 
   mark_point();
   fd = conn->wfd;
   conn->wfd = 9;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->wfd = fd;
 
   mark_point();
   fd = conn->wfd;
   conn->wfd = sockfd;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->wfd = fd;
 
   mark_point();
   fd = conn->listen_fd;
   conn->listen_fd = 10;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   mark_point();
   fd = conn->listen_fd;
   conn->listen_fd = sockfd;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   (void) close(sockfd);
@@ -597,31 +597,31 @@ START_TEST (inet_set_proto_opts_ipv6_test) {
   pr_inet_set_default_family(p, AF_INET6);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
 
   mark_point();
   fd = conn->rfd;
   conn->rfd = 8;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->rfd = fd;
 
   mark_point();
   fd = conn->wfd;
   conn->wfd = 9;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->wfd = fd;
 
   mark_point();
   fd = conn->listen_fd;
   conn->listen_fd = 10;
   res = pr_inet_set_proto_opts(p, conn, 1, 1, 1, 1);
-  fail_unless(res == 0, "Failed to set proto opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set proto opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   pr_inet_close(p, conn);
@@ -640,27 +640,27 @@ START_TEST (inet_set_reuse_port_test) {
 
   mark_point();
   res = pr_inet_set_reuse_port(NULL, NULL, 1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_reuse_port(p, conn, -1);
-  fail_unless(res < 0, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_inet_set_reuse_port(p, conn, 1);
-  fail_unless(res == 0, "Failed to set reuseport option: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set reuseport option: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_reuse_port(p, conn, 0);
-  fail_unless(res == 0, "Failed to set reuseport option: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set reuseport option: %s", strerror(errno));
 
   pr_inet_close(p, conn);
 }
@@ -673,27 +673,27 @@ START_TEST (inet_set_socket_opts_test) {
 
   mark_point();
   res = pr_inet_set_socket_opts(NULL, NULL, 1, 2, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_socket_opts(p, conn, 1, 2, NULL);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_socket_opts(p, conn, INT_MAX, INT_MAX, NULL);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   keepalive.keepalive_enabled = 1;
   keepalive.keepalive_idle = 1;
   keepalive.keepalive_count = 2;
   keepalive.keepalive_intvl = 3;
   res = pr_inet_set_socket_opts(p, conn, 1, 2, &keepalive);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   mark_point();
   sockfd = devnull_fd();
@@ -704,7 +704,7 @@ START_TEST (inet_set_socket_opts_test) {
   fd = conn->listen_fd;
   conn->listen_fd = sockfd;
   res = pr_inet_set_socket_opts(p, conn, 1, 2, &keepalive);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   (void) close(sockfd);
@@ -719,27 +719,27 @@ START_TEST (inet_set_socket_opts2_test) {
 
   mark_point();
   res = pr_inet_set_socket_opts2(NULL, NULL, 1, 2, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_socket_opts2(p, conn, 1, 2, NULL, -1);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_set_socket_opts2(p, conn, INT_MAX, INT_MAX, NULL, 0);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   keepalive.keepalive_enabled = 1;
   keepalive.keepalive_idle = 1;
   keepalive.keepalive_count = 2;
   keepalive.keepalive_intvl = 3;
   res = pr_inet_set_socket_opts2(p, conn, 1, 2, &keepalive, 1);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
 
   mark_point();
   sockfd = devnull_fd();
@@ -750,7 +750,7 @@ START_TEST (inet_set_socket_opts2_test) {
   fd = conn->listen_fd;
   conn->listen_fd = sockfd;
   res = pr_inet_set_socket_opts2(p, conn, 1, 2, &keepalive, 1);
-  fail_unless(res == 0, "Failed to set socket opts: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set socket opts: %s", strerror(errno));
   conn->listen_fd = fd;
 
   (void) close(sockfd);
@@ -763,43 +763,43 @@ START_TEST (inet_listen_test) {
   conn_t *conn;
 
   res = pr_inet_listen(NULL, NULL, 5, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_inet_resetlisten(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   fd = conn->listen_fd;
   conn->listen_fd = 777;
   res = pr_inet_listen(p, conn, 5, 0);
-  fail_unless(res < 0, "Succeeded in listening on conn unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Succeeded in listening on conn unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mode = conn->mode;
   res = pr_inet_resetlisten(p, conn);
-  fail_unless(res < 0, "Succeeded in resetting listening on conn unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Succeeded in resetting listening on conn unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   conn->listen_fd = fd;
   conn->mode = mode;
 
   res = pr_inet_listen(p, conn, 5, 0);
-  fail_unless(res == 0, "Failed to listen on conn: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to listen on conn: %s", strerror(errno));
 
   res = pr_inet_resetlisten(p, conn);
-  fail_unless(res == 0, "Failed to reset listen mode: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to reset listen mode: %s", strerror(errno));
 
   res = pr_inet_listen(p, conn, 5, 0);
-  fail_unless(res < 0, "Failed to handle already-listening socket");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle already-listening socket");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_inet_close(p, conn);
@@ -812,21 +812,21 @@ START_TEST (inet_connect_ipv4_test) {
   const pr_netaddr_t *addr;
 
   res = pr_inet_connect(NULL, NULL, NULL, port);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_connect(p, conn, NULL, 180);
-  fail_unless(res < 0, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '127.0.0.1': %s",
     strerror(errno));
 
   /* On CirrusCI VMs, attempting to connect causes test timeouts. */
@@ -836,13 +836,13 @@ START_TEST (inet_connect_ipv4_test) {
 
   mark_point();
   res = pr_inet_connect(p, conn, addr, 180);
-  fail_unless(res < 0, "Connected to 127.0.0.1#180 unexpectedly");
-  fail_unless(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Connected to 127.0.0.1#180 unexpectedly");
+  ck_assert_msg(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
     ECONNREFUSED, strerror(errno), errno);
 
 #if defined(PR_USE_NETWORK_TESTS)
   addr = pr_netaddr_get_addr(p, dns_resolver, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", dns_resolver,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", dns_resolver,
     strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
@@ -851,22 +851,22 @@ START_TEST (inet_connect_ipv4_test) {
      * to connect to a different address.  Interestingly, trying to connect(2)
      * using that same fd to a different address yields EINVAL.
      */
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
   }
   pr_inet_close(p, conn);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
   fail_if(res < 0, "Failed to connect to %s#53: %s", dns_resolver,
     strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
-  fail_unless(res < 0, "Failed to connect to %s#53: %s", dns_resolver,
+  ck_assert_msg(res < 0, "Failed to connect to %s#53: %s", dns_resolver,
     strerror(errno));
-  fail_unless(errno == EISCONN, "Expected EISCONN (%d), got %s (%d)",
+  ck_assert_msg(errno == EISCONN, "Expected EISCONN (%d), got %s (%d)",
     EISCONN, strerror(errno), errno);
   pr_inet_close(p, conn);
 #endif
@@ -886,11 +886,11 @@ START_TEST (inet_connect_ipv6_test) {
   pr_inet_set_default_family(p, AF_INET6);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   addr = pr_netaddr_get_addr(p, "::1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '::1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '::1': %s",
     strerror(errno));
 
   /* On CirrusCI VMs, attempting to connect causes test timeouts. */
@@ -900,8 +900,8 @@ START_TEST (inet_connect_ipv6_test) {
 
   mark_point();
   res = pr_inet_connect(p, conn, addr, 180);
-  fail_unless(res < 0, "Connected to ::1#180 unexpectedly");
-  fail_unless(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+  ck_assert_msg(res < 0, "Connected to ::1#180 unexpectedly");
+  ck_assert_msg(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
     "Expected ECONNREFUSED (%d), ENETUNREACH (%d), or EADDRNOTAVAIL (%d), got %s (%d)",
     ECONNREFUSED, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
 
@@ -909,7 +909,7 @@ START_TEST (inet_connect_ipv6_test) {
   /* Try connecting to Google's DNS server. */
 
   addr = pr_netaddr_get_addr(p, "2001:4860:4860::8888", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '2001:4860:4860::8888': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '2001:4860:4860::8888': %s",
     strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
@@ -918,27 +918,27 @@ START_TEST (inet_connect_ipv6_test) {
      * to connect to a different address.  Interestingly, trying to connect(2)
      * using that same fd to a different address yields EINVAL.
      */
-    fail_unless(errno == EINVAL || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+    ck_assert_msg(errno == EINVAL || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
       "Expected EINVAL (%d), ENETUNREACH (%d) or EADDRNOTAVAIL (%d), got %s (%d)",
       EINVAL, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
   }
   pr_inet_close(p, conn);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
   if (res < 0) {
     /* This could be expected, e.g. if there's no route. */
-    fail_unless(errno == EHOSTUNREACH || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+    ck_assert_msg(errno == EHOSTUNREACH || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
       "Expected EHOSTUNREACH (%d) or ENETUNREACH (%d) or EADDRNOTAVAIL (%d), got %s (%d)",
       EHOSTUNREACH, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
   }
 
   res = pr_inet_connect(p, conn, addr, 53);
-  fail_unless(res < 0, "Failed to connect to 2001:4860:4860::8888#53: %s",
+  ck_assert_msg(res < 0, "Failed to connect to 2001:4860:4860::8888#53: %s",
     strerror(errno));
-  fail_unless(errno == EISCONN || errno == EHOSTUNREACH || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+  ck_assert_msg(errno == EISCONN || errno == EHOSTUNREACH || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
     "Expected EISCONN (%d) or EHOSTUNREACH (%d) or ENETUNREACH (%d) or EADDRNOTAVAIL (%d), got %s (%d)", EISCONN, EHOSTUNREACH, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
   pr_inet_close(p, conn);
 #endif
@@ -958,37 +958,37 @@ START_TEST (inet_connect_nowait_test) {
   const pr_netaddr_t *addr;
 
   res = pr_inet_connect_nowait(NULL, NULL, NULL, port);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_connect_nowait(p, conn, NULL, 180);
-  fail_unless(res < 0, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '127.0.0.1': %s",
     strerror(errno));
 
   res = pr_inet_connect_nowait(p, conn, addr, 180);
-  fail_unless(res != -1, "Connected to 127.0.0.1#180 unexpectedly");
+  ck_assert_msg(res != -1, "Connected to 127.0.0.1#180 unexpectedly");
 
 #if defined(PR_USE_NETWORK_TESTS)
   /* Try connecting to Google's DNS server. */
 
   addr = pr_netaddr_get_addr(p, dns_resolver, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", dns_resolver,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", dns_resolver,
     strerror(errno));
 
   res = pr_inet_connect_nowait(p, conn, addr, 53);
   if (res < 0 &&
       errno != ECONNREFUSED &&
       errno != EBADF) {
-    fail_unless(res != -1, "Failed to connect to %s#53: %s", dns_resolver,
+    ck_assert_msg(res != -1, "Failed to connect to %s#53: %s", dns_resolver,
       strerror(errno));
   }
 
@@ -1004,8 +1004,8 @@ START_TEST (inet_accept_test) {
   conn_t *conn;
 
   conn = pr_inet_accept(NULL, NULL, NULL, 0, 2, FALSE);
-  fail_unless(conn == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -1016,17 +1016,17 @@ START_TEST (inet_accept_nowait_test) {
 
   mark_point();
   res = pr_inet_accept_nowait(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_accept_nowait(p, conn);
-  fail_unless(res < 0, "Accepted connection unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Accepted connection unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -1039,8 +1039,8 @@ START_TEST (inet_accept_nowait_test) {
   conn->listen_fd = sockfd;
   conn->mode = CM_LISTEN;
   res = pr_inet_accept_nowait(p, conn);
-  fail_unless(res < 0, "Failed to handle non-socket");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle non-socket");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
     ENOTSOCK, strerror(errno), errno);
   conn->listen_fd = fd;
 
@@ -1054,21 +1054,21 @@ START_TEST (inet_conn_info_test) {
   conn_t *conn;
 
   res = pr_inet_get_conn_info(NULL, -1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_get_conn_info(conn, -1);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   res = pr_inet_get_conn_info(conn, 1);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
     ENOTSOCK, strerror(errno), errno);
 
   pr_inet_close(p, conn);
@@ -1082,30 +1082,30 @@ START_TEST (inet_openrw_test) {
 
   mark_point();
   res = pr_inet_openrw(NULL, NULL, NULL, PR_NETIO_STRM_CTRL, -1, -1, -1, FALSE);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_openrw(p, conn, NULL, PR_NETIO_STRM_CTRL, -1, -1, -1, FALSE);
-  fail_unless(res == NULL, "Opened rw conn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Opened rw conn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve 127.0.0.1: %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to resolve 127.0.0.1: %s", strerror(errno));
 
   mark_point();
   res = pr_inet_openrw(p, conn, addr, PR_NETIO_STRM_CTRL, -1, -1, -1, FALSE);
-  fail_unless(res != NULL, "Failed to open rw conn: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to open rw conn: %s", strerror(errno));
   (void) pr_inet_close(p, res);
 
   mark_point();
   res = pr_inet_openrw(p, conn, addr, PR_NETIO_STRM_CTRL, -1, -1, -1, TRUE);
-  fail_unless(res != NULL, "Failed to open rw conn: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to open rw conn: %s", strerror(errno));
 
   mark_point();
   fd = devnull_fd();
@@ -1113,8 +1113,8 @@ START_TEST (inet_openrw_test) {
     return;
   }
   res = pr_inet_openrw(p, conn, addr, PR_NETIO_STRM_CTRL, fd, -1, -1, TRUE);
-  fail_unless(res == NULL, "Failed to handle non-socket");
-  fail_unless(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle non-socket");
+  ck_assert_msg(errno == ENOTSOCK, "Expected ENOTSOCK (%d), got %s (%d)",
     ENOTSOCK, strerror(errno), errno);
 
   (void) close(fd);
@@ -1127,20 +1127,20 @@ START_TEST (inet_generate_socket_event_test) {
   server_rec *s;
 
   res = pr_inet_generate_socket_event(NULL, NULL, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "foo.bar";
   res = pr_inet_generate_socket_event(name, NULL, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null server_rec");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null server_rec");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   s = pcalloc(p, sizeof(server_rec));
   res = pr_inet_generate_socket_event(name, s, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST

--- a/tests/api/inet.c
+++ b/tests/api/inet.c
@@ -860,7 +860,7 @@ START_TEST (inet_connect_ipv4_test) {
   ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);
-  fail_if(res < 0, "Failed to connect to %s#53: %s", dns_resolver,
+  ck_assert_msg(res >= 0, "Failed to connect to %s#53: %s", dns_resolver,
     strerror(errno));
 
   res = pr_inet_connect(p, conn, addr, 53);

--- a/tests/api/jot.c
+++ b/tests/api/jot.c
@@ -71,7 +71,7 @@ static void assert_jot_class_filter(const char *class_name) {
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
@@ -79,7 +79,7 @@ static void assert_jot_class_filter(const char *class_name) {
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 }
@@ -90,7 +90,7 @@ static void assert_jot_command_with_class_filter(const char *rules) {
   mark_point();
   filters = pr_jot_filters_create(p, rules,
     PR_JOT_FILTER_TYPE_COMMANDS_WITH_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 }
@@ -101,31 +101,31 @@ START_TEST (jot_filters_create_test) {
 
   mark_point();
   filters = pr_jot_filters_create(NULL, NULL, 0, 0);
-  fail_unless(filters == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(filters == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   filters = pr_jot_filters_create(p, NULL, 0, 0);
-  fail_unless(filters == NULL, "Failed to handle null rules");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(filters == NULL, "Failed to handle null rules");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   rules = "foo";
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, -1, 0);
-  fail_unless(filters == NULL, "Failed to handle invalid rules type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(filters == NULL, "Failed to handle invalid rules type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Class rules */
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_CLASSES, 0);
-  fail_unless(filters == NULL, "Failed to handle invalid class name '%s'",
+  ck_assert_msg(filters == NULL, "Failed to handle invalid class name '%s'",
     rules);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   assert_jot_class_filter("NONE");
@@ -147,7 +147,7 @@ START_TEST (jot_filters_create_test) {
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
@@ -155,7 +155,7 @@ START_TEST (jot_filters_create_test) {
 
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
@@ -164,14 +164,14 @@ START_TEST (jot_filters_create_test) {
   rules = "FOO,BAR";
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_COMMANDS, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
   rules = "APPE,RETR,STOR,STOU";
   mark_point();
   filters = pr_jot_filters_create(p, rules, PR_JOT_FILTER_TYPE_COMMANDS, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
@@ -211,7 +211,7 @@ START_TEST (jot_filters_create_test) {
   mark_point();
   filters = pr_jot_filters_create(p, rules,
     PR_JOT_FILTER_TYPE_COMMANDS_WITH_CLASSES, 0);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 
@@ -221,7 +221,7 @@ START_TEST (jot_filters_create_test) {
   mark_point();
   filters = pr_jot_filters_create(p, rules,
     PR_JOT_FILTER_TYPE_COMMANDS_WITH_CLASSES, PR_JOT_FILTER_FL_ALL_INCL_ALL);
-  fail_unless(filters != NULL, "Failed to create filters from '%s': %s",
+  ck_assert_msg(filters != NULL, "Failed to create filters from '%s': %s",
     rules, strerror(errno));
   (void) pr_jot_filters_destroy(filters);
 }
@@ -233,15 +233,15 @@ START_TEST (jot_filters_destroy_test) {
 
   mark_point();
   res = pr_jot_filters_destroy(NULL);
-  fail_unless(res < 0, "Failed to handle null filters");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null filters");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   filters = pr_jot_filters_create(p, "NONE", PR_JOT_FILTER_TYPE_CLASSES, 0);
 
   mark_point();
   res = pr_jot_filters_destroy(filters);
-  fail_unless(res == 0, "Failed to destroy filters: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to destroy filters: %s", strerror(errno));
 }
 END_TEST
 
@@ -251,20 +251,20 @@ START_TEST (jot_filters_include_classes_test) {
 
   mark_point();
   res = pr_jot_filters_include_classes(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null filters");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null filters");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   filters = pr_jot_filters_create(p, "NONE", PR_JOT_FILTER_TYPE_CLASSES, 0);
 
   res = pr_jot_filters_include_classes(filters, CL_ALL);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_jot_filters_include_classes(filters, CL_NONE);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   res = pr_jot_filters_destroy(filters);
-  fail_unless(res == 0, "Failed to destroy filters: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to destroy filters: %s", strerror(errno));
 }
 END_TEST
 
@@ -296,16 +296,16 @@ START_TEST (jot_parse_on_meta_test) {
 
   mark_point();
   res = pr_jot_parse_on_meta(p, NULL, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_ctx = pcalloc(p, sizeof(pr_jot_ctx_t));
 
   mark_point();
   res = pr_jot_parse_on_meta(p, jot_ctx, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx->log");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx->log");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_parsed = pcalloc(p, sizeof(pr_jot_parsed_t));
@@ -313,7 +313,7 @@ START_TEST (jot_parse_on_meta_test) {
 
   mark_point();
   res = pr_jot_parse_on_meta(p, jot_ctx, 0, NULL, 0);
-  fail_unless(res == 0, "Failed to handle parse_on_meta callback: %s",
+  ck_assert_msg(res == 0, "Failed to handle parse_on_meta callback: %s",
     strerror(errno));
 }
 END_TEST
@@ -325,16 +325,16 @@ START_TEST (jot_parse_on_unknown_test) {
 
   mark_point();
   res = pr_jot_parse_on_unknown(p, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_ctx = pcalloc(p, sizeof(pr_jot_ctx_t));
 
   mark_point();
   res = pr_jot_parse_on_unknown(p, jot_ctx, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx->log");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx->log");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_parsed = pcalloc(p, sizeof(pr_jot_parsed_t));
@@ -342,7 +342,7 @@ START_TEST (jot_parse_on_unknown_test) {
 
   mark_point();
   res = pr_jot_parse_on_unknown(p, jot_ctx, NULL, 0);
-  fail_unless(res == 0, "Failed to handle parse_on_unknown callback: %s",
+  ck_assert_msg(res == 0, "Failed to handle parse_on_unknown callback: %s",
     strerror(errno));
 }
 END_TEST
@@ -354,16 +354,16 @@ START_TEST (jot_parse_on_other_test) {
 
   mark_point();
   res = pr_jot_parse_on_other(p, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_ctx = pcalloc(p, sizeof(pr_jot_ctx_t));
 
   mark_point();
   res = pr_jot_parse_on_other(p, jot_ctx, 0);
-  fail_unless(res < 0, "Failed to handle null jot_ctx->log");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null jot_ctx->log");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_parsed = pcalloc(p, sizeof(pr_jot_parsed_t));
@@ -371,7 +371,7 @@ START_TEST (jot_parse_on_other_test) {
 
   mark_point();
   res = pr_jot_parse_on_other(p, jot_ctx, 0);
-  fail_unless(res == 0, "Failed to handle parse_on_other callback: %s",
+  ck_assert_msg(res == 0, "Failed to handle parse_on_other callback: %s",
     strerror(errno));
 }
 END_TEST
@@ -384,42 +384,42 @@ START_TEST (jot_parse_logfmt_test) {
 
   mark_point();
   res = pr_jot_parse_logfmt(NULL, NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_parse_logfmt(p, NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "Hello, World!";
 
   mark_point();
   res = pr_jot_parse_logfmt(p, text, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   jot_ctx = pcalloc(p, sizeof(pr_jot_ctx_t));
 
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null on_meta");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null on_meta");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
 
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, NULL, NULL, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 0,
+  ck_assert_msg(parse_on_unknown_count == 0,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 0,
+  ck_assert_msg(parse_on_other_count == 0,
     "Expected on_other count 0, got %u", parse_on_other_count);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
@@ -428,12 +428,12 @@ START_TEST (jot_parse_logfmt_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 0,
+  ck_assert_msg(parse_on_unknown_count == 0,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless((unsigned long) parse_on_other_count == text_len,
+  ck_assert_msg((unsigned long) parse_on_other_count == text_len,
     "Expected on_other count %lu, got %u", (unsigned long) text_len,
     parse_on_other_count);
 
@@ -444,12 +444,12 @@ START_TEST (jot_parse_logfmt_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 3,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 3,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 1,
+  ck_assert_msg(parse_on_unknown_count == 1,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 9,
+  ck_assert_msg(parse_on_other_count == 9,
     "Expected on_other count 9, got %u", parse_on_other_count);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
@@ -459,12 +459,12 @@ START_TEST (jot_parse_logfmt_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 3,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 3,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 1,
+  ck_assert_msg(parse_on_unknown_count == 1,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 17,
+  ck_assert_msg(parse_on_other_count == 17,
     "Expected on_other count 17, got %u", parse_on_other_count);
 }
 END_TEST
@@ -521,10 +521,10 @@ START_TEST (jot_parse_logfmt_short_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0, "Expected on_meta count 0, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0, "Expected on_meta count 0, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 2, "Expected on_other count 2, got %u",
+  ck_assert_msg(parse_on_other_count == 2, "Expected on_other count 2, got %u",
     parse_on_other_count);
 
   text = "%{0}";
@@ -533,12 +533,12 @@ START_TEST (jot_parse_logfmt_short_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 1,
+  ck_assert_msg(parse_on_unknown_count == 1,
     "Expected on_unknown count 1, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 0,
+  ck_assert_msg(parse_on_other_count == 0,
     "Expected on_other count 0, got %u", parse_on_other_count);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
@@ -551,15 +551,15 @@ START_TEST (jot_parse_logfmt_short_vars_test) {
     mark_point();
     res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
       parse_on_other, 0);
-    fail_unless(res == 0, "Failed to parse text '%s': %s", text,
+    ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text,
       strerror(errno));
   }
 
-  fail_unless(parse_on_meta_count == text_count,
+  ck_assert_msg(parse_on_meta_count == text_count,
     "Expected on_meta count %d, got %u", text_count, parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 0,
+  ck_assert_msg(parse_on_unknown_count == 0,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 0,
+  ck_assert_msg(parse_on_other_count == 0,
     "Expected on_other count 0, got %u", parse_on_other_count);
 }
 END_TEST
@@ -608,10 +608,10 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 1, "Expected on_other count 1, got %u",
+  ck_assert_msg(parse_on_other_count == 1, "Expected on_other count 1, got %u",
     parse_on_other_count);
 
   text = "%{note:FOOBAR}!";
@@ -620,10 +620,10 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 1, "Expected on_other count 1, got %u",
+  ck_assert_msg(parse_on_other_count == 1, "Expected on_other count 1, got %u",
     parse_on_other_count);
 
   text = "%{time:FOOBAR}!";
@@ -632,10 +632,10 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 1, "Expected on_other count 1, got %u",
+  ck_assert_msg(parse_on_other_count == 1, "Expected on_other count 1, got %u",
     parse_on_other_count);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
@@ -648,13 +648,13 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
     mark_point();
     res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, NULL,
       parse_on_other, 0);
-    fail_unless(res == 0, "Failed to parse text '%s': %s", text,
+    ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text,
       strerror(errno));
   }
 
-  fail_unless(parse_on_meta_count == text_count,
+  ck_assert_msg(parse_on_meta_count == text_count,
     "Expected on_meta count %d, got %u", text_count, parse_on_meta_count);
-  fail_unless(parse_on_other_count == 0, "Expected on_other count 0, got %u",
+  ck_assert_msg(parse_on_other_count == 0, "Expected on_other count 0, got %u",
     parse_on_other_count);
 
   text = "%{FOOBAR}e";
@@ -663,10 +663,10 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 0, "Expected on_other count 0, got %u",
+  ck_assert_msg(parse_on_other_count == 0, "Expected on_other count 0, got %u",
     parse_on_other_count);
 
   text = "%{FOOBAR}t";
@@ -675,10 +675,10 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, NULL,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1, "Expected on_meta count 1, got %u",
     parse_on_meta_count);
-  fail_unless(parse_on_other_count == 0, "Expected on_other count 0, got %u",
+  ck_assert_msg(parse_on_other_count == 0, "Expected on_other count 0, got %u",
     parse_on_other_count);
 
   text = "%{FOOBAR}T";
@@ -691,12 +691,12 @@ START_TEST (jot_parse_logfmt_long_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, long_on_meta, parse_on_unknown,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 1,
+  ck_assert_msg(parse_on_unknown_count == 1,
     "Expected on_unknown count 1, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 1,
+  ck_assert_msg(parse_on_other_count == 1,
     "Expected on_other count 1, got %u", parse_on_other_count);
 }
 END_TEST
@@ -713,12 +713,12 @@ START_TEST (jot_parse_logfmt_custom_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
     parse_on_other, 0);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 0,
     "Expected on_meta count 0, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 1,
+  ck_assert_msg(parse_on_unknown_count == 1,
     "Expected on_unknown count 1, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 0,
+  ck_assert_msg(parse_on_other_count == 0,
     "Expected on_other count 0, got %u", parse_on_other_count);
 
   parse_on_meta_count = parse_on_unknown_count = parse_on_other_count = 0;
@@ -726,12 +726,12 @@ START_TEST (jot_parse_logfmt_custom_vars_test) {
   mark_point();
   res = pr_jot_parse_logfmt(p, text, jot_ctx, parse_on_meta, parse_on_unknown,
     parse_on_other, PR_JOT_LOGFMT_PARSE_FL_UNKNOWN_AS_CUSTOM);
-  fail_unless(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
-  fail_unless(parse_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to parse text '%s': %s", text, strerror(errno));
+  ck_assert_msg(parse_on_meta_count == 1,
     "Expected on_meta count 1, got %u", parse_on_meta_count);
-  fail_unless(parse_on_unknown_count == 0,
+  ck_assert_msg(parse_on_unknown_count == 0,
     "Expected on_unknown count 0, got %u", parse_on_unknown_count);
-  fail_unless(parse_on_other_count == 0,
+  ck_assert_msg(parse_on_other_count == 0,
     "Expected on_other count 0, got %u", parse_on_other_count);
 }
 END_TEST
@@ -760,22 +760,22 @@ START_TEST (jot_resolve_logfmt_id_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(NULL, NULL, NULL, 0, NULL, 0, NULL, NULL,
     NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, NULL, NULL, 0, NULL, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null cmd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null cmd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, pstrdup(p, "FOO"));
 
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, 0, NULL, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null on_meta");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null on_meta");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   logfmt_id = 0;
@@ -783,8 +783,8 @@ START_TEST (jot_resolve_logfmt_id_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   logfmt_id = LOGFMT_META_START;
@@ -792,8 +792,8 @@ START_TEST (jot_resolve_logfmt_id_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   logfmt_id = LOGFMT_META_ARG_END;
@@ -801,8 +801,8 @@ START_TEST (jot_resolve_logfmt_id_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -819,11 +819,11 @@ START_TEST (jot_resolve_logfmt_id_on_default_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, resolve_id_on_default);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -845,11 +845,11 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   /* With an ALL filter, and no command class. */
@@ -862,11 +862,11 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   /* With explicit filters that allow the class. */
@@ -879,11 +879,11 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   /* With explicit filters that ignore the class. */
@@ -894,10 +894,10 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that do not match the class. */
@@ -908,10 +908,10 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that allow the command. Note that this REQUIRES
@@ -927,11 +927,11 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   /* With explicit filters that ignore the command. */
@@ -942,10 +942,10 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that do not match the command. */
@@ -956,10 +956,10 @@ START_TEST (jot_resolve_logfmt_id_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, jot_filters, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt_id %u", logfmt_id);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 }
 END_TEST
@@ -978,11 +978,11 @@ START_TEST (jot_resolve_logfmt_id_connect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   resolve_on_meta_count = resolve_on_default_count = 0;
@@ -991,11 +991,11 @@ START_TEST (jot_resolve_logfmt_id_connect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -1014,11 +1014,11 @@ START_TEST (jot_resolve_logfmt_id_disconnect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 
   resolve_on_meta_count = resolve_on_default_count = 0;
@@ -1027,11 +1027,11 @@ START_TEST (jot_resolve_logfmt_id_disconnect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
     resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -1054,11 +1054,11 @@ START_TEST (jot_resolve_logfmt_id_custom_test) {
   mark_point();
   res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, custom_data,
     custom_datalen, NULL, resolve_id_on_meta, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+  ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
     strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -1079,13 +1079,13 @@ START_TEST (jot_resolve_logfmt_ids_test) {
     mark_point();
     res = pr_jot_resolve_logfmt_id(p, cmd, NULL, logfmt_id, NULL, 0, NULL,
       resolve_id_on_meta, resolve_id_on_default);
-    fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
+    ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt_id,
       strerror(errno));
   }
 
-  fail_unless(resolve_on_meta_count == 20,
+  ck_assert_msg(resolve_on_meta_count == 20,
     "Expected on_meta count 20, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 28,
+  ck_assert_msg(resolve_on_default_count == 28,
     "Expected on_default count 28, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -1115,36 +1115,36 @@ START_TEST (jot_resolve_logfmt_invalid_test) {
 
   mark_point();
   res = pr_jot_resolve_logfmt(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_resolve_logfmt(p, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null cmd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null cmd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, pstrdup(p, "FOO"));
 
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null logfmt");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null logfmt");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   logfmt = (unsigned char *) "";
 
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null on_meta");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null on_meta");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL, resolve_on_meta,
     NULL, NULL);
-  fail_unless(res == 0, "Failed to handle empty logfmt: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle empty logfmt: %s", strerror(errno));
 }
 END_TEST
 
@@ -1163,12 +1163,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1178,12 +1178,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1193,12 +1193,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1208,12 +1208,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1223,12 +1223,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1239,12 +1239,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -1256,12 +1256,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1270,12 +1270,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1284,12 +1284,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1298,12 +1298,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1312,12 +1312,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1327,12 +1327,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.chroot_path = NULL;
@@ -1344,12 +1344,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1359,12 +1359,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1374,12 +1374,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1389,12 +1389,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1404,12 +1404,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1419,12 +1419,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1434,12 +1434,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1449,12 +1449,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1464,12 +1464,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1479,12 +1479,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1494,12 +1494,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1509,12 +1509,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1524,12 +1524,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1539,12 +1539,12 @@ START_TEST (jot_resolve_logfmt_basename_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -1564,12 +1564,12 @@ START_TEST (jot_resolve_logfmt_bytes_sent_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1577,12 +1577,12 @@ START_TEST (jot_resolve_logfmt_bytes_sent_test) {
   session.xfer.p = p;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -1593,12 +1593,12 @@ START_TEST (jot_resolve_logfmt_bytes_sent_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -1618,12 +1618,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1633,12 +1633,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1648,12 +1648,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   pr_table_add_dup(cmd->notes, "mod_xfer.retr-path", "foobar", 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1663,12 +1663,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   pr_table_add_dup(cmd->notes, "mod_xfer.store-path", "foobar", 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1678,12 +1678,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   pr_table_add_dup(cmd->notes, "mod_xfer.store-path", "foobar", 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1694,12 +1694,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   session.xfer.path = pstrdup(p, "foobar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -1711,12 +1711,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1725,12 +1725,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1739,12 +1739,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1753,12 +1753,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1767,12 +1767,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1782,12 +1782,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   session.chroot_path = "/foo/bar/baz";
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.chroot_path = NULL;
@@ -1799,12 +1799,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1814,12 +1814,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1829,12 +1829,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1844,12 +1844,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1859,12 +1859,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1874,12 +1874,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1889,12 +1889,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1904,12 +1904,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1919,12 +1919,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1934,12 +1934,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1949,12 +1949,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1964,12 +1964,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1979,12 +1979,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->arg = pstrdup(p, "foo bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -1994,12 +1994,12 @@ START_TEST (jot_resolve_logfmt_filename_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2021,12 +2021,12 @@ START_TEST (jot_resolve_logfmt_file_modified_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_xfer.file-modified" note. */
@@ -2036,12 +2036,12 @@ START_TEST (jot_resolve_logfmt_file_modified_test) {
   pr_table_add_dup(cmd->notes, "mod_xfer.file-modified", modified, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2063,12 +2063,12 @@ START_TEST (jot_resolve_logfmt_file_offset_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_xfer.file-offset" note. */
@@ -2079,12 +2079,12 @@ START_TEST (jot_resolve_logfmt_file_offset_test) {
     sizeof(file_offset));
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2106,12 +2106,12 @@ START_TEST (jot_resolve_logfmt_file_size_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_xfer.file-size" note. */
@@ -2121,12 +2121,12 @@ START_TEST (jot_resolve_logfmt_file_size_test) {
   pr_table_add(cmd->notes, "mod_xfer.file-size", &file_size, sizeof(file_size));
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2147,12 +2147,12 @@ START_TEST (jot_resolve_logfmt_env_var_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2168,12 +2168,12 @@ START_TEST (jot_resolve_logfmt_env_var_test) {
   logfmt[8] = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2183,12 +2183,12 @@ START_TEST (jot_resolve_logfmt_env_var_test) {
   pr_env_set(p, key, val);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
   pr_env_unset(p, key);
 }
@@ -2210,12 +2210,12 @@ START_TEST (jot_resolve_logfmt_note_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2231,12 +2231,12 @@ START_TEST (jot_resolve_logfmt_note_test) {
   logfmt[8] = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2247,12 +2247,12 @@ START_TEST (jot_resolve_logfmt_note_test) {
   pr_table_add_dup(session.notes, key, val, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2260,12 +2260,12 @@ START_TEST (jot_resolve_logfmt_note_test) {
   pr_table_add_dup(cmd->notes, key, val, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_table_empty(session.notes);
@@ -2292,12 +2292,12 @@ START_TEST (jot_resolve_logfmt_remote_port_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with a session remote address. */
@@ -2308,7 +2308,7 @@ START_TEST (jot_resolve_logfmt_remote_port_test) {
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
   session.c = conn;
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get address: %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to get address: %s", strerror(errno));
   pr_netaddr_set_port2((pr_netaddr_t *) addr, 2476);
   session.c->remote_addr = addr;
   pr_netaddr_set_sess_addrs();
@@ -2316,12 +2316,12 @@ START_TEST (jot_resolve_logfmt_remote_port_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_inet_close(p, session.c);
@@ -2346,12 +2346,12 @@ START_TEST (jot_resolve_logfmt_rfc1413_ident_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_ident.rfc1413-ident" note. */
@@ -2362,12 +2362,12 @@ START_TEST (jot_resolve_logfmt_rfc1413_ident_test) {
   pr_table_add_dup(session.notes, "mod_ident.rfc1413-ident", ident_user, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_table_empty(session.notes);
@@ -2392,12 +2392,12 @@ START_TEST (jot_resolve_logfmt_xfer_secs_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the session.xfer.p pool, but no transfer times. */
@@ -2407,12 +2407,12 @@ START_TEST (jot_resolve_logfmt_xfer_secs_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2422,12 +2422,12 @@ START_TEST (jot_resolve_logfmt_xfer_secs_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2437,12 +2437,12 @@ START_TEST (jot_resolve_logfmt_xfer_secs_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -2466,12 +2466,12 @@ START_TEST (jot_resolve_logfmt_xfer_ms_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the session.xfer.p pool, but no transfer times. */
@@ -2481,12 +2481,12 @@ START_TEST (jot_resolve_logfmt_xfer_ms_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2496,12 +2496,12 @@ START_TEST (jot_resolve_logfmt_xfer_ms_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2511,12 +2511,12 @@ START_TEST (jot_resolve_logfmt_xfer_ms_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -2539,12 +2539,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2552,12 +2552,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2567,12 +2567,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2582,12 +2582,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2596,12 +2596,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2610,12 +2610,12 @@ START_TEST (jot_resolve_logfmt_command_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2636,12 +2636,12 @@ START_TEST (jot_resolve_logfmt_local_name_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2651,12 +2651,12 @@ START_TEST (jot_resolve_logfmt_local_name_test) {
   cmd->server = server;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2677,12 +2677,12 @@ START_TEST (jot_resolve_logfmt_local_port_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2692,12 +2692,12 @@ START_TEST (jot_resolve_logfmt_local_port_test) {
   cmd->server = server;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -2717,12 +2717,12 @@ START_TEST (jot_resolve_logfmt_user_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2730,12 +2730,12 @@ START_TEST (jot_resolve_logfmt_user_test) {
   session.user = "FOOBAR";
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.user = NULL;
@@ -2757,12 +2757,12 @@ START_TEST (jot_resolve_logfmt_uid_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2771,12 +2771,12 @@ START_TEST (jot_resolve_logfmt_uid_test) {
   session.login_uid = 400;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.auth_mech = NULL;
@@ -2799,12 +2799,12 @@ START_TEST (jot_resolve_logfmt_group_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2812,12 +2812,12 @@ START_TEST (jot_resolve_logfmt_group_test) {
   session.group = "FOOBAR";
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.group = NULL;
@@ -2839,12 +2839,12 @@ START_TEST (jot_resolve_logfmt_gid_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2853,12 +2853,12 @@ START_TEST (jot_resolve_logfmt_gid_test) {
   session.login_gid = 400;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.auth_mech = NULL;
@@ -2883,12 +2883,12 @@ START_TEST (jot_resolve_logfmt_original_user_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_auth.orig-user" note. */
@@ -2899,12 +2899,12 @@ START_TEST (jot_resolve_logfmt_original_user_test) {
   pr_table_add_dup(session.notes, "mod_auth.orig-user", orig_user, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_table_empty(session.notes);
@@ -2928,12 +2928,12 @@ START_TEST (jot_resolve_logfmt_response_code_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2942,12 +2942,12 @@ START_TEST (jot_resolve_logfmt_response_code_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -2959,12 +2959,12 @@ START_TEST (jot_resolve_logfmt_response_code_test) {
   pr_response_add("200", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -2987,12 +2987,12 @@ START_TEST (jot_resolve_logfmt_response_text_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3002,12 +3002,12 @@ START_TEST (jot_resolve_logfmt_response_text_test) {
   pr_response_add("200", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3032,12 +3032,12 @@ START_TEST (jot_resolve_logfmt_response_ms_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "start_ms" note. */
@@ -3047,12 +3047,12 @@ START_TEST (jot_resolve_logfmt_response_ms_test) {
   pr_table_add(cmd->notes, "start_ms", &start_ms, sizeof(start_ms));
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -3072,12 +3072,12 @@ START_TEST (jot_resolve_logfmt_class_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3085,12 +3085,12 @@ START_TEST (jot_resolve_logfmt_class_test) {
   session.conn_class = pcalloc(p, sizeof(pr_class_t));
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.conn_class = NULL;
@@ -3114,12 +3114,12 @@ START_TEST (jot_resolve_logfmt_anon_passwd_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   /* Now, with the "mod_auth.anon-passwd" note. */
@@ -3130,12 +3130,12 @@ START_TEST (jot_resolve_logfmt_anon_passwd_test) {
   pr_table_add_dup(session.notes, "mod_auth.anon-passwd", anon_passwd, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_table_empty(session.notes);
@@ -3159,12 +3159,12 @@ START_TEST (jot_resolve_logfmt_method_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3172,12 +3172,12 @@ START_TEST (jot_resolve_logfmt_method_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3186,12 +3186,12 @@ START_TEST (jot_resolve_logfmt_method_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3200,12 +3200,12 @@ START_TEST (jot_resolve_logfmt_method_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -3225,12 +3225,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3240,12 +3240,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3256,12 +3256,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   session.xfer.path = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.xfer.p = NULL;
@@ -3274,12 +3274,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3289,12 +3289,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3304,12 +3304,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3319,12 +3319,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3334,12 +3334,12 @@ START_TEST (jot_resolve_logfmt_xfer_path_test) {
   cmd->arg = pstrdup(p, "foo/bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -3359,12 +3359,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3374,12 +3374,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3389,12 +3389,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3404,12 +3404,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3419,12 +3419,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3434,12 +3434,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3449,12 +3449,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3464,12 +3464,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3479,12 +3479,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3494,12 +3494,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3509,12 +3509,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3524,12 +3524,12 @@ START_TEST (jot_resolve_logfmt_xfer_port_test) {
   session.data_port = 7777;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.data_port = 0;
@@ -3551,12 +3551,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3566,12 +3566,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   session.sf_flags = SF_ASCII;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3581,12 +3581,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   session.sf_flags = SF_ASCII_OVERRIDE;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.sf_flags = 0;
@@ -3597,12 +3597,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3612,12 +3612,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   tests_stubs_set_protocol("sftp");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3627,12 +3627,12 @@ START_TEST (jot_resolve_logfmt_xfer_type_test) {
   tests_stubs_set_protocol("scp");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   tests_stubs_set_protocol(NULL);
@@ -3654,12 +3654,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3668,12 +3668,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3683,12 +3683,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   tests_stubs_set_protocol("ftps");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   tests_stubs_set_protocol(NULL);
@@ -3702,12 +3702,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   pr_response_add("500", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3721,12 +3721,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   pr_response_add("123", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3740,12 +3740,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   pr_response_add("234", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3759,12 +3759,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   pr_response_add("234", "foo %s", "bar");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3777,12 +3777,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   session.sf_flags = SF_ABORT;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.sf_flags = 0;
@@ -3796,12 +3796,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   tests_stubs_set_protocol("sftp");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3812,12 +3812,12 @@ START_TEST (jot_resolve_logfmt_xfer_status_test) {
   tests_stubs_set_protocol("sftp");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   tests_stubs_set_protocol(NULL);
@@ -3839,12 +3839,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3854,12 +3854,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   tests_stubs_set_protocol("ftps");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   tests_stubs_set_protocol(NULL);
@@ -3872,12 +3872,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   session.sf_flags = SF_ABORT;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.sf_flags = 0;
@@ -3891,12 +3891,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   pr_response_add("543", "foo %s", "BAR BAZ");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3911,12 +3911,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   pr_response_add("123", "foo %s", "BAR BAZ");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3931,12 +3931,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   pr_response_add("234", "foo %s", "BAR BAZ");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_response_clear(&resp_list);
@@ -3949,12 +3949,12 @@ START_TEST (jot_resolve_logfmt_xfer_failure_test) {
   tests_stubs_set_protocol("sftp");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   tests_stubs_set_protocol(NULL);
@@ -3976,12 +3976,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -3990,12 +3990,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4005,12 +4005,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4020,12 +4020,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "/foo");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4035,12 +4035,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "/foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4050,12 +4050,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4065,12 +4065,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4080,12 +4080,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4095,12 +4095,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4110,12 +4110,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4125,12 +4125,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4140,12 +4140,12 @@ START_TEST (jot_resolve_logfmt_dir_name_test) {
   cmd->arg = pstrdup(p, "foo/");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4165,12 +4165,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4180,12 +4180,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4195,12 +4195,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4210,12 +4210,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4225,12 +4225,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4240,12 +4240,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4255,12 +4255,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4270,12 +4270,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4285,12 +4285,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4300,12 +4300,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->arg = pstrdup(p, "/foo/bar/baz");
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4314,12 +4314,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   cmd->cmd_class = CL_MISC;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4329,12 +4329,12 @@ START_TEST (jot_resolve_logfmt_dir_path_test) {
   session.chroot_path = "/foo/bar/baz/";
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.chroot_path = NULL;
@@ -4356,12 +4356,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4369,12 +4369,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4382,12 +4382,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4397,12 +4397,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4411,12 +4411,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4425,12 +4425,12 @@ START_TEST (jot_resolve_logfmt_cmd_params_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4451,12 +4451,12 @@ START_TEST (jot_resolve_logfmt_rename_from_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4465,12 +4465,12 @@ START_TEST (jot_resolve_logfmt_rename_from_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4480,12 +4480,12 @@ START_TEST (jot_resolve_logfmt_rename_from_test) {
   pr_table_add_dup(session.notes, "mod_core.rnfr-path", rnfr_path, 0);
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   pr_table_empty(session.notes);
@@ -4509,12 +4509,12 @@ START_TEST (jot_resolve_logfmt_eos_reason_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4522,12 +4522,12 @@ START_TEST (jot_resolve_logfmt_eos_reason_test) {
   session.disconnect_reason = -1;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4535,12 +4535,12 @@ START_TEST (jot_resolve_logfmt_eos_reason_test) {
   session.disconnect_reason = PR_SESS_DISCONNECT_BANNED;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   session.disconnect_reason = 0;
@@ -4563,12 +4563,12 @@ START_TEST (jot_resolve_logfmt_vhost_ip_test) {
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   mark_point();
@@ -4578,12 +4578,12 @@ START_TEST (jot_resolve_logfmt_vhost_ip_test) {
   cmd->server = server;
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4607,8 +4607,8 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
 
   /* With an ALL filter, and no command class. */
@@ -4621,8 +4621,8 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
 
   /* With explicit filters that allow the class. */
@@ -4635,8 +4635,8 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
 
   /* With explicit filters that ignore the class. */
@@ -4647,10 +4647,10 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that do not match the class. */
@@ -4661,10 +4661,10 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that allow the command. Note that this REQUIRES
@@ -4680,8 +4680,8 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
 
   /* With explicit filters that ignore the command. */
@@ -4692,10 +4692,10 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 
   /* With explicit filters that do not match the command. */
@@ -4706,10 +4706,10 @@ START_TEST (jot_resolve_logfmt_filters_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, jot_filters, logfmt, NULL,
     resolve_on_meta, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle filtered logfmt");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle filtered logfmt");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
 }
 END_TEST
@@ -4728,10 +4728,10 @@ START_TEST (jot_resolve_logfmt_on_default_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, NULL);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 1,
+  ck_assert_msg(resolve_on_default_count == 1,
     "Expected on_default count 1, got %u", resolve_on_default_count);
 }
 END_TEST
@@ -4750,12 +4750,12 @@ START_TEST (jot_resolve_logfmt_on_other_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 1,
+  ck_assert_msg(resolve_on_other_count == 1,
     "Expected on_other count 1, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4776,12 +4776,12 @@ START_TEST (jot_resolve_logfmt_connect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
@@ -4790,12 +4790,12 @@ START_TEST (jot_resolve_logfmt_connect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4816,12 +4816,12 @@ START_TEST (jot_resolve_logfmt_disconnect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 
   resolve_on_meta_count = resolve_on_default_count = resolve_on_other_count = 0;
@@ -4830,12 +4830,12 @@ START_TEST (jot_resolve_logfmt_disconnect_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 0,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 0,
     "Expected on_meta count 0, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4863,12 +4863,12 @@ START_TEST (jot_resolve_logfmt_custom_test) {
   mark_point();
   res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
     resolve_on_meta, resolve_on_default, resolve_on_other);
-  fail_unless(res == 0, "Failed to handle logfmt: %s", strerror(errno));
-  fail_unless(resolve_on_meta_count == 1,
+  ck_assert_msg(res == 0, "Failed to handle logfmt: %s", strerror(errno));
+  ck_assert_msg(resolve_on_meta_count == 1,
     "Expected on_meta count 1, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 0,
+  ck_assert_msg(resolve_on_default_count == 0,
     "Expected on_default count 0, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4891,15 +4891,15 @@ START_TEST (jot_resolve_logfmts_test) {
     mark_point();
     res = pr_jot_resolve_logfmt(p, cmd, NULL, logfmt, NULL,
       resolve_on_meta, resolve_on_default, resolve_on_other);
-    fail_unless(res == 0, "Failed to handle logfmt_id %u: %s", logfmt[1],
+    ck_assert_msg(res == 0, "Failed to handle logfmt_id %u: %s", logfmt[1],
       strerror(errno));
   }
 
-  fail_unless(resolve_on_meta_count == 20,
+  ck_assert_msg(resolve_on_meta_count == 20,
     "Expected on_meta count 20, got %u", resolve_on_meta_count);
-  fail_unless(resolve_on_default_count == 28,
+  ck_assert_msg(resolve_on_default_count == 28,
     "Expected on_default count 28, got %u", resolve_on_default_count);
-  fail_unless(resolve_on_other_count == 0,
+  ck_assert_msg(resolve_on_other_count == 0,
     "Expected on_other count 0, got %u", resolve_on_other_count);
 }
 END_TEST
@@ -4918,14 +4918,14 @@ START_TEST (jot_scan_logfmt_test) {
 
   mark_point();
   res = pr_jot_scan_logfmt(NULL, NULL, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_scan_logfmt(p, NULL, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null logfmt");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null logfmt");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   logfmt[0] = LOGFMT_META_START;
@@ -4943,14 +4943,14 @@ START_TEST (jot_scan_logfmt_test) {
 
   mark_point();
   res = pr_jot_scan_logfmt(p, logfmt, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null on_meta");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null on_meta");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_scan_logfmt(p, logfmt, 0, NULL, scan_on_meta, 0);
-  fail_unless(res < 0, "Failed to handle invalid LogFormat ID");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid LogFormat ID");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   scan_on_meta_count = 0;
@@ -4958,9 +4958,9 @@ START_TEST (jot_scan_logfmt_test) {
   mark_point();
   res = pr_jot_scan_logfmt(p, logfmt, LOGFMT_META_ENV_VAR, NULL, scan_on_meta,
     0);
-  fail_unless(res == 0, "Failed to scan logmt for ENV_VAR: %s",
+  ck_assert_msg(res == 0, "Failed to scan logmt for ENV_VAR: %s",
     strerror(errno));
-  fail_unless(scan_on_meta_count == 0, "Expected scan_on_meta 0, got %u",
+  ck_assert_msg(scan_on_meta_count == 0, "Expected scan_on_meta 0, got %u",
     scan_on_meta_count);
 
   scan_on_meta_count = 0;
@@ -4968,9 +4968,9 @@ START_TEST (jot_scan_logfmt_test) {
   mark_point();
   res = pr_jot_scan_logfmt(p, logfmt, LOGFMT_META_CUSTOM, NULL, scan_on_meta,
     0);
-  fail_unless(res == 0, "Failed to scan logmt for CUSTOM: %s",
+  ck_assert_msg(res == 0, "Failed to scan logmt for CUSTOM: %s",
     strerror(errno));
-  fail_unless(scan_on_meta_count == 1, "Expected scan_on_meta 1, got %u",
+  ck_assert_msg(scan_on_meta_count == 1, "Expected scan_on_meta 1, got %u",
     scan_on_meta_count);
 }
 END_TEST
@@ -4984,28 +4984,28 @@ START_TEST (jot_on_json_test) {
 
   mark_point();
   res = pr_jot_on_json(NULL, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_on_json(p, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctx = pcalloc(p, sizeof(pr_jot_ctx_t));
 
   mark_point();
   res = pr_jot_on_json(p, ctx, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_on_json(p, ctx, 0, NULL, &num);
-  fail_unless(res < 0, "Failed to handle null ctx->log");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctx->log");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
@@ -5013,16 +5013,16 @@ START_TEST (jot_on_json_test) {
 
   mark_point();
   res = pr_jot_on_json(p, ctx, 0, NULL, &num);
-  fail_unless(res < 0, "Failed to handle null ctx->user_data");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null ctx->user_data");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctx->user_data = pr_table_alloc(p, 0);
 
   mark_point();
   res = pr_jot_on_json(p, ctx, 0, NULL, &num);
-  fail_unless(res < 0, "Failed to handle null JSON info");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null JSON info");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctx->user_data = pr_jot_get_logfmt2json(p);
@@ -5030,25 +5030,25 @@ START_TEST (jot_on_json_test) {
   mark_point();
   truth = FALSE;
   res = pr_jot_on_json(p, ctx, LOGFMT_META_CONNECT, NULL, &truth);
-  fail_unless(res == 0, "Failed to handle LOGFMT_META_CONNECT: %s",
+  ck_assert_msg(res == 0, "Failed to handle LOGFMT_META_CONNECT: %s",
     strerror(errno));
 
   mark_point();
   num = 2476;
   res = pr_jot_on_json(p, ctx, LOGFMT_META_PID, NULL, &num);
-  fail_unless(res == 0, "Failed to handle LOGFMT_META_PID: %s",
+  ck_assert_msg(res == 0, "Failed to handle LOGFMT_META_PID: %s",
     strerror(errno));
 
   mark_point();
   text = "lorem ipsum";
   res = pr_jot_on_json(p, ctx, LOGFMT_META_IDENT_USER, NULL, text);
-  fail_unless(res == 0, "Failed to handle LOGFMT_META_IDENT_USER: %s",
+  ck_assert_msg(res == 0, "Failed to handle LOGFMT_META_IDENT_USER: %s",
     strerror(errno));
 
   mark_point();
   text = "alef bet vet";
   res = pr_jot_on_json(p, ctx, LOGFMT_META_USER, "USER_KEY", text);
-  fail_unless(res == 0, "Failed to handle LOGFMT_META_USER: %s",
+  ck_assert_msg(res == 0, "Failed to handle LOGFMT_META_USER: %s",
     strerror(errno));
 
   (void) pr_json_object_free(json);
@@ -5060,13 +5060,13 @@ START_TEST (jot_get_logfmt2json_test) {
 
   mark_point();
   res = pr_jot_get_logfmt2json(NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_jot_get_logfmt2json(p);
-  fail_unless(res != NULL, "Failed to get map: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to get map: %s", strerror(errno));
 }
 END_TEST
 
@@ -5076,20 +5076,20 @@ START_TEST (jot_get_logfmt_id_name_test) {
 
   mark_point();
   res = pr_jot_get_logfmt_id_name(0);
-  fail_unless(res == NULL, "Failed to handle invalid logfmt_id");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid logfmt_id");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Currently, the max known LogFormat meta/ID is 54 (XFER_PORT). */
   for (i = 2; i < 55; i++) {
     mark_point();
     res = pr_jot_get_logfmt_id_name(i);
-    fail_unless(res != NULL, "Failed to get name for LogFormat ID %u: %s",
+    ck_assert_msg(res != NULL, "Failed to get name for LogFormat ID %u: %s",
       i, strerror(errno)); 
   }
 
   res = pr_jot_get_logfmt_id_name(LOGFMT_META_CUSTOM);
-  fail_unless(res != NULL, "Failed to get name for LogFormat ID %u: %s",
+  ck_assert_msg(res != NULL, "Failed to get name for LogFormat ID %u: %s",
     LOGFMT_META_CUSTOM, strerror(errno)); 
 }
 END_TEST

--- a/tests/api/json.c
+++ b/tests/api/json.c
@@ -59,8 +59,8 @@ START_TEST (json_object_free_test) {
 
   mark_point();
   res = pr_json_object_free(NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -71,17 +71,17 @@ START_TEST (json_object_alloc_test) {
 
   mark_point();
   json = pr_json_object_alloc(NULL);
-  fail_unless(json == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   json = pr_json_object_alloc(p);
-  fail_unless(json != NULL, "Failed to allocate object: %s", strerror(errno));
+  ck_assert_msg(json != NULL, "Failed to allocate object: %s", strerror(errno));
 
   mark_point();
   res = pr_json_object_free(json);
-  fail_unless(res == 0, "Failed to free object: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free object: %s", strerror(errno));
 }
 END_TEST
 
@@ -91,44 +91,44 @@ START_TEST (json_object_from_text_test) {
 
   mark_point();
   json = pr_json_object_from_text(NULL, NULL);
-  fail_unless(json == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   json = pr_json_object_from_text(p, NULL);
-  fail_unless(json == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar";
 
   mark_point();
   json = pr_json_object_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle invalid text '%s'", text);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(json == NULL, "Failed to handle invalid text '%s'", text);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   text = "[\"foo\",\"bar\"]";
 
   mark_point();
   json = pr_json_object_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle non-object text '%s'", text);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(json == NULL, "Failed to handle non-object text '%s'", text);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   text = "{\"foo\":\"bar\"}";
 
   mark_point();
   json = pr_json_object_from_text(p, text);
-  fail_unless(json != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(json != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
   (void) pr_json_object_free(json);
 
   mark_point();
   text = "{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":{\"key\":null}}}}}}}}}}}}}}}}}";
   json = pr_json_object_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle depth-exceeding text '%s'", text);
+  ck_assert_msg(json == NULL, "Failed to handle depth-exceeding text '%s'", text);
 }
 END_TEST
 
@@ -138,31 +138,31 @@ START_TEST (json_object_to_text_test) {
 
   mark_point();
   text = pr_json_object_to_text(NULL, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = pr_json_object_to_text(p, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
 
   mark_point();
   text = pr_json_object_to_text(p, json, NULL);
-  fail_unless(text == NULL, "Failed to handle null indent");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null indent");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   expected = "{}";
 
   mark_point();
   text = pr_json_object_to_text(p, json, "");
-  fail_unless(text != NULL, "Failed to get text for object: %s",
+  ck_assert_msg(text != NULL, "Failed to get text for object: %s",
     strerror(errno));
-  fail_unless(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
     text);
 
   (void) pr_json_object_set_string(p, json, "foo", "bar");
@@ -170,9 +170,9 @@ START_TEST (json_object_to_text_test) {
 
   mark_point();
   text = pr_json_object_to_text(p, json, "");
-  fail_unless(text != NULL, "Failed to get text for object: %s",
+  ck_assert_msg(text != NULL, "Failed to get text for object: %s",
     strerror(errno));
-  fail_unless(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
     text);
 
   (void) pr_json_object_free(json);
@@ -197,22 +197,22 @@ START_TEST(json_object_foreach_test) {
 
   mark_point();
   res = pr_json_object_foreach(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_json_object_foreach(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null object");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null object");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_foreach(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null callback");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null callback");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_json_object_free(json);
@@ -222,12 +222,12 @@ START_TEST(json_object_foreach_test) {
 
   mark_point();
   res = pr_json_object_foreach(p, json, object_item_ok, NULL);
-  fail_unless(res == 0, "Failed to iterate over object: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to iterate over object: %s", strerror(errno));
 
   mark_point();
   res = pr_json_object_foreach(p, json, object_item_fail, NULL);
-  fail_unless(res < 0, "Failing callback succeeded unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failing callback succeeded unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   (void) pr_json_object_free(json);
@@ -241,15 +241,15 @@ START_TEST (json_object_count_test) {
 
   mark_point();
   res = pr_json_object_count(NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_count(json);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   (void) pr_json_object_free(json);
 
@@ -258,7 +258,7 @@ START_TEST (json_object_count_test) {
 
   mark_point();
   res = pr_json_object_count(json);
-  fail_unless(res == 3, "Expected 3, got %d", res);
+  ck_assert_msg(res == 3, "Expected 3, got %d", res);
 
   (void) pr_json_object_free(json);
 }
@@ -271,23 +271,23 @@ START_TEST (json_object_exists_test) {
 
   mark_point();
   res = pr_json_object_exists(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_exists(json, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "foo";
 
   mark_point();
   res = pr_json_object_exists(json, key);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   (void) pr_json_object_free(json);
 
@@ -296,7 +296,7 @@ START_TEST (json_object_exists_test) {
 
   mark_point();
   res = pr_json_object_exists(json, key);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   (void) pr_json_object_free(json);
 }
@@ -309,27 +309,27 @@ START_TEST (json_object_remove_test) {
 
   mark_point();
   res = pr_json_object_remove(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_remove(json, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "foo";
 
   mark_point();
   res = pr_json_object_remove(json, key);
-  fail_unless(res == 0, "Failed to remove nonexistent key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to remove nonexistent key '%s': %s", key,
     strerror(errno));
 
   res = pr_json_object_count(json);
-  fail_unless(res == 0, "Expected count 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected count 0, got %d", res);
 
   (void) pr_json_object_free(json);
 
@@ -338,15 +338,15 @@ START_TEST (json_object_remove_test) {
 
   mark_point();
   res = pr_json_object_remove(json, key);
-  fail_unless(res == 0, "Failed to remove existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to remove existing key '%s': %s", key,
     strerror(errno));
   
   res = pr_json_object_count(json);
-  fail_unless(res == 2, "Expected count 2, got %d", res);
+  ck_assert_msg(res == 2, "Expected count 2, got %d", res);
 
   mark_point();
   res = pr_json_object_exists(json, key);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   (void) pr_json_object_free(json);
 }
@@ -359,36 +359,36 @@ START_TEST(json_object_get_bool_test) {
 
   mark_point();
   res = pr_json_object_get_bool(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_bool(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_bool(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_bool(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_bool(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -398,17 +398,17 @@ START_TEST(json_object_get_bool_test) {
 
   mark_point();
   res = pr_json_object_get_bool(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle non-boolean key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-boolean key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
  
   mark_point();
   res = pr_json_object_get_bool(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val == TRUE, "Expected TRUE, got %d", val);
+  ck_assert_msg(val == TRUE, "Expected TRUE, got %d", val);
  
   (void) pr_json_object_free(json);
 }
@@ -421,38 +421,38 @@ START_TEST(json_object_set_bool_test) {
 
   mark_point();
   res = pr_json_object_set_bool(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_bool(p, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_bool(p, json, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_set_bool(p, json, key, val);
-  fail_unless(res == 0, "Failed to set key '%s' to %d: %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to %d: %s", key, val,
     strerror(errno));
  
   val = FALSE;
  
   mark_point();
   res = pr_json_object_get_bool(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val == TRUE, "Expected TRUE, got %d", val);
+  ck_assert_msg(val == TRUE, "Expected TRUE, got %d", val);
  
   (void) pr_json_object_free(json);
 }
@@ -465,30 +465,30 @@ START_TEST(json_object_get_null_test) {
 
   mark_point();
   res = pr_json_object_get_null(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_null(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_null(p, json, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_null(p, json, key);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -498,15 +498,15 @@ START_TEST(json_object_get_null_test) {
 
   mark_point();
   res = pr_json_object_get_null(p, json, key);
-  fail_unless(res < 0, "Failed to handle non-null key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-null key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
  
   mark_point();
   res = pr_json_object_get_null(p, json, key);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
  
   (void) pr_json_object_free(json);
@@ -520,33 +520,33 @@ START_TEST(json_object_set_null_test) {
 
   mark_point();
   res = pr_json_object_set_null(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_null(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_null(p, json, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_set_null(p, json, key);
-  fail_unless(res == 0, "Failed to set key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set key '%s': %s", key, strerror(errno));
  
   mark_point();
   res = pr_json_object_get_null(p, json, key);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
  
   (void) pr_json_object_free(json);
@@ -561,36 +561,36 @@ START_TEST(json_object_get_number_test) {
 
   mark_point();
   res = pr_json_object_get_number(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_number(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_number(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_number(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_number(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -600,17 +600,17 @@ START_TEST(json_object_get_number_test) {
 
   mark_point();
   res = pr_json_object_get_number(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle non-number key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-number key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
  
   mark_point();
   res = pr_json_object_get_number(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
+  ck_assert_msg(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
  
   (void) pr_json_object_free(json);
 }
@@ -624,38 +624,38 @@ START_TEST(json_object_set_number_test) {
 
   mark_point();
   res = pr_json_object_set_number(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_number(p, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_number(p, json, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_set_number(p, json, key, val);
-  fail_unless(res == 0, "Failed to set key '%s' to %d: %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to %d: %s", key, val,
     strerror(errno));
  
   val = 3;
  
   mark_point();
   res = pr_json_object_get_number(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
+  ck_assert_msg(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
  
   (void) pr_json_object_free(json);
 }
@@ -668,36 +668,36 @@ START_TEST(json_object_get_string_test) {
 
   mark_point();
   res = pr_json_object_get_string(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_string(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_string(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_string(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_string(p, json, key, (char **) &val);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -707,17 +707,17 @@ START_TEST(json_object_get_string_test) {
 
   mark_point();
   res = pr_json_object_get_string(p, json, key, (char **) &val);
-  fail_unless(res < 0, "Failed to handle non-string key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-string key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
  
   mark_point();
   res = pr_json_object_get_string(p, json, key, (char **) &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(strcmp(val, "baz") == 0, "Expected 'baz', got '%s'", val);
+  ck_assert_msg(strcmp(val, "baz") == 0, "Expected 'baz', got '%s'", val);
  
   (void) pr_json_object_free(json);
 
@@ -728,9 +728,9 @@ START_TEST(json_object_get_string_test) {
 
   mark_point();
   res = pr_json_object_get_string(p, json, key, (char **) &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(strcmp(val, "") == 0, "Expected '', got '%s'", val);
+  ck_assert_msg(strcmp(val, "") == 0, "Expected '', got '%s'", val);
 
   (void) pr_json_object_free(json);
 }
@@ -743,46 +743,46 @@ START_TEST(json_object_set_string_test) {
 
   mark_point();
   res = pr_json_object_set_string(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_string(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_string(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
  
   mark_point();
   res = pr_json_object_set_string(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "Hello, World!";
 
   mark_point();
   res = pr_json_object_set_string(p, json, key, val);
-  fail_unless(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
     strerror(errno));
  
   val = "glarg";
  
   mark_point();
   res = pr_json_object_get_string(p, json, key, (char **) &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(strcmp(val, "Hello, World!") == 0,
+  ck_assert_msg(strcmp(val, "Hello, World!") == 0,
     "Expected 'Hello, World!', got '%s'", val);
  
   (void) pr_json_object_free(json);
@@ -798,36 +798,36 @@ START_TEST(json_object_get_array_test) {
 
   mark_point();
   res = pr_json_object_get_array(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_array(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_array(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_array(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_array(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -837,8 +837,8 @@ START_TEST(json_object_get_array_test) {
 
   mark_point();
   res = pr_json_object_get_array(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle non-array key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-array key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
@@ -846,13 +846,13 @@ START_TEST(json_object_get_array_test) {
  
   mark_point();
   res = pr_json_object_get_array(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val != NULL, "Expected array, got null");
+  ck_assert_msg(val != NULL, "Expected array, got null");
 
   expected = "[\"baz\"]";
   str = pr_json_array_to_text(p, val, "");
-  fail_unless(strcmp(str, expected) == 0,
+  ck_assert_msg(strcmp(str, expected) == 0,
     "Expected '%s', got '%s'", expected, str);
 
   mark_point();
@@ -871,30 +871,30 @@ START_TEST(json_object_set_array_test) {
 
   mark_point();
   res = pr_json_object_set_array(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_array(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_array(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_set_array(p, json, key, val);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "[1, 1, 2, 3, 5, 8]";
@@ -902,16 +902,16 @@ START_TEST(json_object_set_array_test) {
 
   mark_point();
   res = pr_json_object_set_array(p, json, key, val);
-  fail_unless(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
     strerror(errno));
 
   val = NULL;
  
   mark_point();
   res = pr_json_object_get_array(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val != NULL, "Expected array, got null");
+  ck_assert_msg(val != NULL, "Expected array, got null");
 
   mark_point();
   (void) pr_json_array_free(val); 
@@ -927,36 +927,36 @@ START_TEST(json_object_get_object_test) {
 
   mark_point();
   res = pr_json_object_get_object(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_object(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_get_object(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_get_object(p, json, key, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_get_object(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_object_free(json);
@@ -966,8 +966,8 @@ START_TEST(json_object_get_object_test) {
 
   mark_point();
   res = pr_json_object_get_object(p, json, key, &val);
-  fail_unless(res < 0, "Failed to handle non-object key '%s'", key);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-object key '%s'", key);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   key = "bar";
@@ -975,13 +975,13 @@ START_TEST(json_object_get_object_test) {
  
   mark_point();
   res = pr_json_object_get_object(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val != NULL, "Expected object, got null");
+  ck_assert_msg(val != NULL, "Expected object, got null");
 
   expected = "{\"baz\":null}";
   str = pr_json_object_to_text(p, val, "");
-  fail_unless(strcmp(str, expected) == 0,
+  ck_assert_msg(strcmp(str, expected) == 0,
     "Expected '%s', got '%s'", expected, str);
 
   mark_point();
@@ -999,30 +999,30 @@ START_TEST(json_object_set_object_test) {
 
   mark_point();
   res = pr_json_object_set_object(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_object_set_object(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_object_alloc(p);
 
   mark_point();
   res = pr_json_object_set_object(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   key = "foo";
 
   mark_point();
   res = pr_json_object_set_object(p, json, key, val);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "{\"eeny\":1,\"meeny\":2,\"miny\":3,\"moe\":false}";
@@ -1030,16 +1030,16 @@ START_TEST(json_object_set_object_test) {
 
   mark_point();
   res = pr_json_object_set_object(p, json, key, val);
-  fail_unless(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
     strerror(errno));
 
   val = NULL;
  
   mark_point();
   res = pr_json_object_get_object(p, json, key, &val);
-  fail_unless(res == 0, "Failed to handle existing key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to handle existing key '%s': %s", key,
     strerror(errno));
-  fail_unless(val != NULL, "Expected object, got null");
+  ck_assert_msg(val != NULL, "Expected object, got null");
 
   mark_point();
   (void) pr_json_object_free(val); 
@@ -1052,8 +1052,8 @@ START_TEST(json_array_free_test) {
 
   mark_point();
   res = pr_json_array_free(NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -1064,17 +1064,17 @@ START_TEST(json_array_alloc_test) {
 
   mark_point();
   json = pr_json_array_alloc(NULL);
-  fail_unless(json == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   json = pr_json_array_alloc(p);
-  fail_unless(json != NULL, "Failed to allocate array: %s", strerror(errno));
+  ck_assert_msg(json != NULL, "Failed to allocate array: %s", strerror(errno));
 
   mark_point();
   res = pr_json_array_free(json);
-  fail_unless(res == 0, "Failed to free array: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free array: %s", strerror(errno));
 }
 END_TEST
 
@@ -1084,44 +1084,44 @@ START_TEST(json_array_from_text_test) {
 
   mark_point();
   json = pr_json_array_from_text(NULL, NULL);
-  fail_unless(json == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   json = pr_json_array_from_text(p, NULL);
-  fail_unless(json == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(json == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar";
 
   mark_point();
   json = pr_json_array_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle invalid text '%s'", text);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(json == NULL, "Failed to handle invalid text '%s'", text);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   text = "{\"foo\":null,\"bar\":false}";
 
   mark_point();
   json = pr_json_array_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle non-array text '%s'", text);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(json == NULL, "Failed to handle non-array text '%s'", text);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   text = "[\"foo\",\"bar\"]";
 
   mark_point();
   json = pr_json_array_from_text(p, text);
-  fail_unless(json != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(json != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
   (void) pr_json_array_free(json);
 
   mark_point();
   text = "[[[[[[[[[[[[[[[[[1]]]]]]]]]]]]]]]]]";
   json = pr_json_array_from_text(p, text);
-  fail_unless(json == NULL, "Failed to handle depth-exceeding text '%s'", text);
+  ck_assert_msg(json == NULL, "Failed to handle depth-exceeding text '%s'", text);
 }
 END_TEST
 
@@ -1131,31 +1131,31 @@ START_TEST(json_array_to_text_test) {
 
   mark_point();
   text = pr_json_array_to_text(NULL, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = pr_json_array_to_text(p, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_array_alloc(p);
 
   mark_point();
   text = pr_json_array_to_text(p, json, NULL);
-  fail_unless(text == NULL, "Failed to handle null indent");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null indent");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   expected = "[]";
 
   mark_point();
   text = pr_json_array_to_text(p, json, "");
-  fail_unless(text != NULL, "Failed to get text for array: %s",
+  ck_assert_msg(text != NULL, "Failed to get text for array: %s",
     strerror(errno));
-  fail_unless(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(text, expected) == 0, "Expected '%s', got '%s'", expected,
     text);
 
   (void) pr_json_array_free(json);
@@ -1180,22 +1180,22 @@ START_TEST(json_array_foreach_test) {
 
   mark_point();
   res = pr_json_array_foreach(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_json_array_foreach(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null array");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null array");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_foreach(p, json, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null callback");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null callback");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_json_array_free(json);
@@ -1205,12 +1205,12 @@ START_TEST(json_array_foreach_test) {
 
   mark_point();
   res = pr_json_array_foreach(p, json, array_item_ok, NULL);
-  fail_unless(res == 0, "Failed to iterate over array: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to iterate over array: %s", strerror(errno));
 
   mark_point();
   res = pr_json_array_foreach(p, json, array_item_fail, NULL);
-  fail_unless(res < 0, "Failing callback succeeded unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failing callback succeeded unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   (void) pr_json_array_free(json);
@@ -1224,15 +1224,15 @@ START_TEST(json_array_count_test) {
 
   mark_point();
   res = pr_json_array_count(NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_count(json);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   (void) pr_json_array_free(json);
 
@@ -1241,7 +1241,7 @@ START_TEST(json_array_count_test) {
 
   mark_point();
   res = pr_json_array_count(json);
-  fail_unless(res == 6, "Expected 6, got %d", res);
+  ck_assert_msg(res == 6, "Expected 6, got %d", res);
 
   (void) pr_json_array_free(json);
 }
@@ -1255,15 +1255,15 @@ START_TEST(json_array_exists_test) {
 
   mark_point();
   res = pr_json_array_exists(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_exists(json, 0);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   (void) pr_json_array_free(json);
 
@@ -1274,7 +1274,7 @@ START_TEST(json_array_exists_test) {
 
   mark_point();
   res = pr_json_array_exists(json, idx);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   (void) pr_json_array_free(json);
 }
@@ -1288,8 +1288,8 @@ START_TEST(json_array_remove_test) {
 
   mark_point();
   res = pr_json_array_remove(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   json = pr_json_array_alloc(p);
@@ -1298,11 +1298,11 @@ START_TEST(json_array_remove_test) {
 
   mark_point();
   res = pr_json_array_remove(json, idx);
-  fail_unless(res == 0, "Failed to remove nonexistent index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to remove nonexistent index %u: %s", idx,
     strerror(errno));
 
   res = pr_json_array_count(json);
-  fail_unless(res == 0, "Expected count 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected count 0, got %d", res);
 
   (void) pr_json_array_free(json);
 
@@ -1311,15 +1311,15 @@ START_TEST(json_array_remove_test) {
 
   mark_point();
   res = pr_json_array_remove(json, idx);
-  fail_unless(res == 0, "Failed to remove existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to remove existing index %u: %s", idx,
     strerror(errno));
   
   res = pr_json_array_count(json);
-  fail_unless(res == 5, "Expected count 5, got %d", res);
+  ck_assert_msg(res == 5, "Expected count 5, got %d", res);
 
   mark_point();
   res = pr_json_array_exists(json, idx);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   (void) pr_json_array_free(json);
 }
@@ -1333,30 +1333,30 @@ START_TEST(json_array_get_bool_test) {
 
   mark_point();
   res = pr_json_array_get_bool(NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_bool(p, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_get_bool(p, json, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   idx = 0;
  
   mark_point();
   res = pr_json_array_get_bool(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1366,17 +1366,17 @@ START_TEST(json_array_get_bool_test) {
 
   mark_point();
   res = pr_json_array_get_bool(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle non-boolean index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-boolean index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 3;
 
   mark_point();
   res = pr_json_array_get_bool(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(val == TRUE, "Expected TRUE, got %d", val);
+  ck_assert_msg(val == TRUE, "Expected TRUE, got %d", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1388,29 +1388,29 @@ START_TEST(json_array_append_bool_test) {
 
   mark_point();
   res = pr_json_array_append_bool(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_bool(p, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_bool(p, json, val);
-  fail_unless(res == 0, "Failed to append val %d: %s", val, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append val %d: %s", val, strerror(errno));
  
   val = FALSE;
  
   mark_point();
   res = pr_json_array_get_bool(p, json, 0, &val);
-  fail_unless(res == 0, "Failed to handle existing index 0: %s",
+  ck_assert_msg(res == 0, "Failed to handle existing index 0: %s",
     strerror(errno));
-  fail_unless(val == TRUE, "Expected TRUE, got %d", val);
+  ck_assert_msg(val == TRUE, "Expected TRUE, got %d", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1424,14 +1424,14 @@ START_TEST(json_array_get_null_test) {
 
   mark_point();
   res = pr_json_array_get_null(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_null(p, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
@@ -1440,8 +1440,8 @@ START_TEST(json_array_get_null_test) {
  
   mark_point();
   res = pr_json_array_get_null(p, json, idx);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1451,15 +1451,15 @@ START_TEST(json_array_get_null_test) {
 
   mark_point();
   res = pr_json_array_get_null(p, json, idx);
-  fail_unless(res < 0, "Failed to handle non-null index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-null index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 3;
 
   mark_point();
   res = pr_json_array_get_null(p, json, idx);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
  
   (void) pr_json_array_free(json);
@@ -1472,25 +1472,25 @@ START_TEST(json_array_append_null_test) {
 
   mark_point();
   res = pr_json_array_append_null(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_null(p, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_null(p, json);
-  fail_unless(res == 0, "Failed to append null vall: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append null vall: %s", strerror(errno));
  
   mark_point();
   res = pr_json_array_get_null(p, json, 0);
-  fail_unless(res == 0, "Failed to handle existing index 0: %s",
+  ck_assert_msg(res == 0, "Failed to handle existing index 0: %s",
     strerror(errno));
  
   (void) pr_json_array_free(json);
@@ -1506,30 +1506,30 @@ START_TEST(json_array_get_number_test) {
 
   mark_point();
   res = pr_json_array_get_number(NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_number(p, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_get_number(p, json, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   idx = 3;
  
   mark_point();
   res = pr_json_array_get_number(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1539,17 +1539,17 @@ START_TEST(json_array_get_number_test) {
 
   mark_point();
   res = pr_json_array_get_number(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle non-number index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-number index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 1;
 
   mark_point();
   res = pr_json_array_get_number(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(fabs(val) == fabs((double) 2.0), "Expected 2, got '%e'", val);
+  ck_assert_msg(fabs(val) == fabs((double) 2.0), "Expected 2, got '%e'", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1562,29 +1562,29 @@ START_TEST(json_array_append_number_test) {
 
   mark_point();
   res = pr_json_array_append_number(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_number(p, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_number(p, json, val);
-  fail_unless(res == 0, "Failed to append val %e: %s", val, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append val %e: %s", val, strerror(errno));
  
   val = 2;
  
   mark_point();
   res = pr_json_array_get_number(p, json, 0, &val);
-  fail_unless(res == 0, "Failed to handle existing index 0: %s",
+  ck_assert_msg(res == 0, "Failed to handle existing index 0: %s",
     strerror(errno));
-  fail_unless(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
+  ck_assert_msg(fabs(val) == fabs((double) 7.0), "Expected 7, got %e", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1598,30 +1598,30 @@ START_TEST(json_array_get_string_test) {
 
   mark_point();
   res = pr_json_array_get_string(NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_string(p, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_get_string(p, json, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   idx = 3;
  
   mark_point();
   res = pr_json_array_get_string(p, json, idx, (char **) &val);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1631,17 +1631,17 @@ START_TEST(json_array_get_string_test) {
 
   mark_point();
   res = pr_json_array_get_string(p, json, idx, (char **) &val);
-  fail_unless(res < 0, "Failed to handle non-string index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-string index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 0;
 
   mark_point();
   res = pr_json_array_get_string(p, json, idx, (char **) &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(strcmp(val, "foo") == 0, "Expected 'foo', got '%s'", val);
+  ck_assert_msg(strcmp(val, "foo") == 0, "Expected 'foo', got '%s'", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1654,37 +1654,37 @@ START_TEST(json_array_append_string_test) {
 
   mark_point();
   res = pr_json_array_append_string(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_string(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_string(p, json, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
  
   val = "foo!";
  
   mark_point();
   res = pr_json_array_append_string(p, json, val);
-  fail_unless(res == 0, "Failed to append val '%s': %s", val, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append val '%s': %s", val, strerror(errno));
  
   val = NULL;
  
   mark_point();
   res = pr_json_array_get_string(p, json, 0, (char **) &val);
-  fail_unless(res == 0, "Failed to handle existing index 0: %s",
+  ck_assert_msg(res == 0, "Failed to handle existing index 0: %s",
     strerror(errno));
-  fail_unless(strcmp(val, "foo!") == 0, "Expected 'foo!', got '%s'", val);
+  ck_assert_msg(strcmp(val, "foo!") == 0, "Expected 'foo!', got '%s'", val);
  
   (void) pr_json_array_free(json);
 }
@@ -1699,30 +1699,30 @@ START_TEST(json_array_get_array_test) {
 
   mark_point();
   res = pr_json_array_get_array(NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_array(p, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_get_array(p, json, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   idx = 0;
  
   mark_point();
   res = pr_json_array_get_array(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1732,8 +1732,8 @@ START_TEST(json_array_get_array_test) {
 
   mark_point();
   res = pr_json_array_get_array(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle non-array index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-array index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 3;
@@ -1741,13 +1741,13 @@ START_TEST(json_array_get_array_test) {
  
   mark_point();
   res = pr_json_array_get_array(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(val != NULL, "Expected array, got null");
+  ck_assert_msg(val != NULL, "Expected array, got null");
 
   expected = "[\"baz\"]";
   str = pr_json_array_to_text(p, val, "");
-  fail_unless(strcmp(str, expected) == 0,
+  ck_assert_msg(strcmp(str, expected) == 0,
     "Expected '%s', got '%s'", expected, str);
 
   mark_point();
@@ -1766,22 +1766,22 @@ START_TEST(json_array_append_array_test) {
 
   mark_point();
   res = pr_json_array_append_array(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_array(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_array(p, json, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "[1, 1, 2, 3, 5, 8]";
@@ -1789,16 +1789,16 @@ START_TEST(json_array_append_array_test) {
 
   mark_point();
   res = pr_json_array_append_array(p, json, val);
-  fail_unless(res == 0, "Failed to append array: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append array: %s", strerror(errno));
 
   val = NULL;
   idx = 0;
  
   mark_point();
   res = pr_json_array_get_array(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(val != NULL, "Expected array, got null");
+  ck_assert_msg(val != NULL, "Expected array, got null");
 
   mark_point();
   (void) pr_json_array_free(val); 
@@ -1816,30 +1816,30 @@ START_TEST(json_array_get_object_test) {
 
   mark_point();
   res = pr_json_array_get_object(NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_get_object(p, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_get_object(p, json, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   idx = 0;
  
   mark_point();
   res = pr_json_array_get_object(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle nonexistent index %u", idx);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent index %u", idx);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
  
   (void) pr_json_array_free(json);
@@ -1849,8 +1849,8 @@ START_TEST(json_array_get_object_test) {
 
   mark_point();
   res = pr_json_array_get_object(p, json, idx, &val);
-  fail_unless(res < 0, "Failed to handle non-object index %u", idx);
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle non-object index %u", idx);
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   idx = 3;
@@ -1858,13 +1858,13 @@ START_TEST(json_array_get_object_test) {
  
   mark_point();
   res = pr_json_array_get_object(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(val != NULL, "Expected object, got null");
+  ck_assert_msg(val != NULL, "Expected object, got null");
 
   expected = "{}";
   str = pr_json_object_to_text(p, val, "");
-  fail_unless(strcmp(str, expected) == 0,
+  ck_assert_msg(strcmp(str, expected) == 0,
     "Expected '%s', got '%s'", expected, str);
 
   mark_point();
@@ -1884,22 +1884,22 @@ START_TEST(json_array_append_object_test) {
 
   mark_point();
   res = pr_json_array_append_object(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = pr_json_array_append_object(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null json");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null json");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   json = pr_json_array_alloc(p);
 
   mark_point();
   res = pr_json_array_append_object(p, json, NULL);
-  fail_unless(res < 0, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "{\"foo\":1,\"bar\":2}";
@@ -1907,16 +1907,16 @@ START_TEST(json_array_append_object_test) {
 
   mark_point();
   res = pr_json_array_append_object(p, json, val);
-  fail_unless(res == 0, "Failed to append object: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to append object: %s", strerror(errno));
 
   val = NULL;
   idx = 0;
  
   mark_point();
   res = pr_json_array_get_object(p, json, idx, &val);
-  fail_unless(res == 0, "Failed to handle existing index %u: %s", idx,
+  ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,
     strerror(errno));
-  fail_unless(val != NULL, "Expected object, got null");
+  ck_assert_msg(val != NULL, "Expected object, got null");
 
   mark_point();
   (void) pr_json_object_free(val); 
@@ -1930,27 +1930,27 @@ START_TEST(json_text_validate_test) {
 
   mark_point();
   res = pr_json_text_validate(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_json_text_validate(p, NULL);
-  fail_unless(res < 0, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar";
 
   mark_point();
   res = pr_json_text_validate(p, text);
-  fail_unless(res == FALSE, "Failed to handle invalid text '%s'", text);
+  ck_assert_msg(res == FALSE, "Failed to handle invalid text '%s'", text);
 
   text = "[{}]";
 
   mark_point();
   res = pr_json_text_validate(p, text);
-  fail_unless(res == TRUE, "Failed to handle valid text '%s'", text);
+  ck_assert_msg(res == TRUE, "Failed to handle valid text '%s'", text);
 }
 END_TEST
 
@@ -1958,50 +1958,50 @@ START_TEST(json_type_name_test) {
   const char *res, *expected;
 
   res = pr_json_type_name(0);
-  fail_unless(res == NULL, "Failed to handle invalid JSON type ID 0");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid JSON type ID 0");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   expected = "boolean";
   res = pr_json_type_name(PR_JSON_TYPE_BOOL);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_BOOL: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_BOOL: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = "number";
   res = pr_json_type_name(PR_JSON_TYPE_NUMBER);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_NUMBER: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_NUMBER: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = "null";
   res = pr_json_type_name(PR_JSON_TYPE_NULL);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_NULL: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_NULL: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = "string";
   res = pr_json_type_name(PR_JSON_TYPE_STRING);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_STRING: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_STRING: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = "array";
   res = pr_json_type_name(PR_JSON_TYPE_ARRAY);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_ARRAY: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_ARRAY: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   expected = "object";
   res = pr_json_type_name(PR_JSON_TYPE_OBJECT);
-  fail_unless(res != NULL, "Failed to handle JSON_TYPE_OBJECT: %s",
+  ck_assert_msg(res != NULL, "Failed to handle JSON_TYPE_OBJECT: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST

--- a/tests/api/json.c
+++ b/tests/api/json.c
@@ -646,7 +646,7 @@ START_TEST(json_object_set_number_test) {
 
   mark_point();
   res = pr_json_object_set_number(p, json, key, val);
-  ck_assert_msg(res == 0, "Failed to set key '%s' to %d: %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to %f: %s", key, val,
     strerror(errno));
  
   val = 3;
@@ -902,7 +902,7 @@ START_TEST(json_object_set_array_test) {
 
   mark_point();
   res = pr_json_object_set_array(p, json, key, val);
-  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, text,
     strerror(errno));
 
   val = NULL;
@@ -1030,7 +1030,7 @@ START_TEST(json_object_set_object_test) {
 
   mark_point();
   res = pr_json_object_set_object(p, json, key, val);
-  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s' to '%s': %s", key, text,
     strerror(errno));
 
   val = NULL;

--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -104,20 +104,20 @@ START_TEST (schedule_test) {
   schedule(schedule_cb, 0, NULL, NULL, NULL, NULL);
 
   run_schedule();
-  fail_unless(schedule_called == 1, "Expected 1, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 1, "Expected 1, got %u", schedule_called);
 
   run_schedule();
-  fail_unless(schedule_called == 1, "Expected 1, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 1, "Expected 1, got %u", schedule_called);
 
   mark_point();
   schedule(schedule_cb, 0, NULL, NULL, NULL, NULL);
   schedule(schedule_cb, 0, NULL, NULL, NULL, NULL);
 
   run_schedule();
-  fail_unless(schedule_called == 3, "Expected 3, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 3, "Expected 3, got %u", schedule_called);
 
   run_schedule();
-  fail_unless(schedule_called == 3, "Expected 3, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 3, "Expected 3, got %u", schedule_called);
 
   mark_point();
 
@@ -127,13 +127,13 @@ START_TEST (schedule_test) {
   schedule(schedule_cb, 2, NULL, NULL, NULL, NULL);
 
   run_schedule();
-  fail_unless(schedule_called == 3, "Expected 3, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 3, "Expected 3, got %u", schedule_called);
 
   run_schedule();
-  fail_unless(schedule_called == 3, "Expected 3, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 3, "Expected 3, got %u", schedule_called);
 
   run_schedule();
-  fail_unless(schedule_called == 4, "Expected 4, got %u", schedule_called);
+  ck_assert_msg(schedule_called == 4, "Expected 4, got %u", schedule_called);
 }
 END_TEST
 
@@ -143,8 +143,8 @@ START_TEST (get_name_max_test) {
   int fd;
 
   res = get_name_max(NULL, -1);
-  fail_unless(res < 0, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
@@ -158,7 +158,7 @@ START_TEST (get_name_max_test) {
    * valid file descriptor, and some will not.
    */
   if (res < 0) {
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
   }
 }
@@ -169,29 +169,29 @@ START_TEST (dir_interpolate_test) {
   const char *path;
 
   res = dir_interpolate(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_interpolate(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_interpolate(p, path);
-  fail_unless(path != NULL, "Failed to interpolate '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to interpolate '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 
   mark_point();
   path = "~foo.bar.bar.quxx.quzz/foo";
   res = dir_interpolate(p, path);
-  fail_unless(path != NULL, "Failed to interpolate '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to interpolate '%s': %s", path,
     strerror(errno));
-  fail_unless(*path == '~', "Interpolated path with unknown user unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(*path == '~', "Interpolated path with unknown user unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -201,21 +201,21 @@ START_TEST (dir_best_path_test) {
   const char *path;
 
   res = dir_best_path(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_best_path(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_best_path(p, path);
-  fail_unless(path != NULL, "Failed to get best path for '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to get best path for '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 }
 END_TEST
 
@@ -224,21 +224,21 @@ START_TEST (dir_canonical_path_test) {
   const char *path;
 
   res = dir_canonical_path(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_canonical_path(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_canonical_path(p, path);
-  fail_unless(path != NULL, "Failed to get canonical path for '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to get canonical path for '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 }
 END_TEST
 
@@ -247,21 +247,21 @@ START_TEST (dir_canonical_vpath_test) {
   const char *path;
 
   res = dir_canonical_vpath(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_canonical_vpath(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_canonical_vpath(p, path);
-  fail_unless(path != NULL, "Failed to get canonical vpath for '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to get canonical vpath for '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 }
 END_TEST
 
@@ -275,29 +275,29 @@ START_TEST (dir_readlink_test) {
 
   /* Parameter validation */
   res = dir_readlink(NULL, NULL, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_readlink(p, NULL, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = misc_test_readlink;
   res = dir_readlink(p, path, NULL, 0, flags);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   bufsz = 1024;
   buf = palloc(p, bufsz);
   res = dir_readlink(p, path, buf, 0, flags);
-  fail_unless(res == 0, "Failed to handle zero buffer length");
+  ck_assert_msg(res == 0, "Failed to handle zero buffer length");
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_unless(res < 0, "Failed to handle nonexistent file");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   dst_path = "";
@@ -307,7 +307,7 @@ START_TEST (dir_readlink_test) {
      * them.
      */
     res = dir_readlink(p, path, buf, bufsz, flags);
-    fail_unless(res == 0, "Failed to handle empty symlink");
+    ck_assert_msg(res == 0, "Failed to handle empty symlink");
   }
   (void) unlink(path);
 
@@ -316,14 +316,14 @@ START_TEST (dir_readlink_test) {
   dst_path = "/home/user/file.dat";
   dst_pathlen = strlen(dst_path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Not chrooted, relative dst path, flags to ignore rel path */
@@ -333,14 +333,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Not chrooted, relative dst path without leading '.', flags to ignore rel
@@ -352,14 +352,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Not chrooted, relative dst path, flags to HANDLE rel path */
@@ -371,15 +371,15 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Not chrooted, relative dst path without leading '.', flags to HANDLE rel
@@ -393,15 +393,15 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Not chrooted, dst path longer than given buffer */
@@ -409,8 +409,8 @@ START_TEST (dir_readlink_test) {
   memset(buf, '\0', bufsz);
   res = dir_readlink(p, path, buf, 2, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless(res == 2, "Expected length 2, got %d", res);
-  fail_unless(strncmp(buf, dst_path, 2) == 0, "Expected '%*s', got '%*s'",
+  ck_assert_msg(res == 2, "Expected length 2, got %d", res);
+  ck_assert_msg(strncmp(buf, dst_path, 2) == 0, "Expected '%*s', got '%*s'",
     2, dst_path, 2, buf);
 
   /* Chrooted to "/" */
@@ -418,9 +418,9 @@ START_TEST (dir_readlink_test) {
   memset(buf, '\0', bufsz);
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Chrooted, absolute destination path shorter than chroot path */
@@ -431,14 +431,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Chrooted, overlapping chroot to non-dir */
@@ -448,14 +448,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == dst_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
-  fail_unless(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
     dst_path, buf);
 
   /* Chrooted, absolute destination within chroot */
@@ -467,14 +467,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Chrooted, absolute destination outside of chroot */
@@ -486,14 +486,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Chrooted, relative destination within chroot */
@@ -505,14 +505,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Chrooted, relative destination (without leading '.') within chroot */
@@ -524,14 +524,14 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Chrooted, relative destination outside of chroot */
@@ -543,16 +543,16 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   /* First, tell dir_readlink() to ignore relative destination paths. */
   flags = 0;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Now do it again, telling dir_readlink() to handle relative destination
@@ -566,15 +566,15 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* One more time, this time changing the chroot path to align with the
@@ -588,16 +588,16 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   session.chroot_path = "/tmp";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Now use a relative path that does not start with '.' */
@@ -609,17 +609,17 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   session.chroot_path = "/tmp";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen,
+  ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Now use a relative path that does not start with '.', and a chroot
@@ -633,17 +633,17 @@ START_TEST (dir_readlink_test) {
 
   (void) unlink(path);
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen,
+  ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Now use a relative path, and a chroot deeper down than one directory, and
@@ -660,17 +660,17 @@ START_TEST (dir_readlink_test) {
   (void) mkdir(misc_test_readlink2_dir, 0777);
   path = misc_test_readlink2;
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen,
+  ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   /* Now use a relative path that does not start with '.', and a chroot
@@ -687,17 +687,17 @@ START_TEST (dir_readlink_test) {
   (void) mkdir(misc_test_readlink2_dir, 0777);
   path = misc_test_readlink2;
   res = symlink(dst_path, path);
-  fail_unless(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
+  ck_assert_msg(res == 0, "Failed to symlink '%s' to '%s': %s", path, dst_path,
     strerror(errno));
 
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
   fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
-  fail_unless((size_t) res == expected_pathlen,
+  ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
-  fail_unless(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
     expected_path, buf);
 
   (void) unlink(misc_test_readlink);
@@ -711,28 +711,28 @@ START_TEST (dir_realpath_test) {
   const char *path;
 
   res = dir_realpath(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_realpath(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_realpath(p, path);
-  fail_unless(res == NULL, "Got real path for '%s' unexpectedly", path);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Got real path for '%s' unexpectedly", path);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   path = "/";
   res = dir_realpath(p, path);
-  fail_unless(res != NULL, "Failed to get real path for '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to get real path for '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 }
 END_TEST
 
@@ -741,21 +741,21 @@ START_TEST (dir_abs_path_test) {
   const char *path;
 
   res = dir_abs_path(NULL, NULL, TRUE);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = dir_abs_path(p, NULL, TRUE);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "/foo";
   res = dir_abs_path(p, path, TRUE);
-  fail_unless(path != NULL, "Failed to get absolute path for '%s': %s", path,
+  ck_assert_msg(path != NULL, "Failed to get absolute path for '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
+  ck_assert_msg(strcmp(res, path) == 0, "Expected '%s', got '%s'", path, res);
 }
 END_TEST
 
@@ -765,40 +765,40 @@ START_TEST (safe_token_test) {
   mark_point();
   expected = "";
   res = safe_token(NULL);
-  fail_unless(res != NULL, "Failed to handle null arguments");
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null arguments");
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   mark_point();
   text = "";
   expected = "";
   res = safe_token(&text);
-  fail_unless(res != NULL, "Failed to handle null arguments");
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null arguments");
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   mark_point();
   text = "foo";
   expected = text;
   res = safe_token(&text);
-  fail_unless(res != NULL, "Failed to handle null arguments");
-  fail_unless(res == expected, "Expected '%s', got '%s'", expected, res);
-  fail_unless(strcmp(text, "") == 0, "Expected '', got '%s'", text);
+  ck_assert_msg(res != NULL, "Failed to handle null arguments");
+  ck_assert_msg(res == expected, "Expected '%s', got '%s'", expected, res);
+  ck_assert_msg(strcmp(text, "") == 0, "Expected '', got '%s'", text);
 
   mark_point();
   text = "  foo";
   expected = text + 2;
   res = safe_token(&text);
-  fail_unless(res != NULL, "Failed to handle null arguments");
-  fail_unless(res == expected, "Expected '%s', got '%s'", expected, res);
-  fail_unless(strcmp(text, "") == 0, "Expected '', got '%s'", text);
+  ck_assert_msg(res != NULL, "Failed to handle null arguments");
+  ck_assert_msg(res == expected, "Expected '%s', got '%s'", expected, res);
+  ck_assert_msg(strcmp(text, "") == 0, "Expected '', got '%s'", text);
 
   mark_point();
   text = "  \t";
   expected = "";
   res = safe_token(&text);
-  fail_unless(res != NULL, "Failed to handle null arguments");
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to handle null arguments");
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST
@@ -828,20 +828,20 @@ START_TEST (check_shutmsg_test) {
   char shutdown_msg[PR_TUNABLE_BUFFER_SIZE];
 
   res = check_shutmsg(NULL, NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/foo/bar/baz/quxx/quzz";
   res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle nonexistent path");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   path = "/";
   res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle directory path");
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle directory path");
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   /* XXX More testing needed */
@@ -851,7 +851,7 @@ START_TEST (check_shutmsg_test) {
   (void) unlink(path);
   res = write_shutmsg(path,
     "1970 1 1 0 0 0 0000 0000\nGoodbye, cruel world!\n");
-  fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   memset(shutdown_msg, '\0', sizeof(shutdown_msg));
   pr_env_set(p, "TZ", "GMT");
@@ -859,29 +859,29 @@ START_TEST (check_shutmsg_test) {
   mark_point();
   res = check_shutmsg(p, path, &when_shutdown, &when_deny, &when_disconnect,
     shutdown_msg, sizeof(shutdown_msg));
-  fail_unless(res == 1, "Expected 1, got %d", res);
-  fail_unless(when_shutdown == (time_t) 0, "Expected 0, got %lu",
+  ck_assert_msg(res == 1, "Expected 1, got %d", res);
+  ck_assert_msg(when_shutdown == (time_t) 0, "Expected 0, got %lu",
     (unsigned long) when_shutdown);
-  fail_unless(when_deny == (time_t) 0, "Expected 0, got %lu",
+  ck_assert_msg(when_deny == (time_t) 0, "Expected 0, got %lu",
     (unsigned long) when_deny);
-  fail_unless(when_disconnect == (time_t) 0, "Expected 0, got %lu",
+  ck_assert_msg(when_disconnect == (time_t) 0, "Expected 0, got %lu",
     (unsigned long) when_disconnect);
-  fail_unless(strcmp(shutdown_msg, "Goodbye, cruel world!") == 0,
+  ck_assert_msg(strcmp(shutdown_msg, "Goodbye, cruel world!") == 0,
     "Expected 'Goodbye, cruel world!', got '%s'", shutdown_msg);
 
   (void) unlink(path);
   res = write_shutmsg(path,
     "2037 1 1 0 0 0 0000 0000\nGoodbye, cruel world!\n");
-  fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
   res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res == 1, "Expected 1, got %d", res);
+  ck_assert_msg(res == 1, "Expected 1, got %d", res);
 
   (void) unlink(path);
   res = write_shutmsg(path,
     "0 0 0 0 0 0 0000 0000\nGoodbye, cruel world!\n");
-  fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
   res = check_shutmsg(p, path, NULL, NULL, NULL, NULL, 0);
@@ -907,7 +907,7 @@ START_TEST (memscrub_test) {
 
   mark_point();
   pr_memscrub(text, len);
-  fail_unless(strncmp(text, expected, len + 1) != 0,
+  ck_assert_msg(strncmp(text, expected, len + 1) != 0,
     "Expected other than '%s'", expected);
 }
 END_TEST
@@ -923,11 +923,11 @@ START_TEST (exists_test) {
   const char *path;
 
   res = exists(NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = exists(path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 }
 END_TEST
 
@@ -936,14 +936,14 @@ START_TEST (exists2_test) {
   const char *path;
 
   res = exists2(NULL, NULL);
-  fail_unless(res == FALSE, "Failed to handle null arguments");
+  ck_assert_msg(res == FALSE, "Failed to handle null arguments");
 
   res = exists2(p, NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = exists2(p, path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 }
 END_TEST
 
@@ -952,15 +952,15 @@ START_TEST (dir_exists_test) {
   const char *path;
 
   res = dir_exists(NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = dir_exists(path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 
   path = "./api-tests";
   res = dir_exists(path);
-  fail_unless(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
+  ck_assert_msg(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
 }
 END_TEST
 
@@ -969,18 +969,18 @@ START_TEST (dir_exists2_test) {
   const char *path;
 
   res = dir_exists2(NULL, NULL);
-  fail_unless(res == FALSE, "Failed to handle null arguments");
+  ck_assert_msg(res == FALSE, "Failed to handle null arguments");
 
   res = dir_exists2(p, NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = dir_exists2(p, path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 
   path = "./api-tests";
   res = dir_exists2(p, path);
-  fail_unless(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
+  ck_assert_msg(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
 }
 END_TEST
 
@@ -989,13 +989,13 @@ START_TEST (symlink_mode_test) {
   const char *path;
 
   res = symlink_mode(NULL);
-  fail_unless(res == 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
   res = symlink_mode(path);
-  fail_unless(res == 0, "Found mode for non-symlink '%s'", path);
+  ck_assert_msg(res == 0, "Found mode for non-symlink '%s'", path);
 }
 END_TEST
 
@@ -1004,18 +1004,18 @@ START_TEST (symlink_mode2_test) {
   const char *path;
 
   res = symlink_mode2(NULL, NULL);
-  fail_unless(res == 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = symlink_mode2(p, NULL);
-  fail_unless(res == 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
   res = symlink_mode2(p, path);
-  fail_unless(res == 0, "Found mode for non-symlink '%s'", path);
+  ck_assert_msg(res == 0, "Found mode for non-symlink '%s'", path);
 }
 END_TEST
 
@@ -1024,13 +1024,13 @@ START_TEST (file_mode_test) {
   const char *path;
 
   res = file_mode(NULL);
-  fail_unless(res == 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
   res = file_mode(path);
-  fail_unless(res != 0, "Failed to find mode for '%s': %s", path,
+  ck_assert_msg(res != 0, "Failed to find mode for '%s': %s", path,
     strerror(errno));
 }
 END_TEST
@@ -1040,18 +1040,18 @@ START_TEST (file_mode2_test) {
   const char *path;
 
   res = file_mode2(NULL, NULL);
-  fail_unless(res == 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = file_mode2(p, NULL);
-  fail_unless(res == 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/";
   res = file_mode2(p, path);
-  fail_unless(res != 0, "Failed to find mode for '%s': %s", path,
+  ck_assert_msg(res != 0, "Failed to find mode for '%s': %s", path,
     strerror(errno));
 }
 END_TEST
@@ -1061,15 +1061,15 @@ START_TEST (file_exists_test) {
   const char *path;
 
   res = file_exists(NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = file_exists(path);
-  fail_unless(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
+  ck_assert_msg(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
 
   path = "./api-tests";
   res = file_exists(path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 }
 END_TEST
 
@@ -1078,18 +1078,18 @@ START_TEST (file_exists2_test) {
   const char *path;
 
   res = file_exists2(NULL, NULL);
-  fail_unless(res == FALSE, "Failed to handle null arguments");
+  ck_assert_msg(res == FALSE, "Failed to handle null arguments");
 
   res = file_exists2(p, NULL);
-  fail_unless(res == FALSE, "Failed to handle null path");
+  ck_assert_msg(res == FALSE, "Failed to handle null path");
 
   path = "/";
   res = file_exists2(p, path);
-  fail_unless(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
+  ck_assert_msg(res == FALSE, "Expected FALSE for path '%s', got TRUE", path);
 
   path = "./api-tests";
   res = file_exists2(p, path);
-  fail_unless(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
+  ck_assert_msg(res == TRUE, "Expected TRUE for path '%s', got FALSE", path);
 }
 END_TEST
 
@@ -1099,8 +1099,8 @@ START_TEST (gmtime_test) {
 
   mark_point();
   res = pr_gmtime(NULL, NULL); 
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   time(&now);
@@ -1108,17 +1108,17 @@ START_TEST (gmtime_test) {
   mark_point();
   res = pr_gmtime(NULL, &now);
 #if defined(HAVE_GMTIME_R)
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 #else
-  fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
+  ck_assert_msg(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
 #endif /* HAVE_GMTIME_R */
 
   mark_point();
   res = pr_gmtime(p, &now);
-  fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
+  ck_assert_msg(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
 }
 END_TEST
@@ -1129,8 +1129,8 @@ START_TEST (localtime_test) {
 
   mark_point();
   res = pr_localtime(NULL, NULL); 
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   time(&now);
@@ -1138,17 +1138,17 @@ START_TEST (localtime_test) {
   mark_point();
   res = pr_localtime(NULL, &now);
 #if defined(HAVE_LOCALTIME_R)
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 #else
-  fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
+  ck_assert_msg(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
 #endif /* HAVE_LOCALTIME_R */
 
   mark_point();
   res = pr_localtime(p, &now);
-  fail_unless(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
+  ck_assert_msg(res != NULL, "Failed to handle %lu: %s", (unsigned long) now,
     strerror(errno));
 }
 END_TEST
@@ -1161,11 +1161,11 @@ START_TEST (strtime_test) {
   now = 0;
   res = pr_strtime(now);
 #if defined(HAVE_LOCALTIME_R)
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 #else
-  fail_unless(res != NULL, "Failed to convert time %lu: %s",
+  ck_assert_msg(res != NULL, "Failed to convert time %lu: %s",
     (unsigned long) now, strerror(errno));
 #endif /* HAVE_LOCALTIME_R */
 }
@@ -1181,13 +1181,13 @@ START_TEST (strtime2_test) {
   expected = "Thu Jan 01 00:00:00 1970";
   res = pr_strtime2(now, TRUE);
 #if defined(HAVE_GMTIME_R)
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 #else
-  fail_unless(res != NULL, "Failed to convert time %lu: %s",
+  ck_assert_msg(res != NULL, "Failed to convert time %lu: %s",
     (unsigned long) now, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 #endif /* HAVE_GMTIME_R */
 }
@@ -1202,17 +1202,17 @@ START_TEST (strtime3_test) {
   now = 0;
 #if defined(HAVE_GMTIME_R)
   res = pr_strtime3(NULL, now, TRUE);
-  fail_unless(res == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%s), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%s), got %s (%d)",
     strerror(EINVAL), strerror(errno), errno);
 #endif /* HAVE_GMTIME_R */
 
   mark_point();
   expected = "Thu Jan 01 00:00:00 1970";
   res = pr_strtime3(p, now, TRUE);
-  fail_unless(res != NULL, "Failed to convert time %lu: %s",
+  ck_assert_msg(res != NULL, "Failed to convert time %lu: %s",
     (unsigned long) now, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST
@@ -1223,20 +1223,20 @@ START_TEST (timeval2millis_test) {
   uint64_t ms;
 
   res = pr_timeval2millis(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_timeval2millis(&tv, NULL);
-  fail_unless(res < 0, "Failed to handle null millis argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null millis argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   tv.tv_sec = tv.tv_usec = 0;
   res = pr_timeval2millis(&tv, &ms);
-  fail_unless(res == 0, "Failed to convert timeval to millis: %s",
+  ck_assert_msg(res == 0, "Failed to convert timeval to millis: %s",
     strerror(errno));
-  fail_unless(ms == 0, "Expected 0 ms, got %lu", (unsigned long) ms);
+  ck_assert_msg(ms == 0, "Expected 0 ms, got %lu", (unsigned long) ms);
 }
 END_TEST
 
@@ -1245,14 +1245,14 @@ START_TEST (gettimeofday_millis_test) {
   uint64_t ms;
 
   res = pr_gettimeofday_millis(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ms = 0;
   res = pr_gettimeofday_millis(&ms);
-  fail_unless(res == 0, "Failed to get current time ms: %s", strerror(errno));
-  fail_unless(ms > 0, "Expected >0, got %lu", (unsigned long) ms);
+  ck_assert_msg(res == 0, "Failed to get current time ms: %s", strerror(errno));
+  ck_assert_msg(ms > 0, "Expected >0, got %lu", (unsigned long) ms);
 }
 END_TEST
 
@@ -1262,29 +1262,29 @@ START_TEST (snprintf_test) {
   int res, expected;
 
   res = pr_snprintf(NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   bufsz = 1;
   buf = palloc(p, bufsz);
 
   res = pr_snprintf(buf, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_snprintf(buf, 0, "%d", 0);
-  fail_unless(res == 0, "Failed to handle zero-length buffer");
+  ck_assert_msg(res == 0, "Failed to handle zero-length buffer");
 
   res = pr_snprintf(buf, bufsz, "%d", 0);
-  fail_unless(res < 0, "Failed to handle too-small buffer");
-  fail_unless(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
+  ck_assert_msg(res < 0, "Failed to handle too-small buffer");
+  ck_assert_msg(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
     strerror(errno), errno);
 
   res = pr_snprintf(buf, bufsz, "%s", "foobar");
-  fail_unless(res < 0, "Failed to handle too-small buffer");
-  fail_unless(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
+  ck_assert_msg(res < 0, "Failed to handle too-small buffer");
+  ck_assert_msg(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
     strerror(errno), errno);
 
   bufsz = 32;
@@ -1292,7 +1292,7 @@ START_TEST (snprintf_test) {
 
   expected = 6;
   res = pr_snprintf(buf, bufsz, "%s", "foobar");
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 }
 END_TEST
 
@@ -1302,29 +1302,29 @@ START_TEST (snprintfl_test) {
   int res, expected;
 
   res = pr_snprintfl(NULL, -1, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   bufsz = 1;
   buf = palloc(p, bufsz);
 
   res = pr_snprintfl(NULL, -1, buf, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_snprintfl(__FILE__, __LINE__, buf, 0, "%d", 0);
-  fail_unless(res == 0, "Failed to handle zero-length buffer");
+  ck_assert_msg(res == 0, "Failed to handle zero-length buffer");
 
   res = pr_snprintfl(__FILE__, __LINE__, buf, bufsz, "%d", 0);
-  fail_unless(res < 0, "Failed to handle too-small buffer");
-  fail_unless(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
+  ck_assert_msg(res < 0, "Failed to handle too-small buffer");
+  ck_assert_msg(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
     strerror(errno), errno);
 
   res = pr_snprintfl(__FILE__, __LINE__, buf, bufsz, "%s", "foobar");
-  fail_unless(res < 0, "Failed to handle too-small buffer");
-  fail_unless(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
+  ck_assert_msg(res < 0, "Failed to handle too-small buffer");
+  ck_assert_msg(errno == ENOSPC, "Expected ENOSPC (%d), got %s (%d)", ENOSPC,
     strerror(errno), errno);
 
   bufsz = 32;
@@ -1332,7 +1332,7 @@ START_TEST (snprintfl_test) {
 
   expected = 6;
   res = pr_snprintfl(__FILE__, __LINE__, buf, bufsz, "%s", "foobar");
-  fail_unless(res == expected, "Expected %d, got %d", expected, res);
+  ck_assert_msg(res == expected, "Expected %d, got %d", expected, res);
 }
 END_TEST
 
@@ -1340,27 +1340,27 @@ START_TEST (path_subst_uservar_test) {
   const char *path = NULL, *res, *original, *expected;
 
   res = path_subst_uservar(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = path_subst_uservar(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path pointer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path pointer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = path_subst_uservar(p, &path);
-  fail_unless(res == NULL, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   original = expected = "somepathhere";
   path = pstrdup(p, expected);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   session.user = "user";
@@ -1369,9 +1369,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   session.user = "user";
@@ -1380,9 +1380,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   session.user = "user";
@@ -1391,9 +1391,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   session.user = "user";
@@ -1402,9 +1402,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Attempt to use an invalid index */
@@ -1414,9 +1414,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Attempt to use an out-of-bounds index */
@@ -1426,9 +1426,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   /* Attempt to use an out-of-bounds index */
@@ -1438,9 +1438,9 @@ START_TEST (path_subst_uservar_test) {
   path = pstrdup(p, original);
   mark_point();
   res = path_subst_uservar(p, &path);
-  fail_unless(res != NULL, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res != NULL, "Failed to handle path '%s': %s", path,
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST

--- a/tests/api/misc.c
+++ b/tests/api/misc.c
@@ -149,7 +149,7 @@ START_TEST (get_name_max_test) {
 
   path = "/";
   res = get_name_max(path, -1);
-  fail_if(res < 0, "Failed to handle path '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to handle path '%s': %s", path, strerror(errno));
 
   fd = 1;
   res = get_name_max(NULL, fd);
@@ -320,7 +320,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -337,7 +337,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -356,7 +356,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -376,7 +376,7 @@ START_TEST (dir_readlink_test) {
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -398,7 +398,7 @@ START_TEST (dir_readlink_test) {
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -408,7 +408,7 @@ START_TEST (dir_readlink_test) {
   flags = 0;
   memset(buf, '\0', bufsz);
   res = dir_readlink(p, path, buf, 2, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg(res == 2, "Expected length 2, got %d", res);
   ck_assert_msg(strncmp(buf, dst_path, 2) == 0, "Expected '%*s', got '%*s'",
     2, dst_path, 2, buf);
@@ -417,7 +417,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/";
   memset(buf, '\0', bufsz);
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -435,7 +435,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -452,7 +452,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == dst_pathlen, "Expected length %lu, got %d",
     (unsigned long) dst_pathlen, res);
   ck_assert_msg(strcmp(buf, dst_path) == 0, "Expected '%s', got '%s'",
@@ -471,7 +471,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -490,7 +490,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -509,7 +509,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -528,7 +528,7 @@ START_TEST (dir_readlink_test) {
     strerror(errno));
 
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -549,7 +549,7 @@ START_TEST (dir_readlink_test) {
   /* First, tell dir_readlink() to ignore relative destination paths. */
   flags = 0;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -571,7 +571,7 @@ START_TEST (dir_readlink_test) {
 
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -594,7 +594,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/tmp";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen, "Expected length %lu, got %d",
     (unsigned long) expected_pathlen, res);
   ck_assert_msg(strcmp(buf, expected_path) == 0, "Expected '%s', got '%s'",
@@ -615,7 +615,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/tmp";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
@@ -639,7 +639,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
@@ -666,7 +666,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);
@@ -693,7 +693,7 @@ START_TEST (dir_readlink_test) {
   session.chroot_path = "/tmp/foo/bar";
   flags = PR_DIR_READLINK_FL_HANDLE_REL_PATH;
   res = dir_readlink(p, path, buf, bufsz, flags);
-  fail_if(res < 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to read '%s' symlink: %s", path, strerror(errno));
   ck_assert_msg((size_t) res == expected_pathlen,
     "Expected length %lu, got %d (%s)", (unsigned long) expected_pathlen, res,
     buf);

--- a/tests/api/modules.c
+++ b/tests/api/modules.c
@@ -66,23 +66,23 @@ START_TEST (module_sess_init_test) {
   module m;
 
   res = modules_session_init();
-  fail_unless(res == 0, "Failed to initialize modules: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to initialize modules: %s", strerror(errno));
 
   memset(&m, 0, sizeof(m));
   m.name = "testsuite";
 
   loaded_modules = &m;
   res = modules_session_init();
-  fail_unless(res == 0, "Failed to initialize modules: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to initialize modules: %s", strerror(errno));
 
   m.sess_init = module_sess_init_cb;
   res = modules_session_init();
-  fail_unless(res == 0, "Failed to initialize modules: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to initialize modules: %s", strerror(errno));
 
   sess_init_eperm = TRUE;
   res = modules_session_init();
-  fail_unless(res < 0, "Initialized modules unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Initialized modules unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   loaded_modules = NULL;
@@ -93,7 +93,7 @@ START_TEST (module_command_exists_test) {
   int res;
 
   res = command_exists(NULL);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 }
 END_TEST
 
@@ -102,13 +102,13 @@ START_TEST (module_exists_test) {
   module m;
 
   res = pr_module_exists(NULL);
-  fail_unless(res == FALSE, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == FALSE, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_module_exists("mod_foo.c");
-  fail_unless(res == FALSE, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -117,16 +117,16 @@ START_TEST (module_exists_test) {
   loaded_modules = &m;
 
   res = pr_module_exists("mod_foo.c");
-  fail_unless(res == FALSE, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_module_exists("mod_bar.c");
-  fail_unless(res == TRUE, "Failed to detect existing module");
+  ck_assert_msg(res == TRUE, "Failed to detect existing module");
 
   res = pr_module_exists("mod_BAR.c");
-  fail_unless(res == FALSE, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   loaded_modules = NULL;
@@ -137,13 +137,13 @@ START_TEST (module_get_test) {
   module m, *res;
 
   res = pr_module_get(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_module_get("mod_foo.c");
-  fail_unless(res == NULL, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
@@ -152,17 +152,17 @@ START_TEST (module_get_test) {
   loaded_modules = &m;
 
   res = pr_module_get("mod_foo.c");
-  fail_unless(res == NULL, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_module_get("mod_bar.c");
-  fail_unless(res != NULL, "Failed to detect existing module");
-  fail_unless(res == &m, "Expected %p, got %p", &m, res);
+  ck_assert_msg(res != NULL, "Failed to detect existing module");
+  ck_assert_msg(res == &m, "Expected %p, got %p", &m, res);
 
   res = pr_module_get("mod_BAR.c");
-  fail_unless(res == NULL, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   loaded_modules = NULL;
@@ -181,7 +181,7 @@ START_TEST (module_list_test) {
   mark_point();
   listed = 0;
   modules_list2(module_listf, 0);
-  fail_unless(listed > 0, "Expected >0, got %u", listed);
+  ck_assert_msg(listed > 0, "Expected >0, got %u", listed);
 
   memset(&m, 0, sizeof(m));
   m.name = "testsuite";
@@ -196,12 +196,12 @@ START_TEST (module_list_test) {
   mark_point();
   listed = 0;
   modules_list2(module_listf, PR_MODULES_LIST_FL_SHOW_STATIC);
-  fail_unless(listed > 0, "Expected >0, got %u", listed);
+  ck_assert_msg(listed > 0, "Expected >0, got %u", listed);
 
   mark_point();
   listed = 0;
   modules_list2(module_listf, PR_MODULES_LIST_FL_SHOW_VERSION);
-  fail_unless(listed > 0, "Expected >0, got %u", listed);
+  ck_assert_msg(listed > 0, "Expected >0, got %u", listed);
 
   mark_point();
   modules_list(PR_MODULES_LIST_FL_SHOW_STATIC);
@@ -220,40 +220,40 @@ START_TEST (module_load_test) {
   module m;
 
   res = pr_module_load(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_load(&m);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   m.name = "foo";
 
   res = pr_module_load(&m);
-  fail_unless(res < 0, "Failed to handle badly versioned module");
-  fail_unless(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
+  ck_assert_msg(res < 0, "Failed to handle badly versioned module");
+  ck_assert_msg(errno == EACCES, "Expected EACCES (%d), got %s (%d)", EACCES,
     strerror(errno), errno);
 
   m.api_version = PR_MODULE_API_VERSION;
   m.init = init_cb;
 
   res = pr_module_load(&m);
-  fail_unless(res < 0, "Failed to handle bad module init callback");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle bad module init callback");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   m.init = NULL;
 
   res = pr_module_load(&m);
-  fail_unless(res == 0, "Failed to load module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module: %s", strerror(errno));
 
   res = pr_module_load(&m);
-  fail_unless(res < 0, "Failed to handle duplicate module load");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle duplicate module load");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 }
 END_TEST
@@ -276,32 +276,32 @@ START_TEST (module_unload_test) {
   };
 
   res = pr_module_unload(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_unload(&m);
-  fail_unless(res < 0, "Failed to handle null module name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   m.name = "bar";
 
   res = pr_module_unload(&m);
-  fail_unless(res < 0, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   loaded_modules = &m;
 
   res = pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 
   res = pr_module_unload(&m);
-  fail_unless(res < 0, "Failed to handle nonexistent module");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent module");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   m.authtable = authtab;
@@ -310,7 +310,7 @@ START_TEST (module_unload_test) {
   loaded_modules = &m;
 
   res = pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 
   loaded_modules = NULL;
 }
@@ -325,30 +325,30 @@ START_TEST (module_load_authtab_test) {
   };
 
   res = pr_module_load_authtab(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_load_authtab(&m);
-  fail_unless(res < 0, "Failed to handle null module name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   m.name = "testsuite";
   res = pr_module_load_authtab(&m);
-  fail_unless(res == 0, "Failed to load module authtab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module authtab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 
   m.authtable = authtab;
   res = pr_module_load_authtab(&m);
-  fail_unless(res == 0, "Failed to load module authtab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module authtab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 }
 END_TEST
 
@@ -362,31 +362,31 @@ START_TEST (module_load_cmdtab_test) {
   };
 
   res = pr_module_load_cmdtab(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_load_cmdtab(&m);
-  fail_unless(res < 0, "Failed to handle null module name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   m.name = "testsuite";
   res = pr_module_load_cmdtab(&m);
-  fail_unless(res == 0, "Failed to load module cmdtab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module cmdtab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 
   m.name = "testsuite";
   m.cmdtable = cmdtab;
   res = pr_module_load_cmdtab(&m);
-  fail_unless(res == 0, "Failed to load module cmdtab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module cmdtab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 }
 END_TEST
 
@@ -399,30 +399,30 @@ START_TEST (module_load_conftab_test) {
   };
 
   res = pr_module_load_conftab(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_load_conftab(&m);
-  fail_unless(res < 0, "Failed to handle null module name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   m.name = "testsuite";
   res = pr_module_load_conftab(&m);
-  fail_unless(res == 0, "Failed to load module conftab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module conftab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 
   m.conftable = conftab;
   res = pr_module_load_conftab(&m);
-  fail_unless(res == 0, "Failed to load module conftab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module conftab: %s", strerror(errno));
 
   pr_module_unload(&m);
-  fail_unless(res == 0, "Failed to unload module: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unload module: %s", strerror(errno));
 }
 END_TEST
 
@@ -436,48 +436,48 @@ START_TEST (module_call_test) {
   cmd_rec *cmd;
 
   res = pr_module_call(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   memset(&m, 0, sizeof(m));
 
   res = pr_module_call(&m, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null callback, cmd arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null callback, cmd arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_module_call(NULL, call_cb, NULL);
-  fail_unless(res == NULL, "Failed to handle null module, cmd arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null module, cmd arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   cmd = pcalloc(p, sizeof(cmd_rec));
   cmd->pool = p;
 
   res = pr_module_call(NULL, NULL, cmd);
-  fail_unless(res == NULL, "Failed to handle null module, callback arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null module, callback arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_module_call(&m, call_cb, NULL);
-  fail_unless(res == NULL, "Failed to handle null cmd argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null cmd argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_module_call(&m, NULL, cmd);
-  fail_unless(res == NULL, "Failed to handle null callback argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null callback argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_module_call(NULL, call_cb, cmd);
-  fail_unless(res == NULL, "Failed to handle null module argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == NULL, "Failed to handle null module argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_module_call(&m, call_cb, cmd);
-  fail_unless(res != NULL, "Failed to call function: %s", strerror(errno));
-  fail_unless(MODRET_ISHANDLED(res), "Expected HANDLED result");
+  ck_assert_msg(res != NULL, "Failed to call function: %s", strerror(errno));
+  ck_assert_msg(MODRET_ISHANDLED(res), "Expected HANDLED result");
 }
 END_TEST
 
@@ -487,29 +487,29 @@ START_TEST (module_create_ret_test) {
   char *numeric, *msg;
 
   mr = mod_create_ret(NULL, 0, NULL, NULL);
-  fail_unless(mr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(mr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "testsuite");
   mr = mod_create_ret(cmd, 1, NULL, NULL);
-  fail_unless(mr != NULL, "Failed to create modret: %s", strerror(errno));
-  fail_unless(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
-  fail_unless(mr->mr_numeric == NULL, "Expected null, got '%s'",
+  ck_assert_msg(mr != NULL, "Failed to create modret: %s", strerror(errno));
+  ck_assert_msg(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
+  ck_assert_msg(mr->mr_numeric == NULL, "Expected null, got '%s'",
     mr->mr_numeric);
-  fail_unless(mr->mr_message == NULL, "Expected null, got '%s'",
+  ck_assert_msg(mr->mr_message == NULL, "Expected null, got '%s'",
     mr->mr_message);
 
   numeric = "foo";
   msg = "bar";
   mr = mod_create_ret(cmd, 1, numeric, msg);
-  fail_unless(mr != NULL, "Failed to create modret: %s", strerror(errno));
-  fail_unless(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
-  fail_unless(mr->mr_numeric != NULL, "Expected '%s', got null");
-  fail_unless(strcmp(mr->mr_numeric, numeric) == 0,
+  ck_assert_msg(mr != NULL, "Failed to create modret: %s", strerror(errno));
+  ck_assert_msg(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
+  ck_assert_msg(mr->mr_numeric != NULL, "Expected '%s', got null");
+  ck_assert_msg(strcmp(mr->mr_numeric, numeric) == 0,
     "Expected '%s', got '%s'", numeric, mr->mr_numeric);
-  fail_unless(mr->mr_message != NULL, "Expected '%s', got null");
-  fail_unless(strcmp(mr->mr_message, msg) == 0,
+  ck_assert_msg(mr->mr_message != NULL, "Expected '%s', got null");
+  ck_assert_msg(strcmp(mr->mr_message, msg) == 0,
     "Expected '%s', got '%s'", msg, mr->mr_message);
 }
 END_TEST
@@ -519,14 +519,14 @@ START_TEST (module_create_error_test) {
   modret_t *mr;
 
   mr = mod_create_error(NULL, 0);
-  fail_unless(mr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(mr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "testsuite");
   mr = mod_create_error(cmd, 1);
-  fail_unless(mr != NULL, "Failed to create modret: %s", strerror(errno));
-  fail_unless(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
+  ck_assert_msg(mr != NULL, "Failed to create modret: %s", strerror(errno));
+  ck_assert_msg(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
 }
 END_TEST
 
@@ -536,14 +536,14 @@ START_TEST (module_create_data_test) {
   int data = 1;
 
   mr = mod_create_data(NULL, NULL);
-  fail_unless(mr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(mr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "testsuite");
   mr = mod_create_data(cmd, &data);
-  fail_unless(mr != NULL, "Failed to create modret: %s", strerror(errno));
-  fail_unless(mr->data == &data, "Expected %p, got %p", &data, mr->data);
+  ck_assert_msg(mr != NULL, "Failed to create modret: %s", strerror(errno));
+  ck_assert_msg(mr->data == &data, "Expected %p, got %p", &data, mr->data);
 }
 END_TEST
 

--- a/tests/api/modules.c
+++ b/tests/api/modules.c
@@ -505,10 +505,10 @@ START_TEST (module_create_ret_test) {
   mr = mod_create_ret(cmd, 1, numeric, msg);
   ck_assert_msg(mr != NULL, "Failed to create modret: %s", strerror(errno));
   ck_assert_msg(mr->mr_error == 1, "Expected 1, got %d", mr->mr_error);
-  ck_assert_msg(mr->mr_numeric != NULL, "Expected '%s', got null");
+  ck_assert_msg(mr->mr_numeric != NULL, "Expected '%s', got null", numeric);
   ck_assert_msg(strcmp(mr->mr_numeric, numeric) == 0,
     "Expected '%s', got '%s'", numeric, mr->mr_numeric);
-  ck_assert_msg(mr->mr_message != NULL, "Expected '%s', got null");
+  ck_assert_msg(mr->mr_message != NULL, "Expected '%s', got null", msg);
   ck_assert_msg(strcmp(mr->mr_message, msg) == 0,
     "Expected '%s', got '%s'", msg, mr->mr_message);
 }

--- a/tests/api/netacl.c
+++ b/tests/api/netacl.c
@@ -63,223 +63,223 @@ START_TEST (netacl_create_test) {
   char *acl_str;
 
   res = pr_netacl_create(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_create(NULL, "");
-  fail_unless(res == NULL, "Failed to handle NULL pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_create(p, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL ACL string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL ACL string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_create(p, "");
-  fail_unless(res == NULL, "Failed to handle empty ACL string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle empty ACL string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl_str = "ALL";
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s'", acl_str);
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s'", acl_str);
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_ALL,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_ALL,
     "Failed to have ALL type for ACL string '%s'", acl_str);
 
   acl_str = "none";
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s'", acl_str);
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s'", acl_str);
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_NONE,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_NONE,
     "Failed to have NONE type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "localhost/24");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s",
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s",
     acl_str, strerror(errno));
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl_str = pstrdup(p, "127.0.0.1/24");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMASK,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMASK,
     "Failed to have IPMASK type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "127.0.0.1/36");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "0.0.0.0/0");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
 #ifdef PR_USE_IPV6
   acl_str = pstrdup(p, "::1/36");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMASK,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMASK,
     "Failed to have IPMASK type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "::ffff:127.0.0.1/111");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMASK,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMASK,
     "Failed to have IPMASK type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "::1/136");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "::ffff:127.0.0.1/136");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "::1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMATCH,
     "Failed to have IPMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "!::1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMATCH,
     "Failed to have IPMATCH type for ACL string '%s'", acl_str);
 #endif
 
   acl_str = pstrdup(p, "127.0.0.1/0");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMASK,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMASK,
     "Failed to have IPMASK type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "127.0.0.1/-1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.1.2/24");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.1/25f");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPGLOB,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPGLOB,
     "Failed to have IPGLOB type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "127.0.0.1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMATCH,
     "Failed to have IPMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "!127.0.0.1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPMATCH,
     "Failed to have IPMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "127.0.0.1.1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, ".0.0.1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
+  ck_assert_msg(res == NULL, "Failed to handle bad ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_str = pstrdup(p, "*.0.0.1");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_IPGLOB,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_IPGLOB,
     "Failed to have IPGLOB type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, ".edu");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_DNSGLOB,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_DNSGLOB,
     "Failed to have DNSGLOB type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "localhost");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_DNSMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_DNSMATCH,
     "Failed to have DNSMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "foobar");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_DNSMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_DNSMATCH,
     "Failed to have DNSMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "!foobar");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_DNSMATCH,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_DNSMATCH,
     "Failed to have DNSMATCH type for ACL string '%s'", acl_str);
 
   acl_str = pstrdup(p, "!fo?bar");
   res = pr_netacl_create(p, acl_str);
-  fail_unless(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(res != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   acl_type = pr_netacl_get_type(res);
-  fail_unless(acl_type == PR_NETACL_TYPE_DNSGLOB,
+  ck_assert_msg(acl_type == PR_NETACL_TYPE_DNSGLOB,
     "Failed to have DNSGLOB type for ACL string '%s'", acl_str);
 }
 END_TEST
@@ -290,151 +290,151 @@ START_TEST (netacl_get_str_test) {
   const char *res;
 
   res = pr_netacl_get_str(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_get_str(p, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL ACL");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL ACL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl_str = "all";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_str(NULL, acl);
-  fail_unless(res == NULL, "Failed to handle NULL pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   ok = "all <all>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = "AlL";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = "None";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
  
   ok = "none <none>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1 <IP address match>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "!127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "!127.0.0.1 <IP address match, inverted>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.* <IP address glob>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "localhost");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "localhost <DNS hostname match>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, ".castaglia.org");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "*.castaglia.org <DNS hostname glob>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1/24 <IP address mask, 24-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1/0");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1/0 <IP address mask, 0-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "0.0.0.0/0");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "0.0.0.0/0 <IP address mask, 0-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "!127.0.0.1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "!127.0.0.1/24 <IP address mask, 24-bit mask, inverted>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
 #ifdef PR_USE_IPV6
   acl_str = pstrdup(p, "::1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::1/24 <IP address mask, 24-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "::1/127");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::1/127 <IP address mask, 127-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "::ffff:127.0.0.1/127");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::ffff:127.0.0.1/127 <IP address mask, 127-bit mask>";
   res = pr_netacl_get_str(p, acl);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 #endif
 }
 END_TEST
@@ -446,151 +446,151 @@ START_TEST (netacl_get_str2_test) {
   int flags = PR_NETACL_FL_STR_NO_DESC;
 
   res = pr_netacl_get_str2(NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_get_str2(p, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle NULL ACL");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL ACL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl_str = "all";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_str2(NULL, acl, flags);
-  fail_unless(res == NULL, "Failed to handle NULL pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   ok = "all";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = "AlL";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = "None";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "none";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "!127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "!127.0.0.1";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.*";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "localhost");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "localhost";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, ".castaglia.org");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "*.castaglia.org";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1/24";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "127.0.0.1/0");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "127.0.0.1/0";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "0.0.0.0/0");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "0.0.0.0/0";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "!127.0.0.1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "!127.0.0.1/24";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
 #ifdef PR_USE_IPV6
   acl_str = pstrdup(p, "::1/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::1/24";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "::1/127");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::1/127";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   acl_str = pstrdup(p, "::ffff:127.0.0.1/127");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   ok = "::ffff:127.0.0.1/127";
   res = pr_netacl_get_str2(p, acl, flags);
-  fail_unless(res != NULL, "Failed to get ACL string: %s", strerror(errno));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(res != NULL, "Failed to get ACL string: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 #endif
 }
 END_TEST
@@ -599,23 +599,23 @@ START_TEST (netacl_dup_test) {
   pr_netacl_t *acl, *res;
 
   res = pr_netacl_dup(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_dup(p, NULL);
-  fail_unless(res == NULL, "Failed to handle NULL ACL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL ACL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl = pr_netacl_create(p, "ALL");
-  fail_unless(acl != NULL, "Failed to create ALL ACL");
+  ck_assert_msg(acl != NULL, "Failed to create ALL ACL");
 
   res = pr_netacl_dup(NULL, acl);
-  fail_unless(res == NULL, "Failed to handle NULL pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle NULL pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_dup(p, acl);
-  fail_unless(res != NULL, "Failed to dup ACL: %s", strerror(errno));
-  fail_unless(strcmp(pr_netacl_get_str(p, res), pr_netacl_get_str(p, acl)) == 0,
+  ck_assert_msg(res != NULL, "Failed to dup ACL: %s", strerror(errno));
+  ck_assert_msg(strcmp(pr_netacl_get_str(p, res), pr_netacl_get_str(p, acl)) == 0,
     "Expected '%s', got '%s'", pr_netacl_get_str(p, acl),
     pr_netacl_get_str(p, res));
 }
@@ -628,20 +628,20 @@ START_TEST (netacl_match_test) {
   int have_localdomain = FALSE, res, reverse_dns;
 
   res = pr_netacl_match(NULL, NULL);
-  fail_unless(res == -2, "Failed to handle NULL arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -2, "Failed to handle NULL arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl_str = "all";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, NULL);
-  fail_unless(res == -2, "Failed to handle NULL addr");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -2, "Failed to handle NULL addr");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, "localhost", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", "localhost",
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", "localhost",
     strerror(errno));
 
   if (getenv("CI") == NULL &&
@@ -656,109 +656,109 @@ START_TEST (netacl_match_test) {
   }
 
   res = pr_netacl_match(NULL, addr);
-  fail_unless(res == -2, "Failed to handle NULL ACL");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -2, "Failed to handle NULL ACL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = "none";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+  ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "!127.0.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+  ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "192.168.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 0, "Failed to match ACL to addr: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to match ACL to addr: %s", strerror(errno));
 
   acl_str = pstrdup(p, "!192.168.0.1");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.0/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "!127.0.0.0/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+  ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "!1.2.3.4/24");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "127.0.0.");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "!127.0.0.");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+  ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
     strerror(errno));
 
   acl_str = pstrdup(p, "!1.2.3.");
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   if (!have_localdomain) {
@@ -769,13 +769,13 @@ START_TEST (netacl_match_test) {
   }
 
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
-    fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+    ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
       strerror(errno));
   }
 
@@ -787,23 +787,23 @@ START_TEST (netacl_match_test) {
   }
 
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
-    fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+    ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
       strerror(errno));
   }
 
   acl_str = "!www.google.com";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   if (!have_localdomain) {
@@ -814,13 +814,13 @@ START_TEST (netacl_match_test) {
   }
 
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
-    fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+    ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
       strerror(errno));
   }
 
@@ -832,30 +832,30 @@ START_TEST (netacl_match_test) {
   }
 
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
-    fail_unless(res == -1, "Failed to negatively match ACL to addr: %s",
+    ck_assert_msg(res == -1, "Failed to negatively match ACL to addr: %s",
       strerror(errno));
   }
 
   acl_str = "!www.g*g.com";
   acl = pr_netacl_create(p, acl_str);
-  fail_unless(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
+  ck_assert_msg(acl != NULL, "Failed to handle ACL string '%s': %s", acl_str,
     strerror(errno));
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 1, "Failed to positively match ACL to addr: %s",
+  ck_assert_msg(res == 1, "Failed to positively match ACL to addr: %s",
     strerror(errno));
 
   reverse_dns = ServerUseReverseDNS;
   ServerUseReverseDNS = FALSE;
 
   res = pr_netacl_match(acl, addr);
-  fail_unless(res == 0, "Matched DNS glob ACL to addr unexpectedly");
+  ck_assert_msg(res == 0, "Matched DNS glob ACL to addr unexpectedly");
 
   ServerUseReverseDNS = reverse_dns;
 }
@@ -866,20 +866,20 @@ START_TEST (netacl_get_negated_test) {
   int res;
 
   res = pr_netacl_get_negated(NULL);
-  fail_unless(res == -1, "Failed to handle NULL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle NULL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   acl = pr_netacl_create(p, "127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_negated(acl);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   acl = pr_netacl_create(p, "!127.0.0.1");
-  fail_unless(acl != NULL, "Failed to create ACL: %s", strerror(errno));
+  ck_assert_msg(acl != NULL, "Failed to create ACL: %s", strerror(errno));
 
   res = pr_netacl_get_negated(acl);
-  fail_unless(res == 1, "Expected %d, got %d", 1, res);
+  ck_assert_msg(res == 1, "Expected %d, got %d", 1, res);
 }
 END_TEST
 

--- a/tests/api/netaddr.c
+++ b/tests/api/netaddr.c
@@ -249,7 +249,7 @@ START_TEST (netaddr_get_addr2_test) {
   name = "127.0.0.1";
   res = pr_netaddr_get_addr2(p, name, NULL, flags);
   ck_assert_msg(res != NULL, "Failed to resolve name '%s' to IP address: %s",
-    strerror(errno));
+    name, strerror(errno));
 }
 END_TEST
 
@@ -482,7 +482,7 @@ START_TEST (netaddr_get_sockaddr_test) {
 
   pr_netaddr_disable_ipv6();
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
+  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr: %s", strerror(errno));
   ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
@@ -490,7 +490,7 @@ START_TEST (netaddr_get_sockaddr_test) {
   family = addr->na_family;
   addr->na_family = 777;
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
+  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr: %s", strerror(errno));
   ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   addr->na_family = family;

--- a/tests/api/netaddr.c
+++ b/tests/api/netaddr.c
@@ -234,7 +234,7 @@ START_TEST (netaddr_get_addr2_test) {
     res = pr_netaddr_get_addr2(p, name, NULL, flags);
   }
 
-  fail_if(res == NULL,
+  ck_assert_msg(res != NULL,
     "Expected to resolve name '%s' to an address via INCL_DEVICE", name);
 
   flags = PR_NETADDR_GET_ADDR_FL_EXCL_DNS;
@@ -248,7 +248,7 @@ START_TEST (netaddr_get_addr2_test) {
   flags = PR_NETADDR_GET_ADDR_FL_EXCL_CACHE;
   name = "127.0.0.1";
   res = pr_netaddr_get_addr2(p, name, NULL, flags);
-  fail_if(res == NULL, "Failed to resolve name '%s' to IP address: %s",
+  ck_assert_msg(res != NULL, "Failed to resolve name '%s' to IP address: %s",
     strerror(errno));
 }
 END_TEST

--- a/tests/api/netaddr.c
+++ b/tests/api/netaddr.c
@@ -59,12 +59,12 @@ START_TEST (netaddr_alloc_test) {
   pr_netaddr_t *res;
 
   res = pr_netaddr_alloc(NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netaddr_alloc(p);
-  fail_unless(res != NULL, "Failed to allocate netaddr: %s", strerror(errno));
-  fail_unless(res->na_family == 0, "Allocated netaddr is not zeroed");
+  ck_assert_msg(res != NULL, "Failed to allocate netaddr: %s", strerror(errno));
+  ck_assert_msg(res->na_family == 0, "Allocated netaddr is not zeroed");
 }
 END_TEST
 
@@ -73,12 +73,12 @@ START_TEST (netaddr_dup_test) {
   int port;
 
   res = pr_netaddr_dup(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netaddr_dup(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_alloc(p);
   pr_netaddr_set_family(addr, AF_INET);
@@ -87,14 +87,14 @@ START_TEST (netaddr_dup_test) {
   pr_netaddr_set_port2(addr, port);
   
   res = pr_netaddr_dup(NULL, addr);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netaddr_dup(p, addr);
-  fail_unless(res != NULL, "Failed to dup netaddr: %s", strerror(errno));
-  fail_unless(res->na_family == addr->na_family, "Expected family %d, got %d",
+  ck_assert_msg(res != NULL, "Failed to dup netaddr: %s", strerror(errno));
+  ck_assert_msg(res->na_family == addr->na_family, "Expected family %d, got %d",
     addr->na_family, res->na_family);
-  fail_unless(ntohs(pr_netaddr_get_port(res)) == port,
+  ck_assert_msg(ntohs(pr_netaddr_get_port(res)) == port,
     "Expected port %d, got %d", port, ntohs(pr_netaddr_get_port(res)));
 }
 END_TEST
@@ -109,7 +109,7 @@ START_TEST (netaddr_clear_test) {
   addr->na_family = 1;
 
   pr_netaddr_clear(addr);
-  fail_unless(addr->na_family == 0, "Failed to clear addr");
+  ck_assert_msg(addr->na_family == 0, "Failed to clear addr");
 }
 END_TEST
 
@@ -119,38 +119,38 @@ START_TEST (netaddr_get_addr_test) {
   array_header *addrs = NULL;
 
   res = pr_netaddr_get_addr(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netaddr_get_addr(p, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "134.289.999.0";
 
   res = pr_netaddr_get_addr(NULL, name, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res == NULL, "Unexpected got address for '%s'", name);
-  fail_unless(errno == ENOENT || errno == EAGAIN,
+  ck_assert_msg(res == NULL, "Unexpected got address for '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == EAGAIN,
     "Expected ENOENT (%d) or EAGAIN (%d), got %s (%d)", ENOENT, EAGAIN,
     strerror(errno), errno);
 
   name = "localhost";
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
 
   res = pr_netaddr_get_addr(p, name, &addrs);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
 
 #if defined(PR_USE_NETWORK_TESTS)
@@ -158,40 +158,40 @@ START_TEST (netaddr_get_addr_test) {
   name = "www.google.com";
 
   res = pr_netaddr_get_addr(p, name, &addrs);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
-  fail_unless(addrs != NULL, "Expected additional addresses for '%s'", name);
+  ck_assert_msg(addrs != NULL, "Expected additional addresses for '%s'", name);
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
 #endif
 
   name = "127.0.0.1";
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
 
   res = pr_netaddr_get_addr(p, name, &addrs);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET, "Expected family %d, got %d",
     AF_INET, res->na_family);
-  fail_unless(addrs == NULL, "Expected no additional addresses for '%s'", name);
+  ck_assert_msg(addrs == NULL, "Expected no additional addresses for '%s'", name);
 
   /* Deliberately test an unresolvable name (related to Bug#4104). */
   name = "foo.bar.castaglia.example.com";
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res == NULL, "Resolved '%s' unexpectedly", name);
-  fail_unless(errno == ENOENT || errno == EAGAIN,
+  ck_assert_msg(res == NULL, "Resolved '%s' unexpectedly", name);
+  ck_assert_msg(errno == ENOENT || errno == EAGAIN,
     "Expected ENOENT (%d) or EAGAIN (%d), got %s (%d)", ENOENT, EAGAIN,
     strerror(errno), errno);
 
@@ -199,17 +199,17 @@ START_TEST (netaddr_get_addr_test) {
   name = "::1";
 
   res = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET6, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET6, "Expected family %d, got %d",
     AF_INET6, res->na_family);
 
   res = pr_netaddr_get_addr(p, name, &addrs);
-  fail_unless(res != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(res != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
-  fail_unless(res->na_family == AF_INET6, "Expected family %d, got %d",
+  ck_assert_msg(res->na_family == AF_INET6, "Expected family %d, got %d",
     AF_INET6, res->na_family);
-  fail_unless(addrs == NULL, "Expected no additional addresses for '%s'", name);
+  ck_assert_msg(addrs == NULL, "Expected no additional addresses for '%s'", name);
 #endif /* PR_USE_IPV6 */
 }
 END_TEST
@@ -222,8 +222,8 @@ START_TEST (netaddr_get_addr2_test) {
   flags = PR_NETADDR_GET_ADDR_FL_INCL_DEVICE;
   name = "foobarbaz";
   res = pr_netaddr_get_addr2(p, name, NULL, flags);
-  fail_unless(res == NULL, "Failed to handle unknown device '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Failed to handle unknown device '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   name = "lo0";
@@ -240,10 +240,10 @@ START_TEST (netaddr_get_addr2_test) {
   flags = PR_NETADDR_GET_ADDR_FL_EXCL_DNS;
   name = "localhost";
   res = pr_netaddr_get_addr2(p, name, NULL, flags);
-  fail_unless(res == NULL, "Resolved name '%s' to IP address unexpectedly",
+  ck_assert_msg(res == NULL, "Resolved name '%s' to IP address unexpectedly",
     name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %d (%s)", ENOENT,
-    strerror(errno), errno);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %d (%s)", ENOENT,
+    errno, strerror(errno));
 
   flags = PR_NETADDR_GET_ADDR_FL_EXCL_CACHE;
   name = "127.0.0.1";
@@ -258,15 +258,15 @@ START_TEST (netaddr_get_family_test) {
   int res;
 
   res = pr_netaddr_get_family(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, "localhost", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for 'localhost': %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for 'localhost': %s",
     strerror(errno));
 
   res = pr_netaddr_get_family(addr);
-  fail_unless(res == AF_INET, "Expected family %d, got %d", AF_INET,
+  ck_assert_msg(res == AF_INET, "Expected family %d, got %d", AF_INET,
     res);
 }
 END_TEST
@@ -276,23 +276,23 @@ START_TEST (netaddr_set_family_test) {
   int res;
 
   res = pr_netaddr_set_family(NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
     strerror(errno));
 
   res = pr_netaddr_set_family(addr, -1);
-  fail_unless(res == -1, "Failed to handle bad family");
+  ck_assert_msg(res == -1, "Failed to handle bad family");
 #ifdef EAFNOSUPPORT
-  fail_unless(errno == EAFNOSUPPORT, "Failed to set errno to EAFNOSUPPORT");
+  ck_assert_msg(errno == EAFNOSUPPORT, "Failed to set errno to EAFNOSUPPORT");
 #else
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 #endif
 
   res = pr_netaddr_set_family(addr, AF_INET);
-  fail_unless(res == 0, "Failed to set family to AF_INET: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set family to AF_INET: %s", strerror(errno));
 }
 END_TEST
 
@@ -302,40 +302,40 @@ START_TEST (netaddr_cmp_test) {
   const char *name;
 
   res = pr_netaddr_cmp(NULL, NULL);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   name = "127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_cmp(addr, NULL);
-  fail_unless(res == 1, "Expected 1, got %d", res);
+  ck_assert_msg(res == 1, "Expected 1, got %d", res);
 
   res = pr_netaddr_cmp(NULL, addr);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   name = "::1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_cmp(addr, addr2);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   res = pr_netaddr_cmp(addr2, addr);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   name = "::ffff:127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_cmp(addr, addr2);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   res = pr_netaddr_cmp(addr2, addr);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 }
 END_TEST
 
@@ -346,54 +346,54 @@ START_TEST (netaddr_ncmp_test) {
   const char *name;
 
   res = pr_netaddr_ncmp(NULL, NULL, nbits);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   name = "127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_ncmp(addr, NULL, nbits);
-  fail_unless(res == 1, "Expected 1, got %d", res);
+  ck_assert_msg(res == 1, "Expected 1, got %d", res);
 
   res = pr_netaddr_ncmp(NULL, addr, nbits);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   res = pr_netaddr_ncmp(NULL, addr, nbits);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   nbits = 48;
   res = pr_netaddr_ncmp(addr, addr, nbits);
-  fail_unless(res == -1, "Expected -1, got %d", res);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "::1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   nbits = 0;
   res = pr_netaddr_ncmp(addr, addr2, nbits);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   res = pr_netaddr_ncmp(addr2, addr, nbits);
-  fail_unless(res == -1, "Expected -1, got %d", res);
+  ck_assert_msg(res == -1, "Expected -1, got %d", res);
 
   name = "::ffff:127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_ncmp(addr, addr2, nbits);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   res = pr_netaddr_ncmp(addr2, addr, nbits);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 
   nbits = 24;
   res = pr_netaddr_ncmp(addr2, addr, nbits);
-  fail_unless(res == 0, "Expected 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected 0, got %d", res);
 }
 END_TEST
 
@@ -403,49 +403,49 @@ START_TEST (netaddr_fnmatch_test) {
   const char *name;
 
   res = pr_netaddr_fnmatch(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "localhost";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_fnmatch(addr, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pattern");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pattern");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   flags = PR_NETADDR_MATCH_DNS;
   res = pr_netaddr_fnmatch(addr, "foo", flags);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_netaddr_fnmatch(addr, "LOCAL*", flags);
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
     /* This test is sensitive the environment. */
-    fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+    ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
   }
 
   flags = PR_NETADDR_MATCH_IP;
   res = pr_netaddr_fnmatch(addr, "foo", flags);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_netaddr_fnmatch(addr, "127.0*", flags);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
 #ifdef PR_USE_IPV6
   name = "::ffff:127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_fnmatch(addr, "foo", flags);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = pr_netaddr_fnmatch(addr, "127.0.*", flags);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 #endif /* PR_USE_IPV6 */
 }
 END_TEST
@@ -459,39 +459,39 @@ START_TEST (netaddr_get_sockaddr_test) {
 #endif /* PR_USE_IPV6 */
 
   sockaddr = pr_netaddr_get_sockaddr(NULL);
-  fail_unless(sockaddr == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(sockaddr == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  fail_unless(sockaddr != NULL, "Failed to get sock addr: %s", strerror(errno));
+  ck_assert_msg(sockaddr != NULL, "Failed to get sock addr: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  fail_unless(sockaddr != NULL, "Failed to get sock addr: %s", strerror(errno));
+  ck_assert_msg(sockaddr != NULL, "Failed to get sock addr: %s", strerror(errno));
 
   pr_netaddr_disable_ipv6();
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  fail_unless(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_netaddr_enable_ipv6();
   family = addr->na_family;
   addr->na_family = 777;
   sockaddr = pr_netaddr_get_sockaddr(addr);
-  fail_unless(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(sockaddr == NULL, "Got sock addr for IPv6 addr", strerror(errno));
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   addr->na_family = family;
 #endif /* PR_USE_IPV6 */
@@ -507,31 +507,31 @@ START_TEST (netaddr_get_sockaddr_len_test) {
 #endif /* PR_USE_IPV6 */
 
   res = pr_netaddr_get_sockaddr_len(NULL);
-  fail_unless(res == (size_t) -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == (size_t) -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_get_sockaddr_len(addr);
-  fail_unless(res > 0, "Failed to get sockaddr len: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to get sockaddr len: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_get_sockaddr_len(addr);
-  fail_unless(res > 0, "Failed to get sockaddr len: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to get sockaddr len: %s", strerror(errno));
 
   pr_netaddr_disable_ipv6();
   res = pr_netaddr_get_sockaddr_len(addr);
-  fail_unless(res == (size_t) -1, "Got sockaddr len unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == (size_t) -1, "Got sockaddr len unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_netaddr_enable_ipv6();
@@ -541,8 +541,8 @@ START_TEST (netaddr_get_sockaddr_len_test) {
   res = pr_netaddr_get_sockaddr_len(addr);
   addr->na_family = family;
 
-  fail_unless(res == (size_t) -1, "Got sockaddr len unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == (size_t) -1, "Got sockaddr len unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -561,29 +561,29 @@ START_TEST (netaddr_set_sockaddr_test) {
 #endif /* PR_USE_IPV6 */
 
   res = pr_netaddr_set_sockaddr(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_set_sockaddr(addr, NULL);
-  fail_unless(res < 0, "Failed to handle null sockaddr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null sockaddr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   memset(&sa, 0, sizeof(sa));
 
   res = pr_netaddr_set_sockaddr(addr, &sa);
-  fail_unless(res == 0, "Failed to set sockaddr: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sockaddr: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
 # if defined(HAVE_GETADDRINFO)
@@ -595,15 +595,15 @@ START_TEST (netaddr_set_sockaddr_test) {
   hints.ai_flags |= AI_V4MAPPED;
 #  endif /* AI_V4MAPPED */
   res = getaddrinfo("::1", NULL, &hints, &info);
-  fail_unless(res == 0, "getaddrinfo('::1') failed: %s", gai_strerror(res));
+  ck_assert_msg(res == 0, "getaddrinfo('::1') failed: %s", gai_strerror(res));
 
   res = pr_netaddr_set_sockaddr(addr, info->ai_addr);
-  fail_unless(res == 0, "Failed to set sockaddr: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sockaddr: %s", strerror(errno));
 
   pr_netaddr_disable_ipv6();
   res = pr_netaddr_set_sockaddr(addr, info->ai_addr);
-  fail_unless(res < 0, "Set sockaddr unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Set sockaddr unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   freeaddrinfo(info);
@@ -615,8 +615,8 @@ START_TEST (netaddr_set_sockaddr_test) {
   res = pr_netaddr_set_sockaddr(addr, &sa);
   addr->na_family = family;
 
-  fail_unless(res < 0, "Set sockaddr unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Set sockaddr unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -631,31 +631,31 @@ START_TEST (netaddr_set_sockaddr_any_test) {
 #endif /* PR_USE_IPV6 */
 
   res = pr_netaddr_set_sockaddr_any(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_set_sockaddr_any(addr);
-  fail_unless(res == 0, "Failed to set sockaddr any: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sockaddr any: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_set_sockaddr_any(addr);
-  fail_unless(res == 0, "Failed to set sockaddr any: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sockaddr any: %s", strerror(errno));
 
   pr_netaddr_disable_ipv6();
   res = pr_netaddr_set_sockaddr_any(addr);
-  fail_unless(res < 0, "Set sockaddr any unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Set sockaddr any unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_netaddr_enable_ipv6();
@@ -665,8 +665,8 @@ START_TEST (netaddr_set_sockaddr_any_test) {
   res = pr_netaddr_set_sockaddr_any(addr);
   addr->na_family = family;
 
-  fail_unless(res < 0, "Set sockaddr any unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Set sockaddr any unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -679,33 +679,33 @@ START_TEST (netaddr_get_inaddr_test) {
   const char *name;
 
   inaddr = pr_netaddr_get_inaddr(NULL);
-  fail_unless(inaddr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(inaddr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   family = AF_INET;
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   inaddr = pr_netaddr_get_inaddr(addr);
-  fail_unless(inaddr != NULL, "Failed to get inaddr: %s", strerror(errno));
+  ck_assert_msg(inaddr != NULL, "Failed to get inaddr: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   family = AF_INET6;
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   inaddr = pr_netaddr_get_inaddr(addr);
-  fail_unless(inaddr != NULL, "Failed to get inaddr: %s", strerror(errno));
+  ck_assert_msg(inaddr != NULL, "Failed to get inaddr: %s", strerror(errno));
 
   pr_netaddr_disable_ipv6();
   inaddr = pr_netaddr_get_inaddr(addr);
-  fail_unless(inaddr == NULL, "Got inaddr unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(inaddr == NULL, "Got inaddr unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_netaddr_enable_ipv6();
@@ -715,8 +715,8 @@ START_TEST (netaddr_get_inaddr_test) {
   inaddr = pr_netaddr_get_inaddr(addr);
   addr->na_family = family;
 
-  fail_unless(inaddr == NULL, "Got inaddr unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(inaddr == NULL, "Got inaddr unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -731,34 +731,34 @@ START_TEST (netaddr_get_inaddr_len_test) {
 #endif /* PR_USE_IPV6 */
 
   res = pr_netaddr_get_inaddr_len(NULL);
-  fail_unless(res == (size_t) -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == (size_t) -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_get_inaddr_len(addr);
-  fail_unless(res > 0, "Failed to get inaddr len: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to get inaddr len: %s", strerror(errno));
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_get_inaddr_len(addr);
-  fail_unless(res > 0, "Failed to get inaddr len: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to get inaddr len: %s", strerror(errno));
 
   family = addr->na_family;
   addr->na_family = 777;
   res = pr_netaddr_get_inaddr_len(addr);
   addr->na_family = family;
 
-  fail_unless(res == (size_t) -1, "Got inaddr len unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == (size_t) -1, "Got inaddr len unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -769,20 +769,20 @@ START_TEST (netaddr_get_port_test) {
   unsigned int res;
 
   res = pr_netaddr_get_port(NULL);
-  fail_unless(res == 0, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == 0, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
     strerror(errno));
 
   res = pr_netaddr_get_port(addr);
-  fail_unless(res == 0, "Expected port %u, got %u", 0, res);
+  ck_assert_msg(res == 0, "Expected port %u, got %u", 0, res);
 
   addr->na_family = -1;
   res = pr_netaddr_get_port(addr);
-  fail_unless(res == 0, "Expected port %u, got %u", 0, res);
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == 0, "Expected port %u, got %u", 0, res);
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 }
 END_TEST
 
@@ -792,24 +792,24 @@ START_TEST (netaddr_set_port_test) {
   int res;
 
   res = pr_netaddr_set_port(NULL, 0);
-  fail_unless(res == -1, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = (pr_netaddr_t *) pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for '127.0.0.1': %s",
     strerror(errno));
 
   addr->na_family = -1;
   res = pr_netaddr_set_port(addr, 1);
-  fail_unless(res == -1, "Failed to handle bad family");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle bad family");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   addr->na_family = AF_INET;
   res = pr_netaddr_set_port(addr, 1);
-  fail_unless(res == 0, "Failed to set port: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set port: %s", strerror(errno));
 
   port = pr_netaddr_get_port(addr);
-  fail_unless(port == 1, "Expected port %u, got %u", 1, port);
+  ck_assert_msg(port == 1, "Expected port %u, got %u", 1, port);
 }
 END_TEST
 
@@ -817,10 +817,10 @@ START_TEST (netaddr_set_reverse_dns_test) {
   int res;
 
   res = pr_netaddr_set_reverse_dns(FALSE);
-  fail_unless(res == 1, "Expected reverse %d, got %d", 1, res);
+  ck_assert_msg(res == 1, "Expected reverse %d, got %d", 1, res);
 
   res = pr_netaddr_set_reverse_dns(TRUE);
-  fail_unless(res == 0, "Expected reverse %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected reverse %d, got %d", 0, res);
 }
 END_TEST
 
@@ -831,19 +831,19 @@ START_TEST (netaddr_get_dnsstr_test) {
   ip = "127.0.0.1";
 
   res = pr_netaddr_get_dnsstr(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, ip, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", ip,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", ip,
     strerror(errno));
 
   pr_netaddr_set_reverse_dns(FALSE);
 
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
+  ck_assert_msg(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
 
   pr_netaddr_set_reverse_dns(TRUE);
 
@@ -851,9 +851,9 @@ START_TEST (netaddr_get_dnsstr_test) {
    * previous call to pr_netaddr_get_dnsstr() cached the IP address.
    */
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
+  ck_assert_msg(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
 
   pr_netaddr_clear((pr_netaddr_t *) addr);
 
@@ -861,22 +861,22 @@ START_TEST (netaddr_get_dnsstr_test) {
    * info, in addition to the cached strings.
    */
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
+  ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   /* We need to clear the netaddr internal cache as well. */
   pr_netaddr_clear_ipcache(ip);
   addr = pr_netaddr_get_addr(p, ip, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", ip,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", ip,
     strerror(errno));
 
   mark_point();
-  fail_unless(addr->na_have_dnsstr == 0, "addr already has cached DNS str");
+  ck_assert_msg(addr->na_have_dnsstr == 0, "addr already has cached DNS str");
 
   mark_point();
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
 
   mark_point();
@@ -888,7 +888,7 @@ START_TEST (netaddr_get_dnsstr_test) {
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
     /* This test is sensitive the environment. */
-    fail_unless(strcmp(res, "localhost") == 0 ||
+    ck_assert_msg(strcmp(res, "localhost") == 0 ||
                 strcmp(res, "localhost.localdomain") == 0,
       "Expected '%s', got '%s'", "localhost or localhost.localdomain", res);
   }
@@ -902,21 +902,21 @@ START_TEST (netaddr_get_dnsstr_list_test) {
   const char *dnsstr;
 
   res = pr_netaddr_get_dnsstr_list(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_netaddr_get_dnsstr_list(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "localhost", NULL);
-  fail_unless(addr != NULL, "Failed to resolve 'localhost': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve 'localhost': %s",
     strerror(errno));
 
   res = pr_netaddr_get_dnsstr_list(p, addr);
-  fail_unless(res != NULL, "Failed to get DNS list: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to get DNS list: %s", strerror(errno));
 
   reverse_dns = pr_netaddr_set_reverse_dns(TRUE);
 
@@ -924,11 +924,11 @@ START_TEST (netaddr_get_dnsstr_list_test) {
 
 #if defined(PR_USE_NETWORK_TESTS)
   addr = pr_netaddr_get_addr(p, "www.google.com", &addrs);
-  fail_unless(addr != NULL, "Failed to resolve 'www.google.com': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve 'www.google.com': %s",
     strerror(errno));
 
   dnsstr = pr_netaddr_get_dnsstr(addr);
-  fail_unless(dnsstr != NULL, "Failed to get DNS string for '%s': %s",
+  ck_assert_msg(dnsstr != NULL, "Failed to get DNS string for '%s': %s",
     pr_netaddr_get_ipstr(addr), strerror(errno));
 
   /* We may get a DNS name, but there is no guarantee that the reverse
@@ -936,7 +936,7 @@ START_TEST (netaddr_get_dnsstr_list_test) {
    */
 
   res = pr_netaddr_get_dnsstr_list(p, addr);
-  fail_unless(res != NULL, "Failed to get DNS list: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to get DNS list: %s", strerror(errno));
 
   /* Ideally we would check that res->nelts > 0, BUT this turns out to
    * a fragile test condition, dependent on DNS vagaries.
@@ -955,19 +955,19 @@ START_TEST (netaddr_get_dnsstr_ipv6_test) {
   ip = "::1";
 
   res = pr_netaddr_get_dnsstr(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, ip, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", ip,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", ip,
     strerror(errno));
 
   pr_netaddr_set_reverse_dns(FALSE);
 
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
+  ck_assert_msg(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
 
   pr_netaddr_set_reverse_dns(TRUE);
 
@@ -975,9 +975,9 @@ START_TEST (netaddr_get_dnsstr_ipv6_test) {
    * previous call to pr_netaddr_get_dnsstr() cached the IP address.
    */
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
+  ck_assert_msg(strcmp(res, ip) == 0, "Expected '%s', got '%s'", ip, res);
 
   pr_netaddr_clear((pr_netaddr_t *) addr);
 
@@ -985,22 +985,22 @@ START_TEST (netaddr_get_dnsstr_ipv6_test) {
    * info, in addition to the cached strings.
    */
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
+  ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   /* We need to clear the netaddr internal cache as well. */
   pr_netaddr_clear_ipcache(ip);
   addr = pr_netaddr_get_addr(p, ip, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", ip,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", ip,
     strerror(errno));
 
   mark_point();
-  fail_unless(addr->na_have_dnsstr == 0, "addr already has cached DNS str");
+  ck_assert_msg(addr->na_have_dnsstr == 0, "addr already has cached DNS str");
 
   mark_point();
   res = pr_netaddr_get_dnsstr(addr);
-  fail_unless(res != NULL, "Failed to get DNS str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get DNS str for addr: %s",
     strerror(errno));
 
   mark_point();
@@ -1011,7 +1011,7 @@ START_TEST (netaddr_get_dnsstr_ipv6_test) {
    */
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
-    fail_unless(strcmp(res, "localhost") == 0 ||
+    ck_assert_msg(strcmp(res, "localhost") == 0 ||
                 strcmp(res, "localhost.localdomain") == 0 ||
                 strcmp(res, "localhost6") == 0 ||
                 strcmp(res, "localhost6.localdomain") == 0 ||
@@ -1029,23 +1029,23 @@ START_TEST (netaddr_get_ipstr_test) {
   const char *res;
 
   res = pr_netaddr_get_ipstr(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   addr = pr_netaddr_get_addr(p, "localhost", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for 'localhost': %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for 'localhost': %s",
     strerror(errno));
 
   res = pr_netaddr_get_ipstr(addr);
-  fail_unless(res != NULL, "Failed to get IP str for addr: %s",
+  ck_assert_msg(res != NULL, "Failed to get IP str for addr: %s",
     strerror(errno));
-  fail_unless(strcmp(res, "127.0.0.1") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, "127.0.0.1") == 0, "Expected '%s', got '%s'",
     "127.0.0.1", res);
-  fail_unless(addr->na_have_ipstr == 1, "addr should have cached IP str");
+  ck_assert_msg(addr->na_have_ipstr == 1, "addr should have cached IP str");
 
   pr_netaddr_clear((pr_netaddr_t *) addr);
   res = pr_netaddr_get_ipstr(addr);
-  fail_unless(res == NULL, "Expected null, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected null, got '%s'", res);
 }
 END_TEST
 
@@ -1053,30 +1053,30 @@ START_TEST (netaddr_validate_dns_str_test) {
   char *res, *str;
 
   res = pr_netaddr_validate_dns_str(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "foo");
   res = pr_netaddr_validate_dns_str(str);
-  fail_unless(strcmp(res, str) == 0, "Expected '%s', got '%s'", str, res);
+  ck_assert_msg(strcmp(res, str) == 0, "Expected '%s', got '%s'", str, res);
 
   str = pstrdup(p, "[foo]");
   res = pr_netaddr_validate_dns_str(str);
-  fail_unless(strcmp(res, "_foo_") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, "_foo_") == 0, "Expected '%s', got '%s'",
     "_foo_", res);
 
   str = pstrdup(p, "foo.");
   res = pr_netaddr_validate_dns_str(str);
-  fail_unless(strcmp(res, str) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, str) == 0, "Expected '%s', got '%s'",
     str, res);
 
   str = pstrdup(p, "foo:");
   res = pr_netaddr_validate_dns_str(str);
 #ifdef PR_USE_IPV6
-  fail_unless(strcmp(res, str) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, str) == 0, "Expected '%s', got '%s'",
     str, res);
 #else
-  fail_unless(strcmp(res, "foo_") == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, "foo_") == 0, "Expected '%s', got '%s'",
     "foo_", res);
 #endif
 }
@@ -1086,11 +1086,11 @@ START_TEST (netaddr_get_localaddr_str_test) {
   const char *res;
 
   res = pr_netaddr_get_localaddr_str(NULL);
-  fail_unless(res == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_netaddr_get_localaddr_str(p);
-  fail_unless(res != NULL, "Failed to get local addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to get local addr: %s", strerror(errno));
 }
 END_TEST
 
@@ -1100,44 +1100,44 @@ START_TEST (netaddr_is_loopback_test) {
   const char *name;
 
   res = pr_netaddr_is_loopback(NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
 #if defined(PR_USE_NETWORK_TESTS)
   name = "www.google.com";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_is_loopback(addr);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 #endif
 
   name = "127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_is_loopback(addr);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
 #ifdef PR_USE_IPV6
   name = "::1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_is_loopback(addr);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   name = "::ffff:127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   res = pr_netaddr_is_loopback(addr);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 #endif /* PR_USE_IPV6 */
 }
 END_TEST
@@ -1147,22 +1147,22 @@ START_TEST (netaddr_is_v4_test) {
   const char *name;
 
   res = pr_netaddr_is_v4(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "::1";
   res = pr_netaddr_is_v4(name);
-  fail_unless(res == FALSE, "Expected 'false' for IPv6 address '%s', got %d",
+  ck_assert_msg(res == FALSE, "Expected 'false' for IPv6 address '%s', got %d",
     name, res);
 
   name = "localhost";
   res = pr_netaddr_is_v4(name);
-  fail_unless(res == FALSE, "Expected 'false' for DNS name '%s', got %d",
+  ck_assert_msg(res == FALSE, "Expected 'false' for DNS name '%s', got %d",
     name, res);
 
   name = "127.0.0.1";
   res = pr_netaddr_is_v4(name);
-  fail_unless(res == TRUE, "Expected 'true' for IPv4 address '%s', got %d",
+  ck_assert_msg(res == TRUE, "Expected 'true' for IPv4 address '%s', got %d",
     name, res);
 }
 END_TEST
@@ -1172,17 +1172,17 @@ START_TEST (netaddr_is_v6_test) {
   const char *name;
 
   res = pr_netaddr_is_v6(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "127.0.0.1";
   res = pr_netaddr_is_v6(name);
-  fail_unless(res == FALSE, "Expected 'false' for IPv4 address '%s', got %d",
+  ck_assert_msg(res == FALSE, "Expected 'false' for IPv4 address '%s', got %d",
     name, res);
 
   name = "localhost";
   res = pr_netaddr_is_v6(name);
-  fail_unless(res == FALSE, "Expected 'false' for DNS name '%s', got %d",
+  ck_assert_msg(res == FALSE, "Expected 'false' for DNS name '%s', got %d",
     name, res);
 
   pr_netaddr_enable_ipv6();
@@ -1190,7 +1190,7 @@ START_TEST (netaddr_is_v6_test) {
   if (pr_netaddr_use_ipv6() == TRUE) {
     name = "::1";
     res = pr_netaddr_is_v6(name);
-    fail_unless(res == TRUE, "Expected 'true' for IPv6 address '%s', got %d",
+    ck_assert_msg(res == TRUE, "Expected 'true' for IPv6 address '%s', got %d",
       name, res);
   }
 }
@@ -1202,46 +1202,46 @@ START_TEST (netaddr_is_v4mappedv6_test) {
   const pr_netaddr_t *addr;
 
   res = pr_netaddr_is_v4mappedv6(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_v4mappedv6(addr);
-  fail_unless(res == -1, "Expected -1 for IPv4 address '%s', got %d",
+  ck_assert_msg(res == -1, "Expected -1 for IPv4 address '%s', got %d",
     name, res);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
     errno, strerror(errno));
 
   name = "::1";
   addr = pr_netaddr_get_addr(p, name, NULL);
 #ifdef PR_USE_IPV6
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_v4mappedv6(addr);
-  fail_unless(res == FALSE, "Expected 'false' for IPv6 address '%s', got %d",
+  ck_assert_msg(res == FALSE, "Expected 'false' for IPv6 address '%s', got %d",
     name, res);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
     errno, strerror(errno));
 #else
-  fail_unless(addr == NULL,
+  ck_assert_msg(addr == NULL,
     "IPv6 support disabled, should not be able to get addr for '%s'", name);
 #endif /* PR_USE_IPV6 */
 
   name = "::ffff:127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_v4mappedv6(addr);
 #ifdef PR_USE_IPV6
-  fail_unless(res == TRUE,
+  ck_assert_msg(res == TRUE,
     "Expected 'true' for IPv4-mapped IPv6 address '%s', got %d", name, res);
 #else
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Expected -1 for IPv4-mapped IPv6 address '%s' (--disable-ipv6 used)");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL; got %d [%s]",
     errno, strerror(errno));
 #endif /* PR_USE_IPV6 */
 }
@@ -1253,51 +1253,51 @@ START_TEST (netaddr_is_rfc1918_test) {
   const pr_netaddr_t *addr;
 
   res = pr_netaddr_is_rfc1918(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   name = "127.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == FALSE, "Failed to handle non-RFC1918 IPv4 address");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == FALSE, "Failed to handle non-RFC1918 IPv4 address");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   name = "::1";
   addr = pr_netaddr_get_addr(p, name, NULL);
 #ifdef PR_USE_IPV6
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == FALSE, "Failed to handle IPv6 address");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == FALSE, "Failed to handle IPv6 address");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 #else
-  fail_unless(addr == NULL,
+  ck_assert_msg(addr == NULL,
     "IPv6 support disabled, should not be able to get addr for '%s'", name);
 #endif /* PR_USE_IPV6 */
 
   name = "10.0.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == TRUE, "Expected 'true' for address '%s'", name);
+  ck_assert_msg(res == TRUE, "Expected 'true' for address '%s'", name);
 
   name = "192.168.0.1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == TRUE, "Expected 'true' for address '%s'", name);
+  ck_assert_msg(res == TRUE, "Expected 'true' for address '%s'", name);
 
   name = "172.31.200.55";
   addr = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
+  ck_assert_msg(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == TRUE, "Expected 'true' for address '%s'", name);
+  ck_assert_msg(res == TRUE, "Expected 'true' for address '%s'", name);
 }
 END_TEST
 
@@ -1306,39 +1306,39 @@ START_TEST (netaddr_v6tov4_test) {
   const char *name, *ipstr;
 
   addr = pr_netaddr_v6tov4(NULL, NULL);
-  fail_unless(addr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_v6tov4(p, NULL);
-  fail_unless(addr == NULL, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   addr = pr_netaddr_v6tov4(p, addr2);
-  fail_unless(addr == NULL, "Converted '%s' to IPv4 address unexpectedly",
+  ck_assert_msg(addr == NULL, "Converted '%s' to IPv4 address unexpectedly",
     name);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   name = "::ffff:127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   addr = pr_netaddr_v6tov4(p, addr2);
-  fail_unless(addr != NULL, "Failed to convert '%s' to IPv4 address: %s",
+  ck_assert_msg(addr != NULL, "Failed to convert '%s' to IPv4 address: %s",
     name, strerror(errno));
-  fail_unless(pr_netaddr_get_family(addr) == AF_INET,
+  ck_assert_msg(pr_netaddr_get_family(addr) == AF_INET,
     "Expected %d, got %d", AF_INET, pr_netaddr_get_family(addr));
 
   ipstr = pr_netaddr_get_ipstr(addr);
-  fail_unless(strcmp(ipstr, "127.0.0.1") == 0,
+  ck_assert_msg(strcmp(ipstr, "127.0.0.1") == 0,
     "Expected '127.0.0.1', got '%s'", ipstr);
 }
 END_TEST
@@ -1348,46 +1348,46 @@ START_TEST (netaddr_v4tov6_test) {
   const char *name, *ipstr;
 
   addr = pr_netaddr_v4tov6(NULL, NULL);
-  fail_unless(addr == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_v4tov6(p, NULL);
-  fail_unless(addr == NULL, "Failed to handle null address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   name = "::ffff:127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   addr = pr_netaddr_v4tov6(p, addr2);
-  fail_unless(addr == NULL, "Converted '%s' to IPv6 address unexpectedly",
+  ck_assert_msg(addr == NULL, "Converted '%s' to IPv6 address unexpectedly",
     name);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   name = "127.0.0.1";
   addr2 = pr_netaddr_get_addr(p, name, NULL);
-  fail_unless(addr2 != NULL, "Failed to resolve '%s': %s", name,
+  ck_assert_msg(addr2 != NULL, "Failed to resolve '%s': %s", name,
     strerror(errno));
 
   addr = pr_netaddr_v4tov6(p, addr2);
 #ifdef PR_USE_IPV6
-  fail_unless(addr != NULL, "Failed to convert '%s' to IPv6 address: %s",
+  ck_assert_msg(addr != NULL, "Failed to convert '%s' to IPv6 address: %s",
     name, strerror(errno));
-  fail_unless(pr_netaddr_get_family(addr) == AF_INET6,
+  ck_assert_msg(pr_netaddr_get_family(addr) == AF_INET6,
     "Expected %d, got %d", AF_INET6, pr_netaddr_get_family(addr));
 
   ipstr = pr_netaddr_get_ipstr(addr);
-  fail_unless(strcmp(ipstr, "::ffff:127.0.0.1") == 0,
+  ck_assert_msg(strcmp(ipstr, "::ffff:127.0.0.1") == 0,
     "Expected '::ffff:127.0.0.1', got '%s'", ipstr);
 
 #else
-  fail_unless(addr == NULL, "Converted '%s' to IPv6 address unexpectedly",
+  ck_assert_msg(addr == NULL, "Converted '%s' to IPv6 address unexpectedly",
     name);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }
@@ -1399,15 +1399,15 @@ START_TEST (netaddr_disable_ipv6_test) {
   use_ipv6 = pr_netaddr_use_ipv6();
 
 #ifdef PR_USE_IPV6
-  fail_unless(use_ipv6 == TRUE, "Expected %d, got %d", TRUE, use_ipv6);
+  ck_assert_msg(use_ipv6 == TRUE, "Expected %d, got %d", TRUE, use_ipv6);
 #else
-  fail_unless(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
+  ck_assert_msg(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
 #endif
 
   pr_netaddr_disable_ipv6();
 
   use_ipv6 = pr_netaddr_use_ipv6();
-  fail_unless(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
+  ck_assert_msg(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
 }
 END_TEST
 
@@ -1418,9 +1418,9 @@ START_TEST (netaddr_enable_ipv6_test) {
 
   use_ipv6 = pr_netaddr_use_ipv6();
 #ifdef PR_USE_IPV6
-  fail_unless(use_ipv6 == TRUE, "Expected %d, got %d", TRUE, use_ipv6);
+  ck_assert_msg(use_ipv6 == TRUE, "Expected %d, got %d", TRUE, use_ipv6);
 #else
-  fail_unless(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
+  ck_assert_msg(use_ipv6 == FALSE, "Expected %d, got %d", FALSE, use_ipv6);
 #endif
 }
 END_TEST

--- a/tests/api/netio.c
+++ b/tests/api/netio.c
@@ -2135,7 +2135,7 @@ START_TEST (netio_poll_interval_test) {
   pr_netio_reset_poll_interval(NULL);
 
   pr_netio_reset_poll_interval(nstrm);
-  fail_if(nstrm->strm_flags & PR_NETIO_SESS_INTR,
+  ck_assert_msg(!(nstrm->strm_flags & PR_NETIO_SESS_INTR),
     "Failed to clear PR_NETIO_SESS_INTR stream flag");
 
   (void) pr_netio_close(nstrm);

--- a/tests/api/netio.c
+++ b/tests/api/netio.c
@@ -64,7 +64,7 @@ static int open_tmpfile(void) {
 
   tmp_path = "/tmp/netio-test.dat";
   fd = open(tmp_path, O_RDWR|O_CREAT, 0666);
-  fail_unless(fd >= 0, "Failed to open '%s': %s", tmp_path, strerror(errno));  
+  ck_assert_msg(fd >= 0, "Failed to open '%s': %s", tmp_path, strerror(errno));  
   tmp_fd = fd;
 
   return fd;
@@ -103,36 +103,36 @@ START_TEST (netio_open_test) {
   int fd = -1;
 
   nstrm = pr_netio_open(NULL, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(nstrm == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   nstrm = pr_netio_open(p, 7777, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm == NULL, "Failed to handle unknown stream type argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(nstrm == NULL, "Failed to handle unknown stream type argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   /* open/close CTRL stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
-  fail_unless(nstrm->strm_netio != NULL,
+  ck_assert_msg(nstrm->strm_netio != NULL,
     "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 
   /* open/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_WR);
-  fail_unless(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
     strerror(errno));
-  fail_unless(nstrm->strm_netio != NULL,
+  ck_assert_msg(nstrm->strm_netio != NULL,
     "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 
   /* open/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_WR);
-  fail_unless(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
     strerror(errno));
-  fail_unless(nstrm->strm_netio != NULL,
+  ck_assert_msg(nstrm->strm_netio != NULL,
     "Failed to assign owning NetIO to stream");
   pr_netio_close(nstrm);
 }
@@ -143,35 +143,35 @@ START_TEST (netio_postopen_test) {
   int fd = -1, res;
 
   res = pr_netio_postopen(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* open/postopen/close CTRL stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_postopen(nstrm);
-  fail_unless(res == 0, "Failed to post-open ctrl stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to post-open ctrl stream: %s", strerror(errno));
   (void) pr_netio_close(nstrm);
 
   /* open/postopen/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_postopen(nstrm);
-  fail_unless(res == 0, "Failed to post-open data stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to post-open data stream: %s", strerror(errno));
   (void) pr_netio_close(nstrm);
 
   /* open/postopen/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_postopen(nstrm);
-  fail_unless(res == 0, "Failed to post-open othr stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to post-open othr stream: %s", strerror(errno));
   (void) pr_netio_close(nstrm);
 }
 END_TEST
@@ -181,8 +181,8 @@ START_TEST (netio_close_test) {
   int res, fd = -1;
 
   res = pr_netio_close(NULL);
-  fail_unless(res == -1, "Failed to handle null stream argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null stream argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/close CTRL stream */
@@ -190,28 +190,28 @@ START_TEST (netio_close_test) {
   nstrm->strm_type = 7777;
 
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle unknown stream type argument");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle unknown stream type argument");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
     strerror(errno), errno);
 
   nstrm->strm_type = PR_NETIO_STRM_CTRL;
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
     strerror(errno), errno);
 }
 END_TEST
@@ -222,8 +222,8 @@ START_TEST (netio_lingering_close_test) {
   long linger = 0L;
 
   res = pr_netio_lingering_close(NULL, linger);
-  fail_unless(res == -1, "Failed to handle null stream argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null stream argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/close CTRL stream */
@@ -231,23 +231,23 @@ START_TEST (netio_lingering_close_test) {
   nstrm->strm_type = 7777;
 
   res = pr_netio_lingering_close(nstrm, linger);
-  fail_unless(res < 0, "Failed to handle unknown stream type argument");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle unknown stream type argument");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
     strerror(errno), errno);
 
   nstrm->strm_type = PR_NETIO_STRM_CTRL;
   res = pr_netio_lingering_close(nstrm, linger);
-  fail_unless(res == 0, "Failed to close stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close stream: %s", strerror(errno));
 
   /* Open/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
   res = pr_netio_lingering_close(nstrm, linger);
-  fail_unless(res == 0, "Failed to close stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close stream: %s", strerror(errno));
 
   /* Open/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
   res = pr_netio_lingering_close(nstrm, linger);
-  fail_unless(res == 0, "Failed to close stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close stream: %s", strerror(errno));
 }
 END_TEST
 
@@ -256,8 +256,8 @@ START_TEST (netio_reopen_test) {
   int res, fd = -1;
 
   nstrm2 = pr_netio_reopen(NULL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm2 == NULL, "Failed to handle null stream argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(nstrm2 == NULL, "Failed to handle null stream argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/reopen/close CTRL stream */
@@ -265,35 +265,35 @@ START_TEST (netio_reopen_test) {
   nstrm->strm_type = 7777;
 
   nstrm2 = pr_netio_reopen(nstrm, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm2 == NULL, "Failed to handle unknown stream type argument");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+  ck_assert_msg(nstrm2 == NULL, "Failed to handle unknown stream type argument");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
     strerror(errno), errno);
 
   nstrm->strm_type = PR_NETIO_STRM_CTRL;
   nstrm2 = pr_netio_reopen(nstrm, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm2 != NULL, "Failed to reopen ctrl stream: %s",
+  ck_assert_msg(nstrm2 != NULL, "Failed to reopen ctrl stream: %s",
     strerror(errno));
 
   /* Open/reopen/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
   nstrm2 = pr_netio_reopen(nstrm, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm2 != NULL, "Failed to reopen data stream: %s",
+  ck_assert_msg(nstrm2 != NULL, "Failed to reopen data stream: %s",
     strerror(errno));
 
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
     strerror(errno), errno);
 
   /* Open/reopen/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
   nstrm2 = pr_netio_reopen(nstrm, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm2 != NULL, "Failed to reopen othr stream: %s",
+  ck_assert_msg(nstrm2 != NULL, "Failed to reopen othr stream: %s",
     strerror(errno));
 
   res = pr_netio_close(nstrm);
-  fail_unless(res == -1, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Failed to set errno to EBADF, got %s (%d)",
     strerror(errno), errno);
 }
 END_TEST
@@ -303,14 +303,14 @@ START_TEST (netio_buffer_alloc_test) {
   pr_netio_stream_t *nstrm;
 
   pbuf = pr_netio_buffer_alloc(NULL);
-  fail_unless(pbuf == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(pbuf == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
 
   pbuf = pr_netio_buffer_alloc(nstrm);
-  fail_unless(pbuf != NULL, "Failed to allocate buffer: %s", strerror(errno));
+  ck_assert_msg(pbuf != NULL, "Failed to allocate buffer: %s", strerror(errno));
 
   pr_netio_close(nstrm);
 }
@@ -321,8 +321,8 @@ START_TEST (netio_telnet_gets_args_test) {
   pr_netio_stream_t *in, *out;
 
   res = pr_netio_telnet_gets(NULL, 0, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   buf = "";
@@ -330,19 +330,19 @@ START_TEST (netio_telnet_gets_args_test) {
   out = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_WR);
 
   res = pr_netio_telnet_gets(buf, 0, in, out);
-  fail_unless(res == NULL,
+  ck_assert_msg(res == NULL,
     "Failed to handle zero-length buffer length argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_netio_telnet_gets(buf, 1, NULL, out);
-  fail_unless(res == NULL, "Failed to handle null input stream argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle null input stream argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_netio_telnet_gets(buf, 1, in, NULL);
-  fail_unless(res == NULL, "Failed to handle null output stream argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle null output stream argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   pr_netio_close(in);
@@ -372,11 +372,11 @@ START_TEST (netio_telnet_gets_single_line_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
-  fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
+  ck_assert_msg(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
 
@@ -410,21 +410,21 @@ START_TEST (netio_telnet_gets_multi_line_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, first_cmd) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, first_cmd) == 0, "Expected string '%s', got '%s'",
     first_cmd, buf);
 
   memset(buf, '\0', sizeof(buf));
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, second_cmd) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, second_cmd) == 0, "Expected string '%s', got '%s'",
     second_cmd, buf);
 
-  fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
+  ck_assert_msg(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
 
@@ -455,8 +455,8 @@ START_TEST (netio_telnet_gets_no_newline_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res == NULL, "Read in string unexpectedly, got '%s'", buf);
-  fail_unless(xerrno == E2BIG, "Failed to set errno to E2BIG, got (%d) %s",
+  ck_assert_msg(res == NULL, "Read in string unexpectedly, got '%s'", buf);
+  ck_assert_msg(xerrno == E2BIG, "Failed to set errno to E2BIG, got (%d) %s",
     xerrno, strerror(xerrno));
 
   pr_netio_close(in);
@@ -493,9 +493,9 @@ START_TEST (netio_telnet_gets_telnet_will_test) {
 
   pr_netio_close(in);
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   /* Rewind the output stream fd. */
@@ -503,13 +503,13 @@ START_TEST (netio_telnet_gets_telnet_will_test) {
   len = read(out_fd, buf, sizeof(buf)-1);
   pr_netio_close(out);
 
-  fail_unless(len == 3, "Expected to read 3 bytes from output stream, got %d",
+  ck_assert_msg(len == 3, "Expected to read 3 bytes from output stream, got %d",
     len);
-  fail_unless(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
+  ck_assert_msg(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
     buf[0]);
-  fail_unless(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
+  ck_assert_msg(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
     buf[1]);
-  fail_unless(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
+  ck_assert_msg(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
     telnet_opt, buf[2]);
 
   test_cleanup();
@@ -541,15 +541,15 @@ START_TEST (netio_telnet_gets_telnet_bare_will_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_WILL, "Expected WILL at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_WILL, "Expected WILL at index 7, got %d",
     buf[7]);
-  fail_unless(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
+  ck_assert_msg(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
     telnet_opt, buf[8]);
-  fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
 
   pr_netio_close(in);
@@ -583,9 +583,9 @@ START_TEST (netio_telnet_gets_telnet_will_multi_read_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
 
   /* Fill up the input stream's buffer with the rest of the Telnet WILL
@@ -602,9 +602,9 @@ START_TEST (netio_telnet_gets_telnet_will_multi_read_test) {
   res = pr_netio_telnet_gets(buf + 7, sizeof(buf)-8, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'",
     cmd, buf);
 
   pr_netio_close(in);
@@ -614,13 +614,13 @@ START_TEST (netio_telnet_gets_telnet_will_multi_read_test) {
   len = read(out_fd, buf, sizeof(buf)-1);
   pr_netio_close(out);
 
-  fail_unless(len == 3, "Expected to read 3 bytes from output stream, got %d",
+  ck_assert_msg(len == 3, "Expected to read 3 bytes from output stream, got %d",
     len);
-  fail_unless(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
+  ck_assert_msg(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
     buf[0]);
-  fail_unless(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
+  ck_assert_msg(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
     buf[1]);
-  fail_unless(buf[2] == telnet_opt, "Expected %c at index 2, got %d",
+  ck_assert_msg(buf[2] == telnet_opt, "Expected %c at index 2, got %d",
     telnet_opt, buf[2]);
 
   test_cleanup();
@@ -656,9 +656,9 @@ START_TEST (netio_telnet_gets_telnet_wont_test) {
 
   pr_netio_close(in);
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   /* Rewind the output stream fd. */
@@ -666,13 +666,13 @@ START_TEST (netio_telnet_gets_telnet_wont_test) {
   len = read(out_fd, buf, sizeof(buf)-1);
   pr_netio_close(out);
 
-  fail_unless(len == 3, "Expected to read 3 bytes from output stream, got %d",
+  ck_assert_msg(len == 3, "Expected to read 3 bytes from output stream, got %d",
     len);
-  fail_unless(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
+  ck_assert_msg(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
     buf[0]);
-  fail_unless(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
+  ck_assert_msg(buf[1] == (char) TELNET_DONT, "Expected DONT at index 1, got %d",
     buf[1]);
-  fail_unless(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
+  ck_assert_msg(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
     telnet_opt, buf[2]);
 
   test_cleanup();
@@ -704,15 +704,15 @@ START_TEST (netio_telnet_gets_telnet_bare_wont_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_WONT, "Expected WONT at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_WONT, "Expected WONT at index 7, got %d",
     buf[7]);
-  fail_unless(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
+  ck_assert_msg(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
     telnet_opt, buf[8]);
-  fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
 
   pr_netio_close(in);
@@ -749,9 +749,9 @@ START_TEST (netio_telnet_gets_telnet_do_test) {
 
   pr_netio_close(in);
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   /* Rewind the output stream fd. */
@@ -759,13 +759,13 @@ START_TEST (netio_telnet_gets_telnet_do_test) {
   len = read(out_fd, buf, sizeof(buf)-1);
   pr_netio_close(out);
 
-  fail_unless(len == 3, "Expected to read 3 bytes from output stream, got %d",
+  ck_assert_msg(len == 3, "Expected to read 3 bytes from output stream, got %d",
     len);
-  fail_unless(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
+  ck_assert_msg(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
     buf[0]);
-  fail_unless(buf[1] == (char) TELNET_WONT, "Expected WONT at index 1, got %d",
+  ck_assert_msg(buf[1] == (char) TELNET_WONT, "Expected WONT at index 1, got %d",
     buf[1]);
-  fail_unless(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
+  ck_assert_msg(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
     telnet_opt, buf[2]);
 
   test_cleanup();
@@ -797,15 +797,15 @@ START_TEST (netio_telnet_gets_telnet_bare_do_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_DO, "Expected DO at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_DO, "Expected DO at index 7, got %d",
     buf[7]);
-  fail_unless(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
+  ck_assert_msg(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
     telnet_opt, buf[8]);
-  fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
 
   pr_netio_close(in);
@@ -842,9 +842,9 @@ START_TEST (netio_telnet_gets_telnet_dont_test) {
 
   pr_netio_close(in);
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   /* Rewind the output stream fd. */
@@ -852,13 +852,13 @@ START_TEST (netio_telnet_gets_telnet_dont_test) {
   len = read(out_fd, buf, sizeof(buf)-1);
   pr_netio_close(out);
 
-  fail_unless(len == 3, "Expected to read 3 bytes from output stream, got %d",
+  ck_assert_msg(len == 3, "Expected to read 3 bytes from output stream, got %d",
     len);
-  fail_unless(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
+  ck_assert_msg(buf[0] == (char) TELNET_IAC, "Expected IAC at index 0, got %d",
     buf[0]);
-  fail_unless(buf[1] == (char) TELNET_WONT, "Expected WONT at index 1, got %d",
+  ck_assert_msg(buf[1] == (char) TELNET_WONT, "Expected WONT at index 1, got %d",
     buf[1]);
-  fail_unless(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
+  ck_assert_msg(buf[2] == telnet_opt, "Expected opt '%c' at index 2, got %c",
     telnet_opt, buf[2]);
 
   test_cleanup();
@@ -890,15 +890,15 @@ START_TEST (netio_telnet_gets_telnet_bare_dont_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_DONT, "Expected DONT at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_DONT, "Expected DONT at index 7, got %d",
     buf[7]);
-  fail_unless(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
+  ck_assert_msg(buf[8] == telnet_opt, "Expected Telnet opt %c at index 8, got %d",
     telnet_opt, buf[8]);
-  fail_unless(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 9, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 9);
 
   pr_netio_close(in);
@@ -930,9 +930,9 @@ START_TEST (netio_telnet_gets_telnet_ip_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   pr_netio_close(in);
@@ -963,13 +963,13 @@ START_TEST (netio_telnet_gets_telnet_bare_ip_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_IP, "Expected IP at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_IP, "Expected IP at index 7, got %d",
     buf[7]);
-  fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
 
   pr_netio_close(in);
@@ -1001,9 +1001,9 @@ START_TEST (netio_telnet_gets_telnet_dm_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   pr_netio_close(in);
@@ -1034,13 +1034,13 @@ START_TEST (netio_telnet_gets_telnet_bare_dm_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_DM, "Expected DM at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_DM, "Expected DM at index 7, got %d",
     buf[7]);
-  fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
 
   pr_netio_close(in);
@@ -1071,13 +1071,13 @@ START_TEST (netio_telnet_gets_telnet_single_iac_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_IAC, "Expected IAC at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_IAC, "Expected IAC at index 7, got %d",
     buf[7]);
-  fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
 
   pr_netio_close(in);
@@ -1108,8 +1108,8 @@ START_TEST (netio_telnet_gets_bug3521_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res == NULL, "Expected null");
-  fail_unless(xerrno == E2BIG, "Failed to set errno to E2BIG, got %s (%d)",
+  ck_assert_msg(res == NULL, "Expected null");
+  ck_assert_msg(xerrno == E2BIG, "Failed to set errno to E2BIG, got %s (%d)",
     strerror(xerrno), xerrno);
 
   pr_netio_close(in);
@@ -1141,13 +1141,13 @@ START_TEST (netio_telnet_gets_bug3697_test) {
   res = pr_netio_telnet_gets(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
+  ck_assert_msg(strncmp(buf, cmd, 7) == 0, "Expected string '%*s', got '%*s'",
     7, cmd, 7, buf);
-  fail_unless(buf[7] == (char) TELNET_IAC, "Expected IAC at index 7, got %d",
+  ck_assert_msg(buf[7] == (char) TELNET_IAC, "Expected IAC at index 7, got %d",
     buf[7]);
-  fail_unless(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
+  ck_assert_msg(strcmp(buf + 8, cmd + 7) == 0, "Expected string '%s', got '%s'",
     cmd + 7, buf + 8);
 
   pr_netio_close(in);
@@ -1183,9 +1183,9 @@ START_TEST (netio_telnet_gets_eof_test) {
   res = pr_netio_telnet_gets(buf, strlen(cmd) + 2, in, out);
   xerrno = errno;
 
-  fail_unless(res != NULL, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res != NULL, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
   pr_netio_close(in);
@@ -1218,14 +1218,14 @@ START_TEST (netio_telnet_gets2_single_line_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
-  fail_unless((size_t) res == cmd_len, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == cmd_len, "Expected length %lu, got %d",
     (unsigned long) cmd_len, res);
-  fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
+  ck_assert_msg(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
 
@@ -1260,14 +1260,14 @@ START_TEST (netio_telnet_gets2_single_line_crnul_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
-  fail_unless((size_t) res == cmd_len, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == cmd_len, "Expected length %lu, got %d",
     (unsigned long) cmd_len, res);
-  fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
+  ck_assert_msg(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
 
@@ -1301,14 +1301,14 @@ START_TEST (netio_telnet_gets2_single_line_lf_test) {
   res = pr_netio_telnet_gets2(buf, sizeof(buf)-1, in, out);
   xerrno = errno;
 
-  fail_unless(res > 0, "Failed to get string from stream: (%d) %s",
+  ck_assert_msg(res > 0, "Failed to get string from stream: (%d) %s",
     xerrno, strerror(xerrno));
-  fail_unless(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
+  ck_assert_msg(strcmp(buf, cmd) == 0, "Expected string '%s', got '%s'", cmd,
     buf);
 
-  fail_unless((size_t) res == cmd_len, "Expected length %lu, got %d",
+  ck_assert_msg((size_t) res == cmd_len, "Expected length %lu, got %d",
     (unsigned long) cmd_len, res);
-  fail_unless(pbuf->remaining == (size_t) xfer_bufsz,
+  ck_assert_msg(pbuf->remaining == (size_t) xfer_bufsz,
     "Expected %d remaining bytes, got %lu", xfer_bufsz,
     (unsigned long) pbuf->remaining);
 
@@ -1559,29 +1559,29 @@ START_TEST (netio_read_test) {
 
   mark_point();
   res = pr_netio_read(NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   res = pr_netio_read(nstrm, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null buf");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buf");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   buf = "foo";
   res = pr_netio_read(nstrm, buf, 0, 0);
-  fail_unless(res < 0, "Failed to handle zero buflen");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buflen");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm->strm_fd = -2;
   res = pr_netio_read(nstrm, buf, 3, 0);
-  fail_unless(res < 0, "Failed to handle bad nstrm fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad nstrm fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -1590,17 +1590,17 @@ START_TEST (netio_read_test) {
 
   /* Write to control stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_CTRL);
-  fail_unless(netio2 != NULL, "Failed to get custom ctrl NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom ctrl NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom ctrl NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom ctrl NetIO %p, got %p",
     netio, netio2);
 
   res = netio_read_from_stream(PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to read from custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to read from custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1608,17 +1608,17 @@ START_TEST (netio_read_test) {
 
   /* Read from data stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to register custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom data NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_DATA);
-  fail_unless(netio2 != NULL, "Failed to get custom data NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom data NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom data NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom data NetIO %p, got %p",
     netio, netio2);
 
   res = netio_read_from_stream(PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to read from custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to read from custom data NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1626,17 +1626,17 @@ START_TEST (netio_read_test) {
 
   /* Read from other stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to register custom other NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom other NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_OTHR);
-  fail_unless(netio2 != NULL, "Failed to get custom othr NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom othr NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom othr NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom othr NetIO %p, got %p",
     netio, netio2);
 
   res = netio_read_from_stream(PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to read from custom other NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to read from custom other NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1652,8 +1652,8 @@ START_TEST (netio_gets_test) {
   pr_netio_stream_t *nstrm;
 
   text = pr_netio_gets(NULL, 0, NULL);
-  fail_unless(text == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -1661,29 +1661,29 @@ START_TEST (netio_gets_test) {
   netio->read = netio_read_cb;
 
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open stream: %s", strerror(errno));
+  ck_assert_msg(nstrm != NULL, "Failed to open stream: %s", strerror(errno));
 
   text = pr_netio_gets(NULL, 0, nstrm);
-  fail_unless(text == NULL, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = 1024;
   buf = pcalloc(p, buflen);
 
   text = pr_netio_gets(buf, 0, nstrm);
-  fail_unless(text == NULL, "Failed to handle zero buffer length");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle zero buffer length");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   expected = "Hello, World!\r\n";
   text = pr_netio_gets(buf, buflen-1, nstrm);
-  fail_unless(text != NULL, "Failed to get text: %s", strerror(errno));
-  fail_unless(strcmp(text, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(text != NULL, "Failed to get text: %s", strerror(errno));
+  ck_assert_msg(strcmp(text, expected) == 0, "Expected '%s', got '%s'",
     expected, text);
 
   mark_point();
@@ -1699,29 +1699,29 @@ START_TEST (netio_write_test) {
 
   mark_point();
   res = pr_netio_write(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   res = pr_netio_write(nstrm, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null buf");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buf");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   buf = "foo";
   res = pr_netio_write(nstrm, buf, 0);
-  fail_unless(res < 0, "Failed to handle zero buflen");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buflen");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm->strm_fd = -34;
   res = pr_netio_write(nstrm, buf, 3);
-  fail_unless(res < 0, "Failed to handle bad nstrm fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad nstrm fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -1730,17 +1730,17 @@ START_TEST (netio_write_test) {
 
   /* Write to control stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_CTRL);
-  fail_unless(netio2 != NULL, "Failed to get custom ctrl NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom ctrl NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom ctrl NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom ctrl NetIO %p, got %p",
     netio, netio2);
 
   res = netio_write_to_stream(PR_NETIO_STRM_CTRL, FALSE);
-  fail_unless(res == 0, "Failed to write to custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1748,17 +1748,17 @@ START_TEST (netio_write_test) {
 
   /* Write to data stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to register custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom data NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_DATA);
-  fail_unless(netio2 != NULL, "Failed to get custom data NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom data NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom data NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom data NetIO %p, got %p",
     netio, netio2);
 
   res = netio_write_to_stream(PR_NETIO_STRM_DATA, FALSE);
-  fail_unless(res == 0, "Failed to write to custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom data NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1766,17 +1766,17 @@ START_TEST (netio_write_test) {
 
   /* Write to other stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to register custom other NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom other NetIO: %s",
     strerror(errno));
 
   netio2 = pr_get_netio(PR_NETIO_STRM_OTHR);
-  fail_unless(netio2 != NULL, "Failed to get custom othr NetIO: %s",
+  ck_assert_msg(netio2 != NULL, "Failed to get custom othr NetIO: %s",
     strerror(errno));
-  fail_unless(netio2 == netio, "Expected custom othr NetIO %p, got %p",
+  ck_assert_msg(netio2 == netio, "Expected custom othr NetIO %p, got %p",
     netio, netio2);
 
   res = netio_write_to_stream(PR_NETIO_STRM_OTHR, FALSE);
-  fail_unless(res == 0, "Failed to write to custom other NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom other NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1791,16 +1791,16 @@ START_TEST (netio_write_async_test) {
 
   mark_point();
   res = pr_netio_write_async(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   nstrm->strm_fd = -1;
   res = pr_netio_write_async(nstrm, NULL, 0);
-  fail_unless(res < 0, "Failed to handle bad nstrm fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad nstrm fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -1809,12 +1809,12 @@ START_TEST (netio_write_async_test) {
 
   /* ctrl */
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
   res = netio_write_to_stream(PR_NETIO_STRM_CTRL, TRUE);
-  fail_unless(res == 0, "Failed to write to custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1822,12 +1822,12 @@ START_TEST (netio_write_async_test) {
 
   /* data */
   res = pr_register_netio(netio, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to register custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom data NetIO: %s",
     strerror(errno));
 
   mark_point();
   res = netio_write_to_stream(PR_NETIO_STRM_DATA, TRUE);
-  fail_unless(res == 0, "Failed to write to custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom data NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1835,12 +1835,12 @@ START_TEST (netio_write_async_test) {
 
   /* othr */
   res = pr_register_netio(netio, PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to register custom othr NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom othr NetIO: %s",
     strerror(errno));
 
   mark_point();
   res = netio_write_to_stream(PR_NETIO_STRM_OTHR, TRUE);
-  fail_unless(res == 0, "Failed to write to custom othr NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to write to custom othr NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1903,12 +1903,12 @@ START_TEST (netio_printf_test) {
 
   mark_point();
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
   res = netio_print_to_stream(PR_NETIO_STRM_CTRL, FALSE);
-  fail_unless(res == 0, "Failed to print to custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to print to custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1927,12 +1927,12 @@ START_TEST (netio_printf_async_test) {
 
   mark_point();
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
   res = netio_print_to_stream(PR_NETIO_STRM_CTRL, TRUE);
-  fail_unless(res == 0, "Failed to print to custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to print to custom ctrl NetIO: %s",
     strerror(errno));
 
   mark_point();
@@ -1949,33 +1949,33 @@ START_TEST (netio_abort_test) {
 
   /* open/abort/close CTRL stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
 
   pr_netio_abort(nstrm);
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on ctrl stream");
 
   pr_netio_close(nstrm);
 
   /* open/abort/close DATA stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_WR);
-  fail_unless(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
     strerror(errno));
 
   pr_netio_abort(nstrm);
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on data stream");
 
   pr_netio_close(nstrm);
 
   /* open/abort/close OTHR stream */
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_WR);
-  fail_unless(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
     strerror(errno));
 
   pr_netio_abort(nstrm);
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on othr stream");
 
   pr_netio_close(nstrm);
@@ -1990,16 +1990,16 @@ START_TEST (netio_lingering_abort_test) {
 
   mark_point();
   res = pr_netio_lingering_abort(NULL, linger);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   nstrm->strm_type = 0;
   res = pr_netio_lingering_abort(nstrm, linger);
-  fail_unless(res < 0, "Failed to handle invalid nstrm type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid nstrm type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -2007,18 +2007,18 @@ START_TEST (netio_lingering_abort_test) {
 
   /* open/abort/close CTRL stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_lingering_abort(nstrm, linger);
-  fail_unless(res == 0, "Failed to set lingering abort on ctrl stream: %s",
+  ck_assert_msg(res == 0, "Failed to set lingering abort on ctrl stream: %s",
     strerror(errno));
 
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on ctrl stream");
 
   pr_netio_close(nstrm);
@@ -2026,18 +2026,18 @@ START_TEST (netio_lingering_abort_test) {
 
   /* open/abort/close DATA stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to register custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom data NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_lingering_abort(nstrm, linger);
-  fail_unless(res == 0, "Failed to set lingering abort on data stream: %s",
+  ck_assert_msg(res == 0, "Failed to set lingering abort on data stream: %s",
     strerror(errno));
 
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on data stream");
 
   pr_netio_close(nstrm);
@@ -2045,18 +2045,18 @@ START_TEST (netio_lingering_abort_test) {
 
   /* open/abort/close OTHR stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to register custom othr NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom othr NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_lingering_abort(nstrm, linger);
-  fail_unless(res == 0, "Failed to set lingering abort on othr stream: %s",
+  ck_assert_msg(res == 0, "Failed to set lingering abort on othr stream: %s",
     strerror(errno));
 
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_ABORT,
     "Failed to set PR_NETIO_SESS_ABORT flags on othr stream");
 
   pr_netio_close(nstrm);
@@ -2070,46 +2070,46 @@ START_TEST (netio_poll_test) {
 
   mark_point();
   res = pr_netio_poll(NULL);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   nstrm->strm_fd = -3;
   res = pr_netio_poll(nstrm);
-  fail_unless(res < 0, "Failed to handle bad nstrm fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad nstrm fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   nstrm->strm_fd = fileno(stderr);
   nstrm->strm_flags |= PR_NETIO_SESS_ABORT;
   res = pr_netio_poll(nstrm);
-  fail_unless(res == 1, "Failed to handle SESS_ABORT flag");
+  ck_assert_msg(res == 1, "Failed to handle SESS_ABORT flag");
 
   mark_point();
   nstrm->strm_flags |= PR_NETIO_SESS_INTR;
   res = pr_netio_poll(nstrm);
-  fail_unless(res < 0, "Failed to handle SESS_INTR flag");
-  fail_unless(errno == EOF, "Expected EOF (%d), got %s (%d)", EOF,
+  ck_assert_msg(res < 0, "Failed to handle SESS_INTR flag");
+  ck_assert_msg(errno == EOF, "Expected EOF (%d), got %s (%d)", EOF,
     strerror(errno), errno);
 
   mark_point();
   nstrm->strm_flags &= ~PR_NETIO_SESS_INTR;
   nstrm->strm_type = PR_NETIO_STRM_CTRL;
   res = pr_netio_poll(nstrm);
-  fail_unless(res == 0, "Failed to handle ctrl strm: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle ctrl strm: %s", strerror(errno));
 
   mark_point();
   nstrm->strm_type = PR_NETIO_STRM_DATA;
   res = pr_netio_poll(nstrm);
-  fail_unless(res == 0, "Failed to handle data strm: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle data strm: %s", strerror(errno));
 
   mark_point();
   nstrm->strm_type = PR_NETIO_STRM_OTHR;
   res = pr_netio_poll(nstrm);
-  fail_unless(res == 0, "Failed to handle othr strm: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle othr strm: %s", strerror(errno));
 }
 END_TEST
 
@@ -2122,13 +2122,13 @@ START_TEST (netio_poll_interval_test) {
   pr_netio_set_poll_interval(NULL, 0);
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
 
   pr_netio_set_poll_interval(nstrm, interval); 
-  fail_unless(nstrm->strm_interval == interval,
+  ck_assert_msg(nstrm->strm_interval == interval,
     "Expected stream interval %u, got %u", interval, nstrm->strm_interval);
-  fail_unless(nstrm->strm_flags & PR_NETIO_SESS_INTR,
+  ck_assert_msg(nstrm->strm_flags & PR_NETIO_SESS_INTR,
     "Failed to set PR_NETIO_SESS_INTR stream flag");
 
   mark_point();
@@ -2153,15 +2153,15 @@ START_TEST (netio_shutdown_test) {
 
   mark_point();
   res = pr_netio_shutdown(NULL, how);
-  fail_unless(res < 0, "Failed to handle null nstrm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null nstrm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   nstrm = pcalloc(p, sizeof(pr_netio_stream_t));
   res = pr_netio_shutdown(nstrm, how);
-  fail_unless(res < 0, "Failed to handle invalid nstrm type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid nstrm type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
@@ -2170,45 +2170,45 @@ START_TEST (netio_shutdown_test) {
 
   /* open/shutdown/close CTRL stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_shutdown(nstrm, how);
-  fail_unless(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
 
   pr_netio_close(nstrm);
   pr_unregister_netio(PR_NETIO_STRM_CTRL);
 
   /* open/shutdown/close DATA stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_DATA);
-  fail_unless(res == 0, "Failed to register custom data NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom data NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open data stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_shutdown(nstrm, how);
-  fail_unless(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
 
   pr_netio_close(nstrm);
   pr_unregister_netio(PR_NETIO_STRM_DATA);
 
   /* open/shutdown/close OTHR stream */
   res = pr_register_netio(netio, PR_NETIO_STRM_OTHR);
-  fail_unless(res == 0, "Failed to register custom othr NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom othr NetIO: %s",
     strerror(errno));
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, fd, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
+  ck_assert_msg(nstrm != NULL, "Failed to open othr stream on fd %d: %s", fd,
     strerror(errno));
 
   res = pr_netio_shutdown(nstrm, how);
-  fail_unless(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to shutdown ctrl stream: %s", strerror(errno));
 
   pr_netio_close(nstrm);
   pr_unregister_netio(PR_NETIO_STRM_OTHR);
@@ -2227,8 +2227,8 @@ START_TEST (netio_register_test) {
   cb = netio->abort;
   netio->abort = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null abort cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null abort cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->abort = cb;
 
@@ -2237,8 +2237,8 @@ START_TEST (netio_register_test) {
   cb = netio->close;
   netio->close = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null close cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null close cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->close = cb;
 
@@ -2247,8 +2247,8 @@ START_TEST (netio_register_test) {
   cb = netio->open;
   netio->open = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null open cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null open cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->open = cb;
 
@@ -2257,8 +2257,8 @@ START_TEST (netio_register_test) {
   cb = netio->poll;
   netio->poll = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null poll cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null poll cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->poll = cb;
 
@@ -2267,8 +2267,8 @@ START_TEST (netio_register_test) {
   cb = netio->postopen;
   netio->postopen = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null postopen cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null postopen cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->postopen = cb;
 
@@ -2277,8 +2277,8 @@ START_TEST (netio_register_test) {
   cb = netio->read;
   netio->read = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null read cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null read cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->read = cb;
 
@@ -2287,8 +2287,8 @@ START_TEST (netio_register_test) {
   cb = netio->reopen;
   netio->reopen = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null reopen cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null reopen cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->reopen = cb;
 
@@ -2297,8 +2297,8 @@ START_TEST (netio_register_test) {
   cb = netio->shutdown;
   netio->shutdown = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null shutdown cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null shutdown cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->shutdown = cb;
 
@@ -2307,8 +2307,8 @@ START_TEST (netio_register_test) {
   cb = netio->write;
   netio->write = NULL;
   res = pr_register_netio(netio, 0);
-  fail_unless(res < 0, "Failed to handle null write cb");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null write cb");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   netio->write = cb;
 }
@@ -2319,13 +2319,13 @@ START_TEST (netio_unregister_test) {
 
   mark_point();
   res = pr_unregister_netio(0);
-  fail_unless(res < 0, "Failed to handle invalid types");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid types");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_unregister_netio(10000);
-  fail_unless(res == 0, "Failed to handle invalid types");
+  ck_assert_msg(res == 0, "Failed to handle invalid types");
 }
 END_TEST
 
@@ -2334,14 +2334,14 @@ START_TEST (netio_get_test) {
 
   mark_point();
   netio = pr_get_netio(0);
-  fail_unless(netio == NULL, "Failed to handle zero type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(netio == NULL, "Failed to handle zero type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   netio = pr_get_netio(1000);
-  fail_unless(netio == NULL, "Failed to handle invalid type");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(netio == NULL, "Failed to handle invalid type");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 }
 END_TEST
@@ -2351,14 +2351,14 @@ START_TEST (netio_alloc_test) {
 
   mark_point();
   netio = pr_alloc_netio2(NULL, NULL, NULL);
-  fail_unless(netio == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(netio == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno));
 
   mark_point();
   netio = pr_alloc_netio(NULL);
-  fail_unless(netio == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(netio == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno));
 }
 END_TEST

--- a/tests/api/netio.c
+++ b/tests/api/netio.c
@@ -2353,13 +2353,13 @@ START_TEST (netio_alloc_test) {
   netio = pr_alloc_netio2(NULL, NULL, NULL);
   ck_assert_msg(netio == NULL, "Failed to handle null pool");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
-    strerror(errno));
+    strerror(errno), errno);
 
   mark_point();
   netio = pr_alloc_netio(NULL);
   ck_assert_msg(netio == NULL, "Failed to handle null pool");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
-    strerror(errno));
+    strerror(errno), errno);
 }
 END_TEST
 

--- a/tests/api/parser.c
+++ b/tests/api/parser.c
@@ -591,18 +591,18 @@ START_TEST (parse_config_path_test) {
 
   text = "TestSuiteEngine on\r\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
   ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
   res = parse_config_path2(p, path, 0);
-  fail_if(res < 0, "Failed to parse '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to parse '%s': %s", path, strerror(errno));
 
   path = "/tmp/prt*.conf";
   res = parse_config_path2(p, path, 0);
-  fail_if(res < 0, "Failed to parse '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to parse '%s': %s", path, strerror(errno));
 
   (void) pr_parser_set_include_opts(PR_PARSER_INCLUDE_OPT_ALLOW_SYMLINKS|PR_PARSER_INCLUDE_OPT_IGNORE_TMP_FILES|PR_PARSER_INCLUDE_OPT_IGNORE_WILDCARDS);
 
@@ -612,7 +612,7 @@ START_TEST (parse_config_path_test) {
 
   text = "TestSuiteEnabled off\r\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
   ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
@@ -620,7 +620,7 @@ START_TEST (parse_config_path_test) {
   mark_point();
   path = "/tmp/prt*.conf*";
   res = parse_config_path2(p, path, 0);
-  fail_if(res < 0, "Failed to parse '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to parse '%s': %s", path, strerror(errno));
 
   mark_point();
   path = "/t*p/prt*.conf*";
@@ -634,7 +634,7 @@ START_TEST (parse_config_path_test) {
   mark_point();
   path = "/t*p/prt*.conf*";
   res = parse_config_path2(p, path, 0);
-  fail_if(res < 0, "Failed to parse '%s': %s", path, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to parse '%s': %s", path, strerror(errno));
 
   (void) pr_parser_server_ctxt_close();
   (void) pr_parser_cleanup();
@@ -683,23 +683,23 @@ START_TEST (parser_parse_file_test) {
 
   text = "TestSuiteEngine on\r\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   text = "TestSuiteEnabled on\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   text = "Include ";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   text = (char *) config_path2;
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   text = "\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
   ck_assert_msg(res == 0, "Failed to write '%s': %s", config_path,
@@ -711,7 +711,7 @@ START_TEST (parser_parse_file_test) {
 
   text = "TestSuiteOptions Bebugging\n";
   res = pr_fsio_write(fh, text, strlen(text));
-  fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
   ck_assert_msg(res == 0, "Failed to write '%s': %s", config_path2,

--- a/tests/api/parser.c
+++ b/tests/api/parser.c
@@ -78,14 +78,14 @@ START_TEST (parser_prepare_test) {
   xaset_t *parsed_servers = NULL;
 
   res = pr_parser_prepare(NULL, NULL);
-  fail_unless(res == 0, "Failed to handle null arguments: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle null arguments: %s", strerror(errno));
 
   res = pr_parser_prepare(p, NULL);
-  fail_unless(res == 0, "Failed to handle null parsed_servers: %s",
+  ck_assert_msg(res == 0, "Failed to handle null parsed_servers: %s",
     strerror(errno));
 
   res = pr_parser_prepare(NULL, &parsed_servers);
-  fail_unless(res == 0, "Failed to handle null pool: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle null pool: %s", strerror(errno));
 
   (void) pr_parser_cleanup();
 }
@@ -97,26 +97,26 @@ START_TEST (parser_cleanup_test) {
 
   mark_point();
   res = pr_parser_cleanup();
-  fail_unless(res == 0, "Failed to handle unprepared parser: %s",
+  ck_assert_msg(res == 0, "Failed to handle unprepared parser: %s",
     strerror(errno));
 
   pr_parser_prepare(NULL, NULL);
 
   mark_point();
   ctx = pr_parser_server_ctxt_open("127.0.0.1");
-  fail_unless(ctx != NULL, "Failed to open server context: %s",
+  ck_assert_msg(ctx != NULL, "Failed to open server context: %s",
     strerror(errno));
 
   mark_point();
   res = pr_parser_cleanup();
-  fail_unless(res < 0, "Failed to handle existing contexts");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle existing contexts");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   (void) pr_parser_server_ctxt_close();
   res = pr_parser_cleanup();
-  fail_unless(res == 0, "Failed to cleanup parser: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to cleanup parser: %s", strerror(errno));
 }
 END_TEST
 
@@ -124,28 +124,28 @@ START_TEST (parser_server_ctxt_test) {
   server_rec *ctx, *res;
 
   ctx = pr_parser_server_ctxt_get();
-  fail_unless(ctx == NULL, "Found server context unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(ctx == NULL, "Found server context unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
 
   mark_point();
   res = pr_parser_server_ctxt_close();
-  fail_unless(res == NULL, "Closed server context unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Closed server context unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno));
 
   mark_point();
   res = pr_parser_server_ctxt_open("127.0.0.1");
-  fail_unless(res != NULL, "Failed to open server context: %s",
+  ck_assert_msg(res != NULL, "Failed to open server context: %s",
     strerror(errno));
 
   mark_point();
   ctx = pr_parser_server_ctxt_get();
-  fail_unless(ctx != NULL, "Failed to get current server context: %s",
+  ck_assert_msg(ctx != NULL, "Failed to get current server context: %s",
     strerror(errno));
-  fail_unless(ctx == res, "Expected server context %p, got %p", res, ctx);
+  ck_assert_msg(ctx == res, "Expected server context %p, got %p", res, ctx);
 
   mark_point();
   (void) pr_parser_server_ctxt_close();
@@ -158,29 +158,29 @@ START_TEST (parser_server_ctxt_push_test) {
   server_rec *ctx, *ctx2;
 
   res = pr_parser_server_ctxt_push(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctx = pcalloc(p, sizeof(server_rec));
 
   mark_point();
   res = pr_parser_server_ctxt_push(ctx);
-  fail_unless(res < 0, "Failed to handle unprepared parser");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle unprepared parser");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
 
   mark_point();
   res = pr_parser_server_ctxt_push(ctx);
-  fail_unless(res == 0, "Failed to push server rec: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to push server rec: %s", strerror(errno));
 
   mark_point();
   ctx2 = pr_parser_server_ctxt_get();
-  fail_unless(ctx2 != NULL, "Failed to get current server context: %s",
+  ck_assert_msg(ctx2 != NULL, "Failed to get current server context: %s",
     strerror(errno));
-  fail_unless(ctx2 == ctx, "Expected server context %p, got %p", ctx, ctx2);
+  ck_assert_msg(ctx2 == ctx, "Expected server context %p, got %p", ctx, ctx2);
 
   (void) pr_parser_server_ctxt_close();
   (void) pr_parser_cleanup();
@@ -192,39 +192,39 @@ START_TEST (parser_config_ctxt_test) {
   config_rec *ctx, *res;
 
   ctx = pr_parser_config_ctxt_get();
-  fail_unless(ctx == NULL, "Found config context unexpectedly");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(ctx == NULL, "Found config context unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
   pr_parser_server_ctxt_open("127.0.0.1");
 
   res = pr_parser_config_ctxt_open(NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_parser_config_ctxt_open("<TestSuite>");
-  fail_unless(res != NULL, "Failed to open config context: %s",
+  ck_assert_msg(res != NULL, "Failed to open config context: %s",
     strerror(errno));
 
   mark_point();
   ctx = pr_parser_config_ctxt_get();
-  fail_unless(ctx != NULL, "Failed to get current config context: %s",
+  ck_assert_msg(ctx != NULL, "Failed to get current config context: %s",
     strerror(errno));
-  fail_unless(ctx == res, "Expected config context %p, got %p", res, ctx);
+  ck_assert_msg(ctx == res, "Expected config context %p, got %p", res, ctx);
 
   mark_point();
   (void) pr_parser_config_ctxt_close(&is_empty);
-  fail_unless(is_empty == TRUE, "Expected config context to be empty");
+  ck_assert_msg(is_empty == TRUE, "Expected config context to be empty");
 
   mark_point();
   res = pr_parser_config_ctxt_open("<Global>");
-  fail_unless(res != NULL, "Failed to open config context: %s",
+  ck_assert_msg(res != NULL, "Failed to open config context: %s",
     strerror(errno));
   (void) pr_parser_config_ctxt_close(&is_empty);
-  fail_unless(is_empty == TRUE, "Expected config context to be empty");
+  ck_assert_msg(is_empty == TRUE, "Expected config context to be empty");
 
   (void) pr_parser_server_ctxt_close();
   (void) pr_parser_cleanup();
@@ -236,29 +236,29 @@ START_TEST (parser_config_ctxt_push_test) {
   config_rec *ctx, *ctx2;
 
   res = pr_parser_config_ctxt_push(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctx = pcalloc(p, sizeof(config_rec));
 
   mark_point();
   res = pr_parser_config_ctxt_push(ctx);
-  fail_unless(res < 0, "Failed to handle unprepared parser");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle unprepared parser");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
 
   mark_point();
   res = pr_parser_config_ctxt_push(ctx);
-  fail_unless(res == 0, "Failed to push config rec: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to push config rec: %s", strerror(errno));
 
   mark_point();
   ctx2 = pr_parser_config_ctxt_get();
-  fail_unless(ctx2 != NULL, "Failed to get current config context: %s",
+  ck_assert_msg(ctx2 != NULL, "Failed to get current config context: %s",
     strerror(errno));
-  fail_unless(ctx2 == ctx, "Expected config context %p, got %p", ctx, ctx2);
+  ck_assert_msg(ctx2 == ctx, "Expected config context %p, got %p", ctx, ctx2);
 
   (void) pr_parser_config_ctxt_close(NULL);
   (void) pr_parser_cleanup();
@@ -269,10 +269,10 @@ START_TEST (parser_get_lineno_test) {
   unsigned int res;
 
   res = pr_parser_get_lineno();
-  fail_unless(res == 0, "Expected 0, got %u", res);
+  ck_assert_msg(res == 0, "Expected 0, got %u", res);
 
   res = pr_parser_get_lineno();
-  fail_unless(res == 0, "Expected 0, got %u", res);
+  ck_assert_msg(res == 0, "Expected 0, got %u", res);
 }
 END_TEST
 
@@ -280,8 +280,8 @@ START_TEST (parser_read_line_test) {
   char *res;
 
   res = pr_parser_read_line(NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -293,19 +293,19 @@ START_TEST (parser_parse_line_test) {
 
   mark_point();
   cmd = pr_parser_parse_line(NULL, NULL, 0);
-  fail_unless(cmd == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(cmd == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   cmd = pr_parser_parse_line(p, NULL, 0);
-  fail_unless(cmd == NULL, "Failed to handle null input");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(cmd == NULL, "Failed to handle null input");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_parser_parse_line(p, "", 0);
-  fail_unless(cmd == NULL, "Failed to handle empty input");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(cmd == NULL, "Failed to handle empty input");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
@@ -313,25 +313,25 @@ START_TEST (parser_parse_line_test) {
 
   text = pstrdup(p, "FooBar");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 1, "Expected 1, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], text) == 0,
+  ck_assert_msg(cmd->argc == 1, "Expected 1, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], text) == 0,
     "Expected '%s', got '%s'", text, (char *) cmd->argv[0]);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 1, "Expected lineno 1, got %u", lineno);
+  ck_assert_msg(lineno != 1, "Expected lineno 1, got %u", lineno);
 
   text = pstrdup(p, "FooBar baz quxx");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 3, "Expected 3, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "FooBar") == 0,
+  ck_assert_msg(cmd->argc == 3, "Expected 3, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "FooBar") == 0,
     "Expected 'FooBar', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "baz quxx") == 0,
+  ck_assert_msg(strcmp(cmd->arg, "baz quxx") == 0,
     "Expected 'baz quxx', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 2, "Expected lineno 2, got %u", lineno);
+  ck_assert_msg(lineno != 2, "Expected lineno 2, got %u", lineno);
 
   /* Deliberately omit the trailing '}', to test our handling of malformed
    * inputs.
@@ -339,41 +339,41 @@ START_TEST (parser_parse_line_test) {
   mark_point();
   text = pstrdup(p, "BarBaz %{env:FOO_TEST");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+  ck_assert_msg(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "%{env:FOO_TEST") == 0,
+  ck_assert_msg(strcmp(cmd->arg, "%{env:FOO_TEST") == 0,
     "Expected '%{env:FOO_TEST', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+  ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 
   mark_point();
   pr_env_set(p, "FOO_TEST", "BAR");
   text = pstrdup(p, "BarBaz %{env:FOO_TEST}");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+  ck_assert_msg(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "BAR") == 0,
+  ck_assert_msg(strcmp(cmd->arg, "BAR") == 0,
     "Expected 'BAR', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+  ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 
   /* This time, without the requested environment variable present. */
   pr_env_unset(p, "FOO_TEST");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 1, "Expected 1, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+  ck_assert_msg(cmd->argc == 1, "Expected 1, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "") == 0, "Expected '', got '%s'", cmd->arg);
+  ck_assert_msg(strcmp(cmd->arg, "") == 0, "Expected '', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+  ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 
   /* This time, with a single word containing multiple environment variables
    * (Issue #507).
@@ -382,15 +382,15 @@ START_TEST (parser_parse_line_test) {
   pr_env_set(p, "BAR_TEST", "baR");
   text = pstrdup(p, "BarBaz %{env:FOO_TEST}@%{env:BAR_TEST}");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+  ck_assert_msg(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "Foo@baR") == 0,
+  ck_assert_msg(strcmp(cmd->arg, "Foo@baR") == 0,
     "Expected 'Foo@baR', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+  ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 
   /* This time, with a single word containing multiple environment variables
    * where one of the variables is NOT present (Issue #857).
@@ -398,25 +398,25 @@ START_TEST (parser_parse_line_test) {
   pr_env_set(p, "FOO_TEST", "Foo");
   text = pstrdup(p, "BarBaz %{env:FOO_TEST}@%{env:BAZ_TEST}");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "BarBaz") == 0,
+  ck_assert_msg(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
-  fail_unless(strcmp(cmd->arg, "Foo@") == 0,
+  ck_assert_msg(strcmp(cmd->arg, "Foo@") == 0,
     "Expected 'Foo@', got '%s'", cmd->arg);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 3, "Expected lineno 3, got %u", lineno);
+  ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 
   text = pstrdup(p, "<FooBar baz>");
   cmd = pr_parser_parse_line(p, text, 0);
-  fail_unless(cmd != NULL, "Failed to parse text '%s': %s", text,
+  ck_assert_msg(cmd != NULL, "Failed to parse text '%s': %s", text,
     strerror(errno));
-  fail_unless(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
-  fail_unless(strcmp(cmd->argv[0], "<FooBar>") == 0,
+  ck_assert_msg(cmd->argc == 2, "Expected 2, got %d", cmd->argc);
+  ck_assert_msg(strcmp(cmd->argv[0], "<FooBar>") == 0,
     "Expected '<FooBar>', got '%s'", (char *) cmd->argv[0]);
   lineno = pr_parser_get_lineno();
-  fail_unless(lineno != 5, "Expected lineno 5, got %u", lineno);
+  ck_assert_msg(lineno != 5, "Expected lineno 5, got %u", lineno);
 
   mark_point();
   (void) pr_parser_server_ctxt_close();
@@ -461,32 +461,32 @@ START_TEST (parse_config_path_test) {
 
   mark_point();
   res = parse_config_path(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = parse_config_path2(p, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   path = "foo";
-  fail_unless(res < 0, "Failed to handle relative path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle relative path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = parse_config_path2(p, path, 1024);
-  fail_unless(res < 0, "Failed to handle excessive depth");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle excessive depth");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = parse_config_path2(p, path, 0);
-  fail_unless(res < 0, "Failed to handle invalid path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -495,22 +495,22 @@ START_TEST (parse_config_path_test) {
    * thus make a more predictable directory for our testing.
    */
   res = mkdir(config_path3, 0775);
-  fail_unless(res == 0, "Failed to mkdir '%s': %s", config_path3,
+  ck_assert_msg(res == 0, "Failed to mkdir '%s': %s", config_path3,
     strerror(errno));
 
   path = config_path3;
   res = lstat(path, &st);
-  fail_unless(res == 0, "Failed lstat(2) on '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed lstat(2) on '%s': %s", path, strerror(errno));
 
   mark_point();
   res = parse_config_path2(p, path, 0);
   if (S_ISLNK(st.st_mode)) {
-    fail_unless(res < 0, "Failed to handle uninitialized parser");
-    fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+    ck_assert_msg(res < 0, "Failed to handle uninitialized parser");
+    ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
       strerror(errno), errno);
 
   } else if (S_ISDIR(st.st_mode)) {
-    fail_unless(res == 0, "Failed to handle empty directory");
+    ck_assert_msg(res == 0, "Failed to handle empty directory");
   }
 
   mark_point();
@@ -519,31 +519,31 @@ START_TEST (parse_config_path_test) {
 
   res = parse_config_path2(p, path, 0);
   if (S_ISLNK(st.st_mode)) {
-    fail_unless(res < 0, "Failed to handle directory-only path");
-    fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+    ck_assert_msg(res < 0, "Failed to handle directory-only path");
+    ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
       strerror(errno), errno);
 
   } else if (S_ISDIR(st.st_mode)) {
-    fail_unless(res == 0, "Failed to handle empty directory");
+    ck_assert_msg(res == 0, "Failed to handle empty directory");
   }
 
   res = rmdir(config_path3);
-  fail_unless(res == 0, "Failed to rmdir '%s': %s", config_path3,
+  ck_assert_msg(res == 0, "Failed to rmdir '%s': %s", config_path3,
     strerror(errno));
 
   mark_point();
   path = config_path;
   res = parse_config_path2(p, path, 0);
-  fail_unless(res < 0, "Failed to handle nonexistent file");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   include_opts = pr_parser_set_include_opts(PR_PARSER_INCLUDE_OPT_IGNORE_WILDCARDS);
   mark_point();
   path = "/tmp*/foo.conf";
   res = parse_config_path2(p, path, 0);
-  fail_unless(res < 0, "Failed to handle directory-only path");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle directory-only path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   (void) pr_parser_set_include_opts(include_opts);
 
@@ -552,49 +552,49 @@ START_TEST (parse_config_path_test) {
    * we're on a Mac.
    */
   res = lstat("/tmp", &st);
-  fail_unless(res == 0, "Failed lstat(2) on '/tmp': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed lstat(2) on '/tmp': %s", strerror(errno));
 
   mark_point();
   path = "/tmp/prt*foo*bar*.conf";
   res = parse_config_path2(p, path, 0);
 
   if (S_ISLNK(st.st_mode)) {
-    fail_unless(res < 0, "Failed to handle nonexistent file");
-    fail_unless(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
+    ck_assert_msg(res < 0, "Failed to handle nonexistent file");
+    ck_assert_msg(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
       strerror(errno), errno);
 
     include_opts = pr_parser_set_include_opts(PR_PARSER_INCLUDE_OPT_ALLOW_SYMLINKS);
 
     /* By default, we ignore the case where there are no matching files. */
     res = parse_config_path2(p, path, 0);
-    fail_unless(res == 0, "Failed to handle nonexistent file: %s",
+    ck_assert_msg(res == 0, "Failed to handle nonexistent file: %s",
       strerror(errno));
 
     (void) pr_parser_set_include_opts(include_opts);
 
   } else {
     /* By default, we ignore the case where there are no matching files. */
-    fail_unless(res == 0, "Failed to handle nonexistent file: %s",
+    ck_assert_msg(res == 0, "Failed to handle nonexistent file: %s",
       strerror(errno));
   }
 
   /* Load the module's config handlers. */
   res = load_parser_module();
-  fail_unless(res == 0, "Failed to load module conftab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module conftab: %s", strerror(errno));
 
   include_opts = pr_parser_set_include_opts(PR_PARSER_INCLUDE_OPT_ALLOW_SYMLINKS);
 
   /* Parse single file. */
   path = config_path;
   fh = pr_fsio_open(path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
 
   text = "TestSuiteEngine on\r\n";
   res = pr_fsio_write(fh, text, strlen(text));
   fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
   res = parse_config_path2(p, path, 0);
@@ -608,14 +608,14 @@ START_TEST (parse_config_path_test) {
 
   path = config_tmp_path;
   fh = pr_fsio_open(path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", path, strerror(errno));
 
   text = "TestSuiteEnabled off\r\n";
   res = pr_fsio_write(fh, text, strlen(text));
   fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to write '%s': %s", path, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", path, strerror(errno));
 
   mark_point();
   path = "/tmp/prt*.conf*";
@@ -625,8 +625,8 @@ START_TEST (parse_config_path_test) {
   mark_point();
   path = "/t*p/prt*.conf*";
   res = parse_config_path2(p, path, 0);
-  fail_unless(res < 0, "Failed to handle wildcard path '%s'", path);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle wildcard path '%s'", path);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_parser_set_include_opts(PR_PARSER_INCLUDE_OPT_ALLOW_SYMLINKS|PR_PARSER_INCLUDE_OPT_IGNORE_TMP_FILES);
@@ -652,14 +652,14 @@ START_TEST (parser_parse_file_test) {
 
   mark_point();
   res = pr_parser_parse_file(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_parser_parse_file(p, config_path, NULL, 0);
-  fail_unless(res < 0, "Failed to handle invalid file");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid file");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   pr_parser_prepare(p, NULL);
@@ -667,18 +667,18 @@ START_TEST (parser_parse_file_test) {
 
   mark_point();
   res = pr_parser_parse_file(p, config_path, NULL, 0);
-  fail_unless(res < 0, "Failed to handle invalid file");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle invalid file");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_parser_parse_file(p, "/tmp", NULL, 0);
-  fail_unless(res < 0, "Failed to handle directory");
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle directory");
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   fh = pr_fsio_open(config_path, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", config_path,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", config_path,
     strerror(errno));
 
   text = "TestSuiteEngine on\r\n";
@@ -702,11 +702,11 @@ START_TEST (parser_parse_file_test) {
   fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to write '%s': %s", config_path,
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", config_path,
     strerror(errno));
 
   fh = pr_fsio_open(config_path2, O_CREAT|O_EXCL|O_WRONLY);
-  fail_unless(fh != NULL, "Failed to open '%s': %s", config_path2,
+  ck_assert_msg(fh != NULL, "Failed to open '%s': %s", config_path2,
     strerror(errno));
 
   text = "TestSuiteOptions Bebugging\n";
@@ -714,22 +714,22 @@ START_TEST (parser_parse_file_test) {
   fail_if(res < 0, "Failed to write '%s': %s", text, strerror(errno));
 
   res = pr_fsio_close(fh);
-  fail_unless(res == 0, "Failed to write '%s': %s", config_path2,
+  ck_assert_msg(res == 0, "Failed to write '%s': %s", config_path2,
     strerror(errno));
 
   mark_point();
 
   /* Load the module's config handlers. */
   res = load_parser_module();
-  fail_unless(res == 0, "Failed to load module conftab: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to load module conftab: %s", strerror(errno));
 
   res = pr_parser_parse_file(p, config_path, NULL, PR_PARSER_FL_DYNAMIC_CONFIG);
-  fail_unless(res == 0, "Failed to parse '%s': %s", config_path,
+  ck_assert_msg(res == 0, "Failed to parse '%s': %s", config_path,
     strerror(errno));
 
   res = pr_parser_parse_file(p, config_path, NULL, 0);
-  fail_unless(res < 0, "Parsed '%s' unexpectedly", config_path);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Parsed '%s' unexpectedly", config_path);
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   (void) pr_parser_server_ctxt_close();

--- a/tests/api/parser.c
+++ b/tests/api/parser.c
@@ -134,7 +134,7 @@ START_TEST (parser_server_ctxt_test) {
   res = pr_parser_server_ctxt_close();
   ck_assert_msg(res == NULL, "Closed server context unexpectedly");
   ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
-    strerror(errno));
+    strerror(errno), errno);
 
   mark_point();
   res = pr_parser_server_ctxt_open("127.0.0.1");
@@ -345,7 +345,7 @@ START_TEST (parser_parse_line_test) {
   ck_assert_msg(strcmp(cmd->argv[0], "BarBaz") == 0,
     "Expected 'BarBaz', got '%s'", (char *) cmd->argv[0]);
   ck_assert_msg(strcmp(cmd->arg, "%{env:FOO_TEST") == 0,
-    "Expected '%{env:FOO_TEST', got '%s'", cmd->arg);
+    "Expected '%s', got '%s'", "%{env:FOO_TEST", cmd->arg);
   lineno = pr_parser_get_lineno();
   ck_assert_msg(lineno != 3, "Expected lineno 3, got %u", lineno);
 

--- a/tests/api/pidfile.c
+++ b/tests/api/pidfile.c
@@ -53,23 +53,23 @@ START_TEST (pidfile_set_test) {
   const char *path;
 
   res = pr_pidfile_set(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   path = "foo";
   res = pr_pidfile_set(path);
-  fail_unless(res < 0, "Failed to handle relative path");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle relative path");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   path = "/foo";
   res = pr_pidfile_set(path);
-  fail_unless(res == 0, "Failed to handle path '%s': %s", path,
+  ck_assert_msg(res == 0, "Failed to handle path '%s': %s", path,
     strerror(errno));
 
   path = pr_pidfile_get();
-  fail_unless(strcmp(path, "/foo") == 0, "Expected path '/foo', got '%s'",
+  ck_assert_msg(strcmp(path, "/foo") == 0, "Expected path '/foo', got '%s'",
     path);
 }
 END_TEST
@@ -78,8 +78,8 @@ START_TEST (pidfile_remove_test) {
   int res;
 
   res = pr_pidfile_remove();
-  fail_unless(res < 0, "Removed nonexistent file unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res < 0, "Removed nonexistent file unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -88,20 +88,20 @@ START_TEST (pidfile_write_test) {
   int res;
 
   res = pr_pidfile_set(pidfile_path);
-  fail_unless(res == 0, "Failed to set path '%s': %s", pidfile_path,
+  ck_assert_msg(res == 0, "Failed to set path '%s': %s", pidfile_path,
     strerror(errno));
 
   res = pr_pidfile_write();
-  fail_unless(res == 0, "Failed to write to path '%s': %s", pidfile_path,
+  ck_assert_msg(res == 0, "Failed to write to path '%s': %s", pidfile_path,
     strerror(errno));
 
   res = pr_pidfile_remove();
-  fail_unless(res == 0, "Failed to remove path '%s': %s", pidfile_path,
+  ck_assert_msg(res == 0, "Failed to remove path '%s': %s", pidfile_path,
     strerror(errno));
 
   res = pr_pidfile_remove();
-  fail_unless(res < 0, "Removed nonexistent file unexpectedly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res < 0, "Removed nonexistent file unexpectedly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST

--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -84,14 +84,14 @@ START_TEST (pool_make_sub_pool_test) {
   pool *p, *sub_pool;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
   destroy_pool(p);
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sub_pool = make_sub_pool(p);
-  fail_if(sub_pool == NULL, "Failed to allocate sub pool");
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate sub pool");
 
   destroy_pool(p);
 }
@@ -102,21 +102,21 @@ START_TEST (pool_create_sz_test) {
   size_t sz;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sz = 0;
   sub_pool = pr_pool_create_sz(p, sz);
-  fail_if(sub_pool == NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
   destroy_pool(sub_pool);
 
   sz = 1;
   sub_pool = pr_pool_create_sz(p, sz);
-  fail_if(sub_pool == NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
   destroy_pool(sub_pool);
 
   sz = 16382;
   sub_pool = pr_pool_create_sz(p, sz);
-  fail_if(sub_pool == NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
   destroy_pool(sub_pool);
 
   destroy_pool(p);
@@ -144,7 +144,7 @@ START_TEST (pool_create_sz_with_alloc_test) {
     fprintf(stdout, "pool_sz: %lu bytes (factor %u)\n", pool_sz, factors[i]);
 #endif /* PR_TEST_VERBOSE */
     sub_pool = pr_pool_create_sz(p, pool_sz);
-    fail_if(sub_pool == NULL, "Failed to allocate %u byte sub-pool", pool_sz);
+    ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", pool_sz);
 
     alloc_sz = (pool_sz * 2);
 #ifdef PR_TEST_VERBOSE
@@ -168,7 +168,7 @@ START_TEST (pool_create_sz_with_alloc_test) {
           i + 1, j, j, data[j]);
       }
 #endif /* PR_TEST_VERBOSE */
-      fail_if(data[j] != j,
+      ck_assert_msg(data[j] == j,
         "Iteration #%u: Expected value %u at memory index %u, got %u\n", i + 1,
         j, j, data[j]);
     }
@@ -186,7 +186,7 @@ START_TEST (pool_palloc_test) {
   size_t sz;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sz = 0;
   v = palloc(p, sz);
@@ -194,11 +194,11 @@ START_TEST (pool_palloc_test) {
 
   sz = 1;
   v = palloc(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   sz = 16382;
   v = palloc(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   destroy_pool(p);
 }
@@ -210,7 +210,7 @@ START_TEST (pool_pallocsz_test) {
   size_t sz;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sz = 0;
   v = pallocsz(p, sz);
@@ -218,11 +218,11 @@ START_TEST (pool_pallocsz_test) {
 
   sz = 1;
   v = pallocsz(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   sz = 16382;
   v = pallocsz(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   destroy_pool(p);
 }
@@ -235,7 +235,7 @@ START_TEST (pool_pcalloc_test) {
   size_t sz;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sz = 0;
   v = pcalloc(p, sz);
@@ -243,14 +243,14 @@ START_TEST (pool_pcalloc_test) {
 
   sz = 1;
   v = pcalloc(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
   for (i = 0; i < sz; i++) {
     ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
 
   sz = 16382;
   v = pcalloc(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
   for (i = 0; i < sz; i++) {
     ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
@@ -265,7 +265,7 @@ START_TEST (pool_pcallocsz_test) {
   size_t sz;
 
   p = make_sub_pool(NULL);
-  fail_if(p == NULL, "Failed to allocate parent pool");
+  ck_assert_msg(p != NULL, "Failed to allocate parent pool");
 
   sz = 0;
   v = pcallocsz(p, sz);
@@ -273,11 +273,11 @@ START_TEST (pool_pcallocsz_test) {
 
   sz = 1;
   v = pcallocsz(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   sz = 16382;
   v = pcallocsz(p, sz);
-  fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
 
   destroy_pool(p);
 }
@@ -334,7 +334,7 @@ START_TEST (pool_debug_flags_test) {
     strerror(errno), errno);
 
   res = pr_pool_debug_set_flags(0);
-  fail_if(res < 0, "Failed to set flags: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to set flags: %s", strerror(errno));
 }
 END_TEST
 

--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -190,7 +190,7 @@ START_TEST (pool_palloc_test) {
 
   sz = 0;
   v = palloc(p, sz);
-  fail_unless(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
 
   sz = 1;
   v = palloc(p, sz);
@@ -214,7 +214,7 @@ START_TEST (pool_pallocsz_test) {
 
   sz = 0;
   v = pallocsz(p, sz);
-  fail_unless(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
 
   sz = 1;
   v = pallocsz(p, sz);
@@ -239,20 +239,20 @@ START_TEST (pool_pcalloc_test) {
 
   sz = 0;
   v = pcalloc(p, sz);
-  fail_unless(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
 
   sz = 1;
   v = pcalloc(p, sz);
   fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
   for (i = 0; i < sz; i++) {
-    fail_unless(v[i] == 0, "Allocated non-zero memory at position %u", i);
+    ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
 
   sz = 16382;
   v = pcalloc(p, sz);
   fail_if(v == NULL, "Failed to allocate %u-len memory", sz);
   for (i = 0; i < sz; i++) {
-    fail_unless(v[i] == 0, "Allocated non-zero memory at position %u", i);
+    ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
 
   destroy_pool(p);
@@ -269,7 +269,7 @@ START_TEST (pool_pcallocsz_test) {
 
   sz = 0;
   v = pcallocsz(p, sz);
-  fail_unless(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
 
   sz = 1;
   v = pcallocsz(p, sz);
@@ -306,19 +306,19 @@ START_TEST (pool_get_tag_test) {
   const char *res;
 
   res = pr_pool_get_tag(NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
 
   p = make_sub_pool(permanent_pool);
 
   mark_point();
   res = pr_pool_get_tag(p);
-  fail_unless(res == NULL, "Failed to handle untagged pool");
+  ck_assert_msg(res == NULL, "Failed to handle untagged pool");
 
   mark_point();
   pr_pool_tag(p, "foo");
   res = pr_pool_get_tag(p);
-  fail_unless(res != NULL, "Failed to get pool tag: %s", strerror(errno));
-  fail_unless(strcmp(res, "foo") == 0, "Expected tag 'foo', got '%s'", res);
+  ck_assert_msg(res != NULL, "Failed to get pool tag: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "foo") == 0, "Expected tag 'foo', got '%s'", res);
 
   destroy_pool(p);
 
@@ -329,8 +329,8 @@ START_TEST (pool_debug_flags_test) {
   int res;
 
   res = pr_pool_debug_set_flags(-1);
-  fail_unless(res < 0, "Failed to handle invalid flags");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid flags");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_pool_debug_set_flags(0);
@@ -366,7 +366,7 @@ START_TEST (pool_debug_memory_test) {
 END_TEST
 
 static void test_visitf(const pr_pool_info_t *pinfo, void *user_data) {
-  fail_unless(pinfo != NULL, "Expected pool info, got NULL");
+  ck_assert_msg(pinfo != NULL, "Expected pool info, got NULL");
 }
 
 START_TEST (pool_debug_memory2_test) {
@@ -416,7 +416,7 @@ START_TEST (pool_register_cleanup_test) {
 
   register_cleanup(p, NULL, cleanup_cb, cleanup_cb);
   destroy_pool(p);
-  fail_unless(pool_cleanup_count > 0, "Expected cleanup count >0, got %u",
+  ck_assert_msg(pool_cleanup_count > 0, "Expected cleanup count >0, got %u",
     pool_cleanup_count);
 }
 END_TEST
@@ -435,7 +435,7 @@ START_TEST (pool_register_cleanup2_test) {
 
   register_cleanup2(p, NULL, cleanup_cb);
   destroy_pool(p);
-  fail_unless(pool_cleanup_count > 0, "Expected cleanup count >0, got %u",
+  ck_assert_msg(pool_cleanup_count > 0, "Expected cleanup count >0, got %u",
     pool_cleanup_count);
 }
 END_TEST
@@ -452,17 +452,17 @@ START_TEST (pool_unregister_cleanup_test) {
   p = make_sub_pool(permanent_pool);
   register_cleanup(p, NULL, cleanup_cb, cleanup_cb);
   unregister_cleanup(p, NULL, NULL);
-  fail_unless(pool_cleanup_count == 0, "Expected cleanup count 0, got %u",
+  ck_assert_msg(pool_cleanup_count == 0, "Expected cleanup count 0, got %u",
     pool_cleanup_count);
 
   pool_cleanup_count = 0;
   register_cleanup(p, NULL, cleanup_cb, cleanup_cb);
   unregister_cleanup(p, NULL, cleanup_cb);
-  fail_unless(pool_cleanup_count == 0, "Expected cleanup count >0, got %u",
+  ck_assert_msg(pool_cleanup_count == 0, "Expected cleanup count >0, got %u",
     pool_cleanup_count);
 
   destroy_pool(p);
-  fail_unless(pool_cleanup_count == 0, "Expected cleanup count >0, got %u",
+  ck_assert_msg(pool_cleanup_count == 0, "Expected cleanup count >0, got %u",
     pool_cleanup_count);
 }
 END_TEST

--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -106,17 +106,17 @@ START_TEST (pool_create_sz_test) {
 
   sz = 0;
   sub_pool = pr_pool_create_sz(p, sz);
-  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %lu byte sub-pool", (unsigned long)sz);
   destroy_pool(sub_pool);
 
   sz = 1;
   sub_pool = pr_pool_create_sz(p, sz);
-  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %lu byte sub-pool", (unsigned long)sz);
   destroy_pool(sub_pool);
 
   sz = 16382;
   sub_pool = pr_pool_create_sz(p, sz);
-  ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", sz);
+  ck_assert_msg(sub_pool != NULL, "Failed to allocate %lu byte sub-pool", (unsigned long)sz);
   destroy_pool(sub_pool);
 
   destroy_pool(p);
@@ -144,11 +144,11 @@ START_TEST (pool_create_sz_with_alloc_test) {
     fprintf(stdout, "pool_sz: %lu bytes (factor %u)\n", pool_sz, factors[i]);
 #endif /* PR_TEST_VERBOSE */
     sub_pool = pr_pool_create_sz(p, pool_sz);
-    ck_assert_msg(sub_pool != NULL, "Failed to allocate %u byte sub-pool", pool_sz);
+    ck_assert_msg(sub_pool != NULL, "Failed to allocate %lu byte sub-pool", (unsigned long)pool_sz);
 
     alloc_sz = (pool_sz * 2);
 #ifdef PR_TEST_VERBOSE
-    fprintf(stdout, "alloc_sz: %lu bytes (factor %u)\n", alloc_sz, factors[i]);
+    fprintf(stdout, "alloc_sz: %lu bytes (factor %u)\n", (unsigned long)alloc_sz, factors[i]);
 #endif /* PR_TEST_VERBOSE */
     data = palloc(sub_pool, alloc_sz);
 
@@ -190,15 +190,15 @@ START_TEST (pool_palloc_test) {
 
   sz = 0;
   v = palloc(p, sz);
-  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %lu-len memory", (unsigned long)sz);
 
   sz = 1;
   v = palloc(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   sz = 16382;
   v = palloc(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   destroy_pool(p);
 }
@@ -214,15 +214,15 @@ START_TEST (pool_pallocsz_test) {
 
   sz = 0;
   v = pallocsz(p, sz);
-  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %lu-len memory", (unsigned long)sz);
 
   sz = 1;
   v = pallocsz(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   sz = 16382;
   v = pallocsz(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   destroy_pool(p);
 }
@@ -239,18 +239,18 @@ START_TEST (pool_pcalloc_test) {
 
   sz = 0;
   v = pcalloc(p, sz);
-  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %lu-len memory", (unsigned long)sz);
 
   sz = 1;
   v = pcalloc(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
   for (i = 0; i < sz; i++) {
     ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
 
   sz = 16382;
   v = pcalloc(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
   for (i = 0; i < sz; i++) {
     ck_assert_msg(v[i] == 0, "Allocated non-zero memory at position %u", i);
   }
@@ -269,15 +269,15 @@ START_TEST (pool_pcallocsz_test) {
 
   sz = 0;
   v = pcallocsz(p, sz);
-  ck_assert_msg(v == NULL, "Allocated %u-len memory", sz);
+  ck_assert_msg(v == NULL, "Allocated %lu-len memory", (unsigned long)sz);
 
   sz = 1;
   v = pcallocsz(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   sz = 16382;
   v = pcallocsz(p, sz);
-  ck_assert_msg(v != NULL, "Failed to allocate %u-len memory", sz);
+  ck_assert_msg(v != NULL, "Failed to allocate %lu-len memory", (unsigned long)sz);
 
   destroy_pool(p);
 }

--- a/tests/api/privs.c
+++ b/tests/api/privs.c
@@ -65,7 +65,7 @@ START_TEST (privs_set_nonroot_daemon_test) {
     strerror(errno), errno);
 
   nonroot = set_nonroot_daemon(TRUE);
-  fail_if(nonroot != FALSE && nonroot != TRUE,  "Expected true/false, got %d",
+  ck_assert_msg(nonroot == FALSE || nonroot == TRUE,  "Expected true/false, got %d",
     nonroot);
   set_nonroot_daemon(nonroot);
 }

--- a/tests/api/privs.c
+++ b/tests/api/privs.c
@@ -60,8 +60,8 @@ START_TEST (privs_set_nonroot_daemon_test) {
   int nonroot, res;
 
   res = set_nonroot_daemon(-1);
-  fail_unless(res < 0, "Failed to handle non-Boolean parameter");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle non-Boolean parameter");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   nonroot = set_nonroot_daemon(TRUE);
@@ -76,19 +76,19 @@ START_TEST (privs_setup_test) {
 
   if (privs_uid != 0) {
     res = pr_privs_setup(privs_uid, privs_gid, __FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to setup privs: %s", strerror(errno));
-    fail_unless(session.uid == privs_uid, "Expected %lu, got %lu",
+    ck_assert_msg(res == 0, "Failed to setup privs: %s", strerror(errno));
+    ck_assert_msg(session.uid == privs_uid, "Expected %lu, got %lu",
       (unsigned long) privs_uid, (unsigned long) session.uid);
-    fail_unless(session.gid == privs_gid, "Expected %lu, got %lu",
+    ck_assert_msg(session.gid == privs_gid, "Expected %lu, got %lu",
       (unsigned long) privs_gid, (unsigned long) session.gid);
 
     nonroot = set_nonroot_daemon(FALSE);
 
     res = pr_privs_setup(privs_uid, privs_gid, __FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to setup privs: %s", strerror(errno));
-    fail_unless(session.uid == privs_uid, "Expected %lu, got %lu",
+    ck_assert_msg(res == 0, "Failed to setup privs: %s", strerror(errno));
+    ck_assert_msg(session.uid == privs_uid, "Expected %lu, got %lu",
       (unsigned long) privs_uid, (unsigned long) session.uid);
-    fail_unless(session.gid == privs_gid, "Expected %lu, got %lu",
+    ck_assert_msg(session.gid == privs_gid, "Expected %lu, got %lu",
       (unsigned long) privs_gid, (unsigned long) session.gid);
 
     set_nonroot_daemon(nonroot);
@@ -101,12 +101,12 @@ START_TEST (privs_root_test) {
 
   if (privs_uid != 0) {
     res = pr_privs_root(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to set root privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to set root privs: %s", strerror(errno));
 
     nonroot = set_nonroot_daemon(FALSE);
 
     res = pr_privs_root(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to set root privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to set root privs: %s", strerror(errno));
 
     set_nonroot_daemon(nonroot);
   }
@@ -118,12 +118,12 @@ START_TEST (privs_user_test) {
 
   if (privs_uid != 0) {
     res = pr_privs_user(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to set user privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to set user privs: %s", strerror(errno));
 
     nonroot = set_nonroot_daemon(FALSE);
 
     res = pr_privs_user(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to set user privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to set user privs: %s", strerror(errno));
 
     set_nonroot_daemon(nonroot);
   }
@@ -135,12 +135,12 @@ START_TEST (privs_relinquish_test) {
 
   if (privs_uid != 0) {
     res = pr_privs_relinquish(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to relinquish privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to relinquish privs: %s", strerror(errno));
 
     nonroot = set_nonroot_daemon(FALSE);
 
     res = pr_privs_relinquish(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to relinquish privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to relinquish privs: %s", strerror(errno));
 
     set_nonroot_daemon(nonroot);
   }
@@ -152,12 +152,12 @@ START_TEST (privs_revoke_test) {
 
   if (privs_uid != 0) {
     res = pr_privs_revoke(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to revoke privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to revoke privs: %s", strerror(errno));
 
     nonroot = set_nonroot_daemon(FALSE);
 
     res = pr_privs_revoke(__FILE__, __LINE__);
-    fail_unless(res == 0, "Failed to revoke privs: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to revoke privs: %s", strerror(errno));
 
     set_nonroot_daemon(nonroot);
   }

--- a/tests/api/random.c
+++ b/tests/api/random.c
@@ -88,7 +88,7 @@ START_TEST (random_next_range_1000_test) {
    * good, right?
    */
   for (i = 0; i < count; i++) {
-    fail_unless(seen[i] == 1, "Expected to have generated number %d", i);
+    ck_assert_msg(seen[i] == 1, "Expected to have generated number %d", i);
   }
 }
 END_TEST

--- a/tests/api/random.c
+++ b/tests/api/random.c
@@ -58,8 +58,8 @@ START_TEST (random_next_range_10_test) {
     long num;
 
     num = pr_random_next(min, max);
-    fail_if(num < min, "random number %ld less than minimum %ld", num, min);
-    fail_if(num > max, "random number %ld greater than maximum %ld", num, max);
+    ck_assert_msg(num >= min, "random number %ld less than minimum %ld", num, min);
+    ck_assert_msg(num <= max, "random number %ld greater than maximum %ld", num, max);
   }
 }
 END_TEST
@@ -78,8 +78,8 @@ START_TEST (random_next_range_1000_test) {
     long num;
 
     num = pr_random_next(min, max);
-    fail_if(num < min, "random number %ld less than minimum %ld", num, min);
-    fail_if(num > max, "random number %ld greater than maximum %ld", num, max);
+    ck_assert_msg(num >= min, "random number %ld less than minimum %ld", num, min);
+    ck_assert_msg(num <= max, "random number %ld greater than maximum %ld", num, max);
 
     seen[num] = 1;
   }

--- a/tests/api/redis.c
+++ b/tests/api/redis.c
@@ -82,8 +82,8 @@ START_TEST (redis_conn_destroy_test) {
 
   mark_point();
   res = pr_redis_conn_destroy(NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -93,8 +93,8 @@ START_TEST (redis_conn_close_test) {
 
   mark_point();
   res = pr_redis_conn_close(NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -105,18 +105,18 @@ START_TEST (redis_conn_new_test) {
 
   mark_point();
   redis = pr_redis_conn_new(NULL, NULL, 0);
-  fail_unless(redis == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(redis == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 
   if (getenv("CI") == NULL &&
       getenv("CIRRUS_CLONE_DEPTH") == NULL &&
@@ -126,8 +126,8 @@ START_TEST (redis_conn_new_test) {
 
     mark_point();
     redis = pr_redis_conn_new(p, NULL, 0);
-    fail_unless(redis == NULL, "Failed to handle invalid address");
-    fail_unless(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
+    ck_assert_msg(redis == NULL, "Failed to handle invalid address");
+    ck_assert_msg(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
       strerror(errno), errno);
   }
 
@@ -135,8 +135,8 @@ START_TEST (redis_conn_new_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis == NULL, "Failed to handle invalid port");
-  fail_unless(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
+  ck_assert_msg(redis == NULL, "Failed to handle invalid port");
+  ck_assert_msg(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
     strerror(errno), errno);
 
   /* Restore our testing server/port. */
@@ -150,37 +150,37 @@ START_TEST (redis_conn_get_test) {
 
   mark_point();
   redis = pr_redis_conn_get(NULL, 0UL);
-  fail_unless(redis == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(redis == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_get(p, 0UL);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 
   mark_point();
   redis = pr_redis_conn_get(p, 0UL);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   redis2 = pr_redis_conn_get(p, 0UL);
-  fail_unless(redis2 != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis2 != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
-  fail_unless(redis == redis2, "Expected %p, got %p", redis, redis2);
+  ck_assert_msg(redis == redis2, "Expected %p, got %p", redis, redis2);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -193,24 +193,24 @@ START_TEST (redis_conn_set_namespace_test) {
 
   mark_point();
   res = pr_redis_conn_set_namespace(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, NULL, 0);
-  fail_unless(res == 0, "Failed to set null namespace prefix: %s",
+  ck_assert_msg(res == 0, "Failed to set null namespace prefix: %s",
     strerror(errno));
 
   prefix = "test.";
@@ -218,23 +218,23 @@ START_TEST (redis_conn_set_namespace_test) {
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, prefix, 0);
-  fail_unless(res < 0, "Failed to handle empty namespace prefix");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty namespace prefix");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, prefix, prefixsz);
-  fail_unless(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
+  ck_assert_msg(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, NULL, 0);
-  fail_unless(res == 0, "Failed to set null namespace prefix: %s",
+  ck_assert_msg(res == 0, "Failed to set null namespace prefix: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -245,28 +245,28 @@ START_TEST (redis_conn_get_version_test) {
 
   mark_point();
   res = pr_redis_conn_get_version(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_get_version(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null version arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null version arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_get_version(redis, &major, &minor, &patch);
-  fail_unless(res == 0, "Failed to get Redis version: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to get Redis version: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -279,19 +279,19 @@ START_TEST (redis_conn_auth_test) {
 
   mark_point();
   res = pr_redis_auth(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_auth(redis, NULL);
-  fail_unless(res < 0, "Failed to handle null password");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null password");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* What happens if we try to AUTH to a non-password-protected Redis?
@@ -304,15 +304,15 @@ START_TEST (redis_conn_auth_test) {
 
   mark_point();
   res = pr_redis_conn_get_version(redis, &major_version, NULL, NULL);
-  fail_unless(res == 0, "Failed to get Redis version: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to get Redis version: %s", strerror(errno));
 
   mark_point();
   text = "password";
   res = pr_redis_auth(redis, text);
 
   if (major_version < 6) {
-    fail_unless(res < 0, "Failed to handle lack of need for authentication");
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(res < 0, "Failed to handle lack of need for authentication");
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
 
     /* Use CONFIG SET to require a password. */
@@ -324,7 +324,7 @@ START_TEST (redis_conn_auth_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STATUS);
-    fail_unless(res == 0, "Failed to enable authentication: %s",
+    ck_assert_msg(res == 0, "Failed to enable authentication: %s",
       strerror(errno));
 
     args = make_array(p, 0, sizeof(char *));
@@ -332,13 +332,13 @@ START_TEST (redis_conn_auth_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_ARRAY);
-    fail_unless(res < 0, "Failed to handle required authentication");
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(res < 0, "Failed to handle required authentication");
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
 
     mark_point();
     res = pr_redis_auth(redis, text);
-    fail_unless(res == 0, "Failed to authenticate client: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to authenticate client: %s", strerror(errno));
 
     /* Don't forget to remove the password. */
     args = make_array(p, 0, sizeof(char *));
@@ -349,17 +349,17 @@ START_TEST (redis_conn_auth_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STATUS);
-    fail_unless(res == 0, "Failed to remove password authentication: %s",
+    ck_assert_msg(res == 0, "Failed to remove password authentication: %s",
       strerror(errno));
 
   } else {
-    fail_unless(res == 0, "Failed to handle AUTH command: %s",
+    ck_assert_msg(res == 0, "Failed to handle AUTH command: %s",
       strerror(errno));
   }
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -372,19 +372,19 @@ START_TEST (redis_conn_auth2_test) {
 
   mark_point();
   res = pr_redis_auth2(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_auth2(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null username");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null username");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Note: Do NOT use "default" as the initial username; that name has
@@ -394,8 +394,8 @@ START_TEST (redis_conn_auth2_test) {
 
   mark_point();
   res = pr_redis_auth2(redis, username, NULL);
-  fail_unless(res < 0, "Failed to handle null password");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null password");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* What happens if we try to AUTH to a non-password-protected Redis?
@@ -408,13 +408,13 @@ START_TEST (redis_conn_auth2_test) {
 
   mark_point();
   res = pr_redis_conn_get_version(redis, &major_version, NULL, NULL);
-  fail_unless(res == 0, "Failed to get Redis version: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to get Redis version: %s", strerror(errno));
 
   mark_point();
   password = "password";
   res = pr_redis_auth2(redis, username, password);
-  fail_unless(res < 0, "Failed to handle lack of need for authentication");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle lack of need for authentication");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   if (major_version < 6) {
@@ -427,7 +427,7 @@ START_TEST (redis_conn_auth2_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STATUS);
-    fail_unless(res == 0, "Failed to enable authentication: %s",
+    ck_assert_msg(res == 0, "Failed to enable authentication: %s",
       strerror(errno));
 
     args = make_array(p, 0, sizeof(char *));
@@ -435,13 +435,13 @@ START_TEST (redis_conn_auth2_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_ARRAY);
-    fail_unless(res < 0, "Failed to handle required authentication");
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(res < 0, "Failed to handle required authentication");
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
 
     mark_point();
     res = pr_redis_auth2(redis, username, password);
-    fail_unless(res == 0, "Failed to authenticate client: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to authenticate client: %s", strerror(errno));
 
     /* Don't forget to remove the password. */
     args = make_array(p, 0, sizeof(char *));
@@ -452,13 +452,13 @@ START_TEST (redis_conn_auth2_test) {
 
     mark_point();
     res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STATUS);
-    fail_unless(res == 0, "Failed to remove password authentication: %s",
+    ck_assert_msg(res == 0, "Failed to remove password authentication: %s",
       strerror(errno));
   }
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -469,57 +469,57 @@ START_TEST (redis_conn_select_test) {
 
   mark_point();
   res = pr_redis_select(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_select(redis, NULL);
-  fail_unless(res < 0, "Failed to handle null db_idx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null db_idx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = "-1";
   res = pr_redis_select(redis, text);
-  fail_unless(res < 0, "Failed to handle invalid index %s", text);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index %s", text);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = "100";
   res = pr_redis_select(redis, text);
-  fail_unless(res < 0, "Failed to handle invalid index %s", text);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index %s", text);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = "someotherlabel";
   res = pr_redis_select(redis, text);
-  fail_unless(res < 0, "Failed to handle invalid index %s", text);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index %s", text);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = "0";
   res = pr_redis_select(redis, text);
-  fail_unless(res == 0, "Failed to select database %s: %s", text,
+  ck_assert_msg(res == 0, "Failed to select database %s: %s", text,
     strerror(errno));
 
   mark_point();
   text = "1";
   res = pr_redis_select(redis, text);
-  fail_unless(res == 0, "Failed to select database %s: %s", text,
+  ck_assert_msg(res == 0, "Failed to select database %s: %s", text,
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -536,7 +536,7 @@ START_TEST (redis_conn_reconnect_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   /* Now we PAUSE, and elsewhere, stop/start the Redis server, breaking the
@@ -552,19 +552,19 @@ START_TEST (redis_conn_reconnect_test) {
   /* This first one should fail, due to the reconnect. */
   mark_point();
   res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STRING);
-  fail_unless(res < 0, "Failed to handle reconnect");
-  fail_unless(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
+  ck_assert_msg(res < 0, "Failed to handle reconnect");
+  ck_assert_msg(errno == EIO, "Expected EIO (%d), got %s (%d)", EIO,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STRING);
-  fail_unless(res == 0, "Failed to handle valid command with array: %s",
+  ck_assert_msg(res == 0, "Failed to handle valid command with array: %s",
     strerror(errno));
 
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -575,40 +575,40 @@ START_TEST (redis_command_test) {
 
   mark_point();
   res = pr_redis_command(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_command(redis, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null args");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null args");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   args = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_command(redis, args, 0);
-  fail_unless(res < 0, "Failed to handle empty args");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty args");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((char **) push_array(args)) = pstrdup(p, "FOO");
 
   mark_point();
   res = pr_redis_command(redis, args, -1);
-  fail_unless(res < 0, "Failed to handle invalid reply type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid reply type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_ERROR);
-  fail_unless(res == 0, "Failed to handle invalid command with error: %s",
+  ck_assert_msg(res == 0, "Failed to handle invalid command with error: %s",
     strerror(errno));
 
   args = make_array(p, 0, sizeof(char *));
@@ -617,7 +617,7 @@ START_TEST (redis_command_test) {
 
   mark_point();
   res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_INTEGER);
-  fail_unless(res == 0, "Failed to handle valid command with integer: %s",
+  ck_assert_msg(res == 0, "Failed to handle valid command with integer: %s",
     strerror(errno));
 
   args = make_array(p, 0, sizeof(char *));
@@ -625,12 +625,12 @@ START_TEST (redis_command_test) {
 
   mark_point();
   res = pr_redis_command(redis, args, PR_REDIS_REPLY_TYPE_STRING);
-  fail_unless(res == 0, "Failed to handle valid command with array: %s",
+  ck_assert_msg(res == 0, "Failed to handle valid command with array: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -642,44 +642,44 @@ START_TEST (redis_sentinel_get_master_addr_test) {
 
   mark_point();
   res = pr_redis_sentinel_get_master_addr(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sentinel_get_master_addr(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sentinel_get_master_addr(p, redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   name = "foobar";
   res = pr_redis_sentinel_get_master_addr(p, redis, name, NULL);
-  fail_unless(res < 0, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   name = "foobar";
   res = pr_redis_sentinel_get_master_addr(p, redis, name, &addr);
-  fail_unless(res < 0, "Failed to handle invalid sentinel");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid sentinel");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -690,36 +690,36 @@ START_TEST (redis_sentinel_get_masters_test) {
 
   mark_point();
   res = pr_redis_sentinel_get_masters(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sentinel_get_masters(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sentinel_get_masters(p, redis, NULL);
-  fail_unless(res < 0, "Failed to handle null masters");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null masters");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sentinel_get_masters(p, redis, &masters);
-  fail_unless(res < 0, "Failed to handle invalid sentinel");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid sentinel");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -747,12 +747,12 @@ START_TEST (redis_sentinel_conn_new_test) {
 
     mark_point();
     res = redis_set_sentinels(sentinels, NULL);
-    fail_unless(res == 0, "Failed to set sentinel list: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to set sentinel list: %s", strerror(errno));
 
     mark_point();
     redis = pr_redis_conn_new(p, NULL, 0);
-    fail_unless(redis == NULL, "Failed to handle invald sentinels");
-    fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+    ck_assert_msg(redis == NULL, "Failed to handle invald sentinels");
+    ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
       strerror(errno), errno);
 
     /* Restore our testing server/port. */
@@ -764,8 +764,8 @@ START_TEST (redis_sentinel_conn_new_test) {
 
   mark_point();
   res = redis_set_sentinels(sentinels, NULL);
-  fail_unless(res < 0, "Failed to handle empty sentinel list");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty sentinel list");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Set a list of bad sentinels */
@@ -779,12 +779,12 @@ START_TEST (redis_sentinel_conn_new_test) {
 
   mark_point();
   res = redis_set_sentinels(sentinels, NULL);
-  fail_unless(res == 0, "Failed to set sentinels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sentinels: %s", strerror(errno));
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis == NULL, "Failed to handle invalid sentinels");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(redis == NULL, "Failed to handle invalid sentinels");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   /* Set a list of one bad, one good sentinel -- use "bad" master" */
@@ -801,12 +801,12 @@ START_TEST (redis_sentinel_conn_new_test) {
 
   mark_point();
   res = redis_set_sentinels(sentinels, master);
-  fail_unless(res == 0, "Failed to set sentinels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sentinels: %s", strerror(errno));
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis == NULL, "Failed to handle invalid master");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(redis == NULL, "Failed to handle invalid master");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   /* Set a list of one bad, one good sentinel -- use "good" master */
@@ -823,16 +823,16 @@ START_TEST (redis_sentinel_conn_new_test) {
 
   mark_point();
   res = redis_set_sentinels(sentinels, master);
-  fail_unless(res == 0, "Failed to set sentinels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sentinels: %s", strerror(errno));
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to discover valid master: %s",
+  ck_assert_msg(redis != NULL, "Failed to discover valid master: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 
   /* Set a list of one bad, one good sentinel -- use no master */
   sentinels = make_array(p, 0, sizeof(pr_netaddr_t *));
@@ -848,16 +848,16 @@ START_TEST (redis_sentinel_conn_new_test) {
 
   mark_point();
   res = redis_set_sentinels(sentinels, master);
-  fail_unless(res == 0, "Failed to set sentinels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set sentinels: %s", strerror(errno));
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to discover valid master: %s",
+  ck_assert_msg(redis != NULL, "Failed to discover valid master: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 
   /* Restore our testing server/port. */
   redis_set_server(redis_server, redis_port, 0UL, NULL, NULL);
@@ -873,38 +873,38 @@ START_TEST (redis_remove_test) {
 
   mark_point();
   res = pr_redis_remove(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_remove(redis, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res < 0, "Unexpectedly removed key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly removed key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -919,33 +919,33 @@ START_TEST (redis_add_test) {
 
   mark_point();
   res = pr_redis_add(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_add(redis, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_add(redis, &m, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_add(redis, &m, key, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -954,27 +954,27 @@ START_TEST (redis_add_test) {
 
   mark_point();
   res = pr_redis_add(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   expires = 3;
 
   mark_point();
   res = pr_redis_add(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -989,7 +989,7 @@ START_TEST (redis_add_with_namespace_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   prefix = "test.";
@@ -997,7 +997,7 @@ START_TEST (redis_add_with_namespace_test) {
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, prefix, prefixsz);
-  fail_unless(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
+  ck_assert_msg(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
     strerror(errno));
 
   key = "key";
@@ -1007,21 +1007,21 @@ START_TEST (redis_add_with_namespace_test) {
 
   mark_point();
   res = pr_redis_add(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, NULL, 0);
-  fail_unless(res == 0, "Failed to set null namespace prefix: %s",
+  ck_assert_msg(res == 0, "Failed to set null namespace prefix: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1037,31 +1037,31 @@ START_TEST (redis_get_test) {
 
   mark_point();
   data = pr_redis_get(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(data == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(data == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   data = pr_redis_get(p, NULL, NULL, NULL, NULL);
-  fail_unless(data == NULL, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(data == NULL, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   data = pr_redis_get(p, redis, NULL, NULL, NULL);
-  fail_unless(data == NULL, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(data == NULL, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   data = pr_redis_get(p, redis, &m, NULL, NULL);
-  fail_unless(data == NULL, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(data == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -1069,14 +1069,14 @@ START_TEST (redis_get_test) {
 
   mark_point();
   data = pr_redis_get(p, redis, &m, key, NULL);
-  fail_unless(data == NULL, "Failed to handle null valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(data == NULL, "Failed to handle null valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   data = pr_redis_get(p, redis, &m, key, &valsz);
-  fail_unless(data == NULL, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(data == NULL, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "Hello, World!";
@@ -1085,31 +1085,31 @@ START_TEST (redis_get_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   valsz = 0;
 
   mark_point();
   data = pr_redis_get(p, redis, &m, key, &valsz);
-  fail_unless(data != NULL, "Failed to get data for key '%s': %s", key,
+  ck_assert_msg(data != NULL, "Failed to get data for key '%s': %s", key,
     strerror(errno));
-  fail_unless(valsz == strlen(val), "Expected %lu, got %lu",
+  ck_assert_msg(valsz == strlen(val), "Expected %lu, got %lu",
     (unsigned long) strlen(val), (unsigned long) valsz);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   data = pr_redis_get(p, redis, &m, key, &valsz);
-  fail_unless(data == NULL, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(data == NULL, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1127,7 +1127,7 @@ START_TEST (redis_get_with_namespace_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   prefix = "prefix.";
@@ -1142,12 +1142,12 @@ START_TEST (redis_get_with_namespace_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_conn_set_namespace(redis, &m, prefix, prefixsz);
-  fail_unless(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
+  ck_assert_msg(res == 0, "Failed to set namespace prefix '%s': %s", prefix,
     strerror(errno));
 
   key = "testkey";
@@ -1155,16 +1155,16 @@ START_TEST (redis_get_with_namespace_test) {
 
   mark_point();
   data = pr_redis_get(p, redis, &m, key, &valsz);
-  fail_unless(data != NULL, "Failed to get data for key '%s': %s", key,
+  ck_assert_msg(data != NULL, "Failed to get data for key '%s': %s", key,
     strerror(errno));
-  fail_unless(valsz == strlen(val), "Expected %lu, got %lu",
+  ck_assert_msg(valsz == strlen(val), "Expected %lu, got %lu",
     (unsigned long) strlen(val), (unsigned long) valsz);
-  fail_unless(memcmp(data, val, valsz) == 0, "Expected '%s', got '%.*s'",
+  ck_assert_msg(memcmp(data, val, valsz) == 0, "Expected '%s', got '%.*s'",
     val, (int) valsz, data);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1179,31 +1179,31 @@ START_TEST (redis_get_str_test) {
 
   mark_point();
   str = pr_redis_get_str(NULL, NULL, NULL, NULL);
-  fail_unless(str == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(str == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   str = pr_redis_get_str(p, NULL, NULL, NULL);
-  fail_unless(str == NULL, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(str == NULL, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   str = pr_redis_get_str(p, redis, NULL, NULL);
-  fail_unless(str == NULL, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(str == NULL, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   str = pr_redis_get_str(p, redis, &m, NULL);
-  fail_unless(str == NULL, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(str == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "test_string";
@@ -1211,8 +1211,8 @@ START_TEST (redis_get_str_test) {
 
   mark_point();
   str = pr_redis_get_str(p, redis, &m, key);
-  fail_unless(str == NULL, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(str == NULL, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "Hello, World!";
@@ -1221,29 +1221,29 @@ START_TEST (redis_get_str_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   str = pr_redis_get_str(p, redis, &m, key);
-  fail_unless(str != NULL, "Failed to get string for key '%s': %s", key,
+  ck_assert_msg(str != NULL, "Failed to get string for key '%s': %s", key,
     strerror(errno));
-  fail_unless(strlen(str) == strlen(val), "Expected %lu, got %lu",
+  ck_assert_msg(strlen(str) == strlen(val), "Expected %lu, got %lu",
     (unsigned long) strlen(val), (unsigned long) strlen(str));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   str = pr_redis_get_str(p, redis, &m, key);
-  fail_unless(str == NULL, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(str == NULL, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1260,25 +1260,25 @@ START_TEST (redis_incr_test) {
 
   mark_point();
   res = pr_redis_incr(NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_incr(redis, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_incr(redis, &m, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testval";
@@ -1286,16 +1286,16 @@ START_TEST (redis_incr_test) {
 
   mark_point();
   res = pr_redis_incr(redis, &m, key, 0, NULL);
-  fail_unless(res < 0, "Failed to handle zero incr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero incr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   incr = 2;
 
   mark_point();
   res = pr_redis_incr(redis, &m, key, incr, NULL);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Note: Yes, Redis wants a string, NOT the actual bytes.  Makes sense,
@@ -1307,25 +1307,25 @@ START_TEST (redis_incr_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, value, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_incr(redis, &m, key, incr, NULL);
-  fail_unless(res == 0, "Failed to increment key '%s' by %lu: %s", key,
+  ck_assert_msg(res == 0, "Failed to increment key '%s' by %lu: %s", key,
     (unsigned long) incr, strerror(errno));
 
   val = 0;
 
   mark_point();
   res = pr_redis_incr(redis, &m, key, incr, &val);
-  fail_unless(res == 0, "Failed to increment key '%s' by %lu: %s", key,
+  ck_assert_msg(res == 0, "Failed to increment key '%s' by %lu: %s", key,
     (unsigned long) incr, strerror(errno));
-  fail_unless(val == 35, "Expected %lu, got %lu", 35, (unsigned long) val);
+  ck_assert_msg(val == 35, "Expected %lu, got %lu", 35, (unsigned long) val);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   /* Now, let's try incrementing a non-numeric value. */
   value = "Hello, World!";
@@ -1334,20 +1334,20 @@ START_TEST (redis_incr_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, value, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_incr(redis, &m, key, incr, &val);
-  fail_unless(res < 0, "Failed to handle non-numeric key value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle non-numeric key value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1364,25 +1364,25 @@ START_TEST (redis_decr_test) {
 
   mark_point();
   res = pr_redis_decr(NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_decr(redis, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_decr(redis, &m, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testval";
@@ -1390,16 +1390,16 @@ START_TEST (redis_decr_test) {
 
   mark_point();
   res = pr_redis_decr(redis, &m, key, 0, NULL);
-  fail_unless(res < 0, "Failed to handle zero decr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero decr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   decr = 5;
 
   mark_point();
   res = pr_redis_decr(redis, &m, key, decr, NULL);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Note: Yes, Redis wants a string, NOT the actual bytes.  Makes sense,
@@ -1411,25 +1411,25 @@ START_TEST (redis_decr_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, value, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_decr(redis, &m, key, decr, NULL);
-  fail_unless(res == 0, "Failed to decrement key '%s' by %lu: %s", key,
+  ck_assert_msg(res == 0, "Failed to decrement key '%s' by %lu: %s", key,
     (unsigned long) decr, strerror(errno));
 
   val = 0;
 
   mark_point();
   res = pr_redis_decr(redis, &m, key, decr, &val);
-  fail_unless(res == 0, "Failed to decrement key '%s' by %lu: %s", key,
+  ck_assert_msg(res == 0, "Failed to decrement key '%s' by %lu: %s", key,
     (unsigned long) decr, strerror(errno));
-  fail_unless(val == 21, "Expected %lu, got %lu", 21, (unsigned long) val);
+  ck_assert_msg(val == 21, "Expected %lu, got %lu", 21, (unsigned long) val);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   /* Now, let's try decrementing a non-numeric value. */
   value = "Hello, World!";
@@ -1438,20 +1438,20 @@ START_TEST (redis_decr_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, value, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_decr(redis, &m, key, decr, &val);
-  fail_unless(res < 0, "Failed to handle non-numeric key value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle non-numeric key value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1466,41 +1466,41 @@ START_TEST (redis_rename_test) {
 
   mark_point();
   res = pr_redis_rename(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_rename(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_rename(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null from");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null from");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   from = "fromkey";
 
   mark_point();
   res = pr_redis_rename(redis, &m, from, NULL);
-  fail_unless(res < 0, "Failed to handle null to");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null to");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   to = "tokey";
 
   mark_point();
   res = pr_redis_rename(redis, &m, from, to);
-  fail_unless(res < 0, "Failed to handle nonexistent from key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent from key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "testval";
@@ -1509,21 +1509,21 @@ START_TEST (redis_rename_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, from, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", from, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", from, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_rename(redis, &m, from, to);
-  fail_unless(res == 0, "Failed to rename '%s' to '%s': %s", from, to,
+  ck_assert_msg(res == 0, "Failed to rename '%s' to '%s': %s", from, to,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, to);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", to, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", to, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1538,33 +1538,33 @@ START_TEST (redis_set_test) {
 
   mark_point();
   res = pr_redis_set(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set(redis, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set(redis, &m, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_set(redis, &m, key, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -1573,27 +1573,27 @@ START_TEST (redis_set_test) {
 
   mark_point();
   res = pr_redis_set(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   expires = 3;
 
   mark_point();
   res = pr_redis_set(redis, &m, key, val, valsz, expires);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1605,38 +1605,38 @@ START_TEST (redis_hash_remove_test) {
 
   mark_point();
   res = pr_redis_hash_remove(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_remove(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_remove(redis, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_hash_remove(redis, &m, key);
-  fail_unless(res < 0, "Unexpectedly removed key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly removed key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1650,31 +1650,31 @@ START_TEST (redis_hash_get_test) {
 
   mark_point();
   res = pr_redis_hash_get(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_get(p, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_get(p, redis, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_get(p, redis, &m, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -1682,29 +1682,29 @@ START_TEST (redis_hash_get_test) {
 
   mark_point();
   res = pr_redis_hash_get(p, redis, &m, key, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null field");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null field");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   field = "hashfield";
 
   mark_point();
   res = pr_redis_hash_get(p, redis, &m, key, field, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_get(p, redis, &m, key, field, (void **) &val, &valsz);
-  fail_unless(res < 0, "Failed to handle nonexistent item");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent item");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1718,25 +1718,25 @@ START_TEST (redis_hash_set_test) {
 
   mark_point();
   res = pr_redis_hash_set(NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_set(redis, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -1744,16 +1744,16 @@ START_TEST (redis_hash_set_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null field");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null field");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   field = "hashfield";
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "hashval";
@@ -1761,33 +1761,33 @@ START_TEST (redis_hash_set_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, 0);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   val = NULL;
   valsz = 0;
 
   mark_point();
   res = pr_redis_hash_get(p, redis, &m, key, field, (void **) &val, &valsz);
-  fail_unless(res == 0, "Failed to get item: %s", strerror(errno));
-  fail_unless(valsz == 7, "Expected item length 7, got %lu",
+  ck_assert_msg(res == 0, "Failed to get item: %s", strerror(errno));
+  ck_assert_msg(valsz == 7, "Expected item length 7, got %lu",
     (unsigned long) valsz);
-  fail_unless(val != NULL, "Failed to get value from hash");
-  fail_unless(memcmp(val, "hashval", valsz) == 0,
+  ck_assert_msg(val != NULL, "Failed to get value from hash");
+  ck_assert_msg(memcmp(val, "hashval", valsz) == 0,
     "Expected 'hashval', got '%.*s'", (int) valsz, val);
 
   mark_point();
   res = pr_redis_hash_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove hash: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove hash: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1801,25 +1801,25 @@ START_TEST (redis_hash_delete_test) {
 
   mark_point();
   res = pr_redis_hash_delete(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_delete(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_delete(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -1827,16 +1827,16 @@ START_TEST (redis_hash_delete_test) {
 
   mark_point();
   res = pr_redis_hash_delete(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null field");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null field");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   field = "hashfield";
 
   mark_point();
   res = pr_redis_hash_delete(redis, &m, key, field);
-  fail_unless(res < 0, "Failed to handle nonexistent field");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent field");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "hashval";
@@ -1844,11 +1844,11 @@ START_TEST (redis_hash_delete_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_delete(redis, &m, key, field);
-  fail_unless(res == 0, "Failed to delete field: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to delete field: %s", strerror(errno));
 
   /* Note that we add this item back, just so that the hash is NOT empty when
    * we go to remove it entirely.
@@ -1856,13 +1856,13 @@ START_TEST (redis_hash_delete_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1877,25 +1877,25 @@ START_TEST (redis_hash_count_test) {
 
   mark_point();
   res = pr_redis_hash_count(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_count(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_count(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -1903,13 +1903,13 @@ START_TEST (redis_hash_count_test) {
 
   mark_point();
   res = pr_redis_hash_count(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to get count using key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to get count using key '%s': %s", key,
     strerror(errno));
 
   field = "hashfield";
@@ -1918,18 +1918,18 @@ START_TEST (redis_hash_count_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to get count: %s", strerror(errno));
-  fail_unless(count == 1, "Expected 1, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to get count: %s", strerror(errno));
+  ck_assert_msg(count == 1, "Expected 1, got %lu", (unsigned long) count);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -1943,25 +1943,25 @@ START_TEST (redis_hash_exists_test) {
 
   mark_point();
   res = pr_redis_hash_exists(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_exists(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_exists(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -1969,32 +1969,32 @@ START_TEST (redis_hash_exists_test) {
 
   mark_point();
   res = pr_redis_hash_exists(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null field");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null field");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   field = "hashfield";
 
   mark_point();
   res = pr_redis_hash_exists(redis, &m, key, field);
-  fail_unless(res == FALSE, "Failed to handle nonexistent field");
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent field");
 
   val = "hashval";
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_exists(redis, &m, key, field);
-  fail_unless(res == TRUE, "Failed to handle existing field");
+  ck_assert_msg(res == TRUE, "Failed to handle existing field");
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2009,25 +2009,25 @@ START_TEST (redis_hash_incr_test) {
 
   mark_point();
   res = pr_redis_hash_incr(NULL, NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_incr(redis, NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -2035,16 +2035,16 @@ START_TEST (redis_hash_incr_test) {
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, key, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null field");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null field");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   field = "hashfield";
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, key, field, 0, NULL);
-  fail_unless(res < 0, "Failed to handle nonexistent field");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent field");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "1";
@@ -2052,27 +2052,27 @@ START_TEST (redis_hash_incr_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, key, field, 0, NULL);
-  fail_unless(res == 0, "Failed to handle existing field: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle existing field: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, key, field, 1, &num);
-  fail_unless(res == 0, "Failed to handle existing field: %s", strerror(errno));
-  fail_unless(num == 2, "Expected 2, got %lu", (unsigned long) num);
+  ck_assert_msg(res == 0, "Failed to handle existing field: %s", strerror(errno));
+  ck_assert_msg(num == 2, "Expected 2, got %lu", (unsigned long) num);
 
   mark_point();
   res = pr_redis_hash_incr(redis, &m, key, field, -3, &num);
-  fail_unless(res == 0, "Failed to handle existing field: %s", strerror(errno));
-  fail_unless(num == -1, "Expected -1, got %lu", (unsigned long) num);
+  ck_assert_msg(res == 0, "Failed to handle existing field: %s", strerror(errno));
+  ck_assert_msg(num == -1, "Expected -1, got %lu", (unsigned long) num);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2087,31 +2087,31 @@ START_TEST (redis_hash_keys_test) {
 
   mark_point();
   res = pr_redis_hash_keys(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_keys(p, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_keys(p, redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_keys(p, redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -2119,14 +2119,14 @@ START_TEST (redis_hash_keys_test) {
 
   mark_point();
   res = pr_redis_hash_keys(p, redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null fields");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null fields");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_keys(p, redis, &m, key, &fields);
-  fail_unless(res < 0, "Failed to handle nonexistent fields");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent fields");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Add some fields */
@@ -2137,7 +2137,7 @@ START_TEST (redis_hash_keys_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   field = "bar";
   val = "baz quxx";
@@ -2145,21 +2145,21 @@ START_TEST (redis_hash_keys_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   fields = NULL;
 
   mark_point();
   res = pr_redis_hash_keys(p, redis, &m, key, &fields);
-  fail_unless(res == 0, "Failed to handle existing fields: %s", strerror(errno));
-  fail_unless(fields != NULL, "Failed to get hash fields");
-  fail_unless(fields->nelts == 2, "Expected 2, got %u", fields->nelts);
+  ck_assert_msg(res == 0, "Failed to handle existing fields: %s", strerror(errno));
+  ck_assert_msg(fields != NULL, "Failed to get hash fields");
+  ck_assert_msg(fields->nelts == 2, "Expected 2, got %u", fields->nelts);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2174,31 +2174,31 @@ START_TEST (redis_hash_values_test) {
 
   mark_point();
   res = pr_redis_hash_values(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_values(p, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_values(p, redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_values(p, redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -2206,14 +2206,14 @@ START_TEST (redis_hash_values_test) {
 
   mark_point();
   res = pr_redis_hash_values(p, redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_values(p, redis, &m, key, &values);
-  fail_unless(res < 0, "Failed to handle nonexistent values");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent values");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Add some fields */
@@ -2224,7 +2224,7 @@ START_TEST (redis_hash_values_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   field = "bar";
   val = "baz quxx";
@@ -2232,21 +2232,21 @@ START_TEST (redis_hash_values_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   values = NULL;
 
   mark_point();
   res = pr_redis_hash_values(p, redis, &m, key, &values);
-  fail_unless(res == 0, "Failed to handle existing values: %s", strerror(errno));
-  fail_unless(values != NULL, "Failed to get hash values");
-  fail_unless(values->nelts == 2, "Expected 2, got %u", values->nelts);
+  ck_assert_msg(res == 0, "Failed to handle existing values: %s", strerror(errno));
+  ck_assert_msg(values != NULL, "Failed to get hash values");
+  ck_assert_msg(values->nelts == 2, "Expected 2, got %u", values->nelts);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2261,31 +2261,31 @@ START_TEST (redis_hash_getall_test) {
 
   mark_point();
   res = pr_redis_hash_getall(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_getall(p, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_getall(p, redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_getall(p, redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -2293,14 +2293,14 @@ START_TEST (redis_hash_getall_test) {
 
   mark_point();
   res = pr_redis_hash_getall(p, redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null hash");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null hash");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_getall(p, redis, &m, key, &hash);
-  fail_unless(res < 0, "Failed to handle nonexistent hash");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent hash");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   /* Add some fields */
@@ -2311,7 +2311,7 @@ START_TEST (redis_hash_getall_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   field = "bar";
   val = "baz quxx";
@@ -2319,22 +2319,22 @@ START_TEST (redis_hash_getall_test) {
 
   mark_point();
   res = pr_redis_hash_set(redis, &m, key, field, val, valsz);
-  fail_unless(res == 0, "Failed to set item: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set item: %s", strerror(errno));
 
   hash = NULL;
 
   mark_point();
   res = pr_redis_hash_getall(p, redis, &m, key, &hash);
-  fail_unless(res == 0, "Failed to handle existing fields: %s", strerror(errno));
-  fail_unless(hash != NULL, "Failed to get hash");
+  ck_assert_msg(res == 0, "Failed to handle existing fields: %s", strerror(errno));
+  ck_assert_msg(hash != NULL, "Failed to get hash");
   res = pr_table_count(hash);
-  fail_unless(res == 2, "Expected 2, got %d", res);
+  ck_assert_msg(res == 2, "Expected 2, got %d", res);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2350,25 +2350,25 @@ START_TEST (redis_hash_setall_test) {
 
   mark_point();
   res = pr_redis_hash_setall(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_hash_setall(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_hash_setall(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testhashkey";
@@ -2376,16 +2376,16 @@ START_TEST (redis_hash_setall_test) {
 
   mark_point();
   res = pr_redis_hash_setall(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null hash");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null hash");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   hash = pr_table_alloc(p, 0);
 
   mark_point();
   res = pr_redis_hash_setall(redis, &m, key, hash);
-  fail_unless(res < 0, "Failed to handle empty hash");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty hash");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Add some fields */
@@ -2401,18 +2401,18 @@ START_TEST (redis_hash_setall_test) {
 
   mark_point();
   res = pr_redis_hash_setall(redis, &m, key, hash);
-  fail_unless(res == 0, "Failed to set hash: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set hash: %s", strerror(errno));
 
   mark_point();
   res = pr_redis_hash_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to count hash: %s", strerror(errno));
-  fail_unless(count == 2, "Expected 2, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to count hash: %s", strerror(errno));
+  ck_assert_msg(count == 2, "Expected 2, got %lu", (unsigned long) count);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2424,38 +2424,38 @@ START_TEST (redis_list_remove_test) {
 
   mark_point();
   res = pr_redis_list_remove(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res < 0, "Failed to handle nonexistent list");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent list");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2469,25 +2469,25 @@ START_TEST (redis_list_append_test) {
 
   mark_point();
   res = pr_redis_list_append(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_append(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_append(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -2495,16 +2495,16 @@ START_TEST (redis_list_append_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "Some JSON here";
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, 0);
-  fail_unless(res < 0, "Failed to handle empty value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -2514,16 +2514,16 @@ START_TEST (redis_list_append_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2538,25 +2538,25 @@ START_TEST (redis_list_count_test) {
 
   mark_point();
   res = pr_redis_list_count(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_count(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_count(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -2564,33 +2564,33 @@ START_TEST (redis_list_count_test) {
 
   mark_point();
   res = pr_redis_list_count(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to get list count: %s", strerror(errno));
-  fail_unless(count == 0, "Expected 0, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to get list count: %s", strerror(errno));
+  ck_assert_msg(count == 0, "Expected 0, got %lu", (unsigned long) count);
 
   val = "Some JSON here";
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to get list count: %s", strerror(errno));
-  fail_unless(count == 1, "Expected 1, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to get list count: %s", strerror(errno));
+  ck_assert_msg(count == 1, "Expected 1, got %lu", (unsigned long) count);
 
   (void) pr_redis_remove(redis, &m, key);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2604,25 +2604,25 @@ START_TEST (redis_list_delete_test) {
 
   mark_point();
   res = pr_redis_list_delete(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_delete(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_delete(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -2630,16 +2630,16 @@ START_TEST (redis_list_delete_test) {
 
   mark_point();
   res = pr_redis_list_delete(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "Some JSON here";
 
   mark_point();
   res = pr_redis_list_delete(redis, &m, key, val, 0);
-  fail_unless(res < 0, "Failed to handle empty value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -2649,18 +2649,18 @@ START_TEST (redis_list_delete_test) {
 
   mark_point();
   res = pr_redis_list_delete(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle nonexistent items");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent items");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_delete(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to handle existing items");
+  ck_assert_msg(res == 0, "Failed to handle existing items");
 
   /* Note that we add this item back, just so that the list is NOT empty when
    * we go to remove it entirely.
@@ -2668,16 +2668,16 @@ START_TEST (redis_list_delete_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2691,25 +2691,25 @@ START_TEST (redis_list_exists_test) {
 
   mark_point();
   res = pr_redis_list_exists(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_exists(redis, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_exists(redis, &m, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -2717,33 +2717,33 @@ START_TEST (redis_list_exists_test) {
 
   mark_point();
   res = pr_redis_list_exists(redis, &m, key, 0);
-  fail_unless(res == FALSE, "Failed to handle nonexistent item");
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent item");
 
   val = "testval";
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_exists(redis, &m, key, 0);
-  fail_unless(res == TRUE, "Failed to handle existing item");
+  ck_assert_msg(res == TRUE, "Failed to handle existing item");
 
   mark_point();
   res = pr_redis_list_exists(redis, &m, key, 3);
-  fail_unless(res < 0, "Failed to handle invalid index");
-  fail_unless(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
+  ck_assert_msg(res < 0, "Failed to handle invalid index");
+  ck_assert_msg(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2757,31 +2757,31 @@ START_TEST (redis_list_get_test) {
 
   mark_point();
   res = pr_redis_list_get(NULL, NULL, NULL, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_get(p, NULL, NULL, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_get(p, redis, NULL, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_get(p, redis, &m, NULL, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -2789,14 +2789,14 @@ START_TEST (redis_list_get_test) {
 
   mark_point();
   res = pr_redis_list_get(p, redis, &m, key, 0, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_get(p, redis, &m, key, 0, (void **) &val, NULL);
-  fail_unless(res < 0, "Failed to handle null valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
@@ -2804,7 +2804,7 @@ START_TEST (redis_list_get_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   val = NULL;
@@ -2812,25 +2812,25 @@ START_TEST (redis_list_get_test) {
 
   mark_point();
   res = pr_redis_list_get(p, redis, &m, key, 3, (void **) &val, &valsz);
-  fail_unless(res < 0, "Failed to handle invalid index");
-  fail_unless(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
+  ck_assert_msg(res < 0, "Failed to handle invalid index");
+  ck_assert_msg(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_get(p, redis, &m, key, 0, (void **) &val, &valsz);
-  fail_unless(res == 0, "Failed to get item in list: %s", strerror(errno));
-  fail_unless(val != NULL, "Expected value, got null");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to get item in list: %s", strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got null");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
     (int) valsz, val);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2845,31 +2845,31 @@ START_TEST (redis_list_getall_test) {
 
   mark_point();
   res = pr_redis_list_getall(NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_getall(p, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_getall(p, redis, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_getall(p, redis, &m, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -2877,14 +2877,14 @@ START_TEST (redis_list_getall_test) {
 
   mark_point();
   res = pr_redis_list_getall(p, redis, &m, key, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_getall(p, redis, &m, key, &values, NULL);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
@@ -2892,7 +2892,7 @@ START_TEST (redis_list_getall_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   val = "bar";
@@ -2900,7 +2900,7 @@ START_TEST (redis_list_getall_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   val = "baz";
@@ -2908,24 +2908,24 @@ START_TEST (redis_list_getall_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_getall(p, redis, &m, key, &values, &valueszs);
-  fail_unless(res == 0, "Failed to get items in list: %s", strerror(errno));
-  fail_unless(values != NULL, "Expected values, got null");
-  fail_unless(valueszs != NULL, "Expected valueszs, got null");
-  fail_unless(values->nelts == 3, "Expected 3, got %u", values->nelts);
-  fail_unless(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
+  ck_assert_msg(res == 0, "Failed to get items in list: %s", strerror(errno));
+  ck_assert_msg(values != NULL, "Expected values, got null");
+  ck_assert_msg(valueszs != NULL, "Expected valueszs, got null");
+  ck_assert_msg(values->nelts == 3, "Expected 3, got %u", values->nelts);
+  ck_assert_msg(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -2939,56 +2939,56 @@ START_TEST (redis_list_pop_params_test) {
 
   mark_point();
   res = pr_redis_list_pop(NULL, NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_pop(p, NULL, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_pop(p, redis, NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, &valsz, 0);
-  fail_unless(res < 0, "Failed to handle invalid flags");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid flags");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3002,7 +3002,7 @@ START_TEST (redis_list_pop_left_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   key = "testkey";
@@ -3010,8 +3010,8 @@ START_TEST (redis_list_pop_left_test) {
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, &valsz, flags);
-  fail_unless(res < 0, "Failed to handle nonexistent list");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent list");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "foo";
@@ -3019,7 +3019,7 @@ START_TEST (redis_list_pop_left_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   val = NULL;
@@ -3027,15 +3027,15 @@ START_TEST (redis_list_pop_left_test) {
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, &valsz, flags);
-  fail_unless(res == 0, "Failed to get item in list: %s", strerror(errno));
-  fail_unless(val != NULL, "Expected value, got null");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to get item in list: %s", strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got null");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
     (int) valsz, val);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3049,7 +3049,7 @@ START_TEST (redis_list_pop_right_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   key = "testkey";
@@ -3057,8 +3057,8 @@ START_TEST (redis_list_pop_right_test) {
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, &valsz, flags);
-  fail_unless(res < 0, "Failed to handle nonexistent list");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent list");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "foo";
@@ -3066,7 +3066,7 @@ START_TEST (redis_list_pop_right_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item to key '%s': %s", key,
     strerror(errno));
 
   val = NULL;
@@ -3074,15 +3074,15 @@ START_TEST (redis_list_pop_right_test) {
 
   mark_point();
   res = pr_redis_list_pop(p, redis, &m, key, (void **) &val, &valsz, flags);
-  fail_unless(res == 0, "Failed to get item in list: %s", strerror(errno));
-  fail_unless(val != NULL, "Expected value, got null");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to get item in list: %s", strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got null");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "foo", 3) == 0, "Expected 'foo', got '%.*s'",
     (int) valsz, val);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3096,33 +3096,33 @@ START_TEST (redis_list_push_params_test) {
 
   mark_point();
   res = pr_redis_list_push(NULL, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_push(redis, NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_push(redis, &m, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_list_push(redis, &m, key, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -3130,19 +3130,19 @@ START_TEST (redis_list_push_params_test) {
 
   mark_point();
   res = pr_redis_list_push(redis, &m, key, val, 0, 0);
-  fail_unless(res < 0, "Failed to handle empty valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_push(redis, &m, key, val, valsz, 0);
-  fail_unless(res < 0, "Failed to handle invalid flags");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid flags");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3156,7 +3156,7 @@ START_TEST (redis_list_push_left_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   key = "testlistkey";
@@ -3167,16 +3167,16 @@ START_TEST (redis_list_push_left_test) {
 
   mark_point();
   res = pr_redis_list_push(redis, &m, key, val, valsz, flags);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3190,7 +3190,7 @@ START_TEST (redis_list_push_right_test) {
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   key = "testlistkey";
@@ -3201,16 +3201,16 @@ START_TEST (redis_list_push_right_test) {
 
   mark_point();
   res = pr_redis_list_push(redis, &m, key, val, valsz, flags);
-  fail_unless(res == 0, "Failed to append to list '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append to list '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3224,31 +3224,31 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_rotate(NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_rotate(p, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -3256,20 +3256,20 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, (void **) &val, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, (void **) &val, &valsz);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "foo";
@@ -3277,7 +3277,7 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item using key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item using key '%s': %s", key,
     strerror(errno));
 
   val = "bar";
@@ -3285,7 +3285,7 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item using key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item using key '%s': %s", key,
     strerror(errno));
 
   val = NULL;
@@ -3293,10 +3293,10 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, (void **) &val, &valsz);
-  fail_unless(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
-  fail_unless(val != NULL, "Expected value, got NULL");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "bar", valsz) == 0, "Expected 'bar', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got NULL");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "bar", valsz) == 0, "Expected 'bar', got '%.*s'",
     (int) valsz, val);
 
   val = NULL;
@@ -3304,10 +3304,10 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, (void **) &val, &valsz);
-  fail_unless(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
-  fail_unless(val != NULL, "Expected value, got NULL");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "foo", valsz) == 0, "Expected 'foo', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got NULL");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "foo", valsz) == 0, "Expected 'foo', got '%.*s'",
     (int) valsz, val);
 
   val = NULL;
@@ -3315,19 +3315,19 @@ START_TEST (redis_list_rotate_test) {
 
   mark_point();
   res = pr_redis_list_rotate(p, redis, &m, key, (void **) &val, &valsz);
-  fail_unless(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
-  fail_unless(val != NULL, "Expected value, got NULL");
-  fail_unless(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
-  fail_unless(memcmp(val, "bar", valsz) == 0, "Expected 'bar', got '%.*s'",
+  ck_assert_msg(res == 0, "Failed to rotate list '%s': %s", key, strerror(errno));
+  ck_assert_msg(val != NULL, "Expected value, got NULL");
+  ck_assert_msg(valsz == 3, "Expected 3, got %lu", (unsigned long) valsz);
+  ck_assert_msg(memcmp(val, "bar", valsz) == 0, "Expected 'bar', got '%.*s'",
     (int) valsz, val);
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3341,25 +3341,25 @@ START_TEST (redis_list_set_test) {
 
   mark_point();
   res = pr_redis_list_set(NULL, NULL, NULL, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_set(redis, NULL, NULL, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_set(redis, &m, NULL, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -3367,16 +3367,16 @@ START_TEST (redis_list_set_test) {
 
   mark_point();
   res = pr_redis_list_set(redis, &m, key, 0, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "Some JSON here";
 
   mark_point();
   res = pr_redis_list_set(redis, &m, key, 0, val, 0);
-  fail_unless(res < 0, "Failed to handle empty value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -3386,21 +3386,21 @@ START_TEST (redis_list_set_test) {
 
   mark_point();
   res = pr_redis_list_set(redis, &m, key, 3, val, valsz);
-  fail_unless(res < 0, "Failed to handle invalid index");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_set(redis, &m, key, 0, val, valsz);
-  fail_unless(res < 0, "Failed to handle invalid index");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Append the item first, then set it. */
 
   mark_point();
   res = pr_redis_list_append(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to append item using key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to append item using key '%s': %s", key,
     strerror(errno));
 
   val = "listval2";
@@ -3408,16 +3408,16 @@ START_TEST (redis_list_set_test) {
 
   mark_point();
   res = pr_redis_list_set(redis, &m, key, 0, val, valsz);
-  fail_unless(res == 0, "Failed to set item at index 0 using key '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set item at index 0 using key '%s': %s",
     key, strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3430,25 +3430,25 @@ START_TEST (redis_list_setall_test) {
 
   mark_point();
   res = pr_redis_list_setall(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_list_setall(redis, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testlistkey";
@@ -3456,32 +3456,32 @@ START_TEST (redis_list_setall_test) {
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   vals = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, vals, NULL);
-  fail_unless(res < 0, "Failed to handle empty values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((char **) push_array(vals)) = pstrdup(p, "Some JSON here");
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, vals, NULL);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valszs = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, vals, valszs);
-  fail_unless(res < 0, "Failed to handle empty valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("Some JSON here");
@@ -3489,8 +3489,8 @@ START_TEST (redis_list_setall_test) {
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, vals, valszs);
-  fail_unless(res < 0, "Failed to handle mismatched values/valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle mismatched values/valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("bar");
@@ -3500,16 +3500,16 @@ START_TEST (redis_list_setall_test) {
 
   mark_point();
   res = pr_redis_list_setall(redis, &m, key, vals, valszs);
-  fail_unless(res == 0, "Failed to set items using key '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set items using key '%s': %s",
     key, strerror(errno));
 
   mark_point();
   res = pr_redis_list_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove list '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3521,38 +3521,38 @@ START_TEST (redis_set_remove_test) {
 
   mark_point();
   res = pr_redis_set_remove(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_remove(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_remove(redis, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_set_remove(redis, &m, key);
-  fail_unless(res < 0, "Unexpectedly removed key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly removed key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3566,25 +3566,25 @@ START_TEST (redis_set_exists_test) {
 
   mark_point();
   res = pr_redis_set_exists(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_exists(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_exists(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -3592,8 +3592,8 @@ START_TEST (redis_set_exists_test) {
 
   mark_point();
   res = pr_redis_set_exists(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -3601,32 +3601,32 @@ START_TEST (redis_set_exists_test) {
 
   mark_point();
   res = pr_redis_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res == FALSE, "Failed to handle nonexistent item");
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent item");
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res == TRUE, "Failed to handle existing item");
+  ck_assert_msg(res == TRUE, "Failed to handle existing item");
 
   mark_point();
   res = pr_redis_set_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3640,25 +3640,25 @@ START_TEST (redis_set_add_test) {
 
   mark_point();
   res = pr_redis_set_add(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_add(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_add(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -3666,8 +3666,8 @@ START_TEST (redis_set_add_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -3675,30 +3675,30 @@ START_TEST (redis_set_add_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, 0);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle duplicates");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle duplicates");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3713,25 +3713,25 @@ START_TEST (redis_set_count_test) {
 
   mark_point();
   res = pr_redis_set_count(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_count(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_count(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -3741,35 +3741,35 @@ START_TEST (redis_set_count_test) {
 
   mark_point();
   res = pr_redis_set_count(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to handle get set count: %s", strerror(errno));
-  fail_unless(count == 0, "Expected 0, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to handle get set count: %s", strerror(errno));
+  ck_assert_msg(count == 0, "Expected 0, got %lu", (unsigned long) count);
 
   val = "testval";
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to handle get set count: %s", strerror(errno));
-  fail_unless(count == 1, "Expected 1, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to handle get set count: %s", strerror(errno));
+  ck_assert_msg(count == 1, "Expected 1, got %lu", (unsigned long) count);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3783,25 +3783,25 @@ START_TEST (redis_set_delete_test) {
 
   mark_point();
   res = pr_redis_set_delete(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_delete(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_delete(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -3809,8 +3809,8 @@ START_TEST (redis_set_delete_test) {
 
   mark_point();
   res = pr_redis_set_delete(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -3818,26 +3818,26 @@ START_TEST (redis_set_delete_test) {
 
   mark_point();
   res = pr_redis_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle nonexistent item");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent item");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to delete item from set: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to delete item from set: %s", strerror(errno));
 
   /* Note that we add this item back, just so that the set is NOT empty when
    * we go to remove it entirely.
@@ -3845,16 +3845,16 @@ START_TEST (redis_set_delete_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3869,31 +3869,31 @@ START_TEST (redis_set_getall_test) {
 
   mark_point();
   res = pr_redis_set_getall(NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_getall(p, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_getall(p, redis, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_getall(p, redis, &m, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -3901,14 +3901,14 @@ START_TEST (redis_set_getall_test) {
 
   mark_point();
   res = pr_redis_set_getall(p, redis, &m, key, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_getall(p, redis, &m, key, &values, NULL);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
@@ -3916,7 +3916,7 @@ START_TEST (redis_set_getall_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   val = "bar";
@@ -3924,7 +3924,7 @@ START_TEST (redis_set_getall_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   val = "baz";
@@ -3932,24 +3932,24 @@ START_TEST (redis_set_getall_test) {
 
   mark_point();
   res = pr_redis_set_add(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_getall(p, redis, &m, key, &values, &valueszs);
-  fail_unless(res == 0, "Failed to get items in set: %s", strerror(errno));
-  fail_unless(values != NULL, "Expected values, got null");
-  fail_unless(valueszs != NULL, "Expected valueszs, got null");
-  fail_unless(values->nelts == 3, "Expected 3, got %u", values->nelts);
-  fail_unless(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
+  ck_assert_msg(res == 0, "Failed to get items in set: %s", strerror(errno));
+  ck_assert_msg(values != NULL, "Expected values, got null");
+  ck_assert_msg(valueszs != NULL, "Expected valueszs, got null");
+  ck_assert_msg(values->nelts == 3, "Expected 3, got %u", values->nelts);
+  ck_assert_msg(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -3962,25 +3962,25 @@ START_TEST (redis_set_setall_test) {
 
   mark_point();
   res = pr_redis_set_setall(NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_set_setall(redis, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testsetkey";
@@ -3988,32 +3988,32 @@ START_TEST (redis_set_setall_test) {
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   vals = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, vals, NULL);
-  fail_unless(res < 0, "Failed to handle empty values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((char **) push_array(vals)) = pstrdup(p, "Some JSON here");
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, vals, NULL);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valszs = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, vals, valszs);
-  fail_unless(res < 0, "Failed to handle empty valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("Some JSON here");
@@ -4021,8 +4021,8 @@ START_TEST (redis_set_setall_test) {
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, vals, valszs);
-  fail_unless(res < 0, "Failed to handle mismatched values/valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle mismatched values/valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("bar");
@@ -4032,16 +4032,16 @@ START_TEST (redis_set_setall_test) {
 
   mark_point();
   res = pr_redis_set_setall(redis, &m, key, vals, valszs);
-  fail_unless(res == 0, "Failed to set items using key '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set items using key '%s': %s",
     key, strerror(errno));
 
   mark_point();
   res = pr_redis_set_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove set '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove set '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4053,38 +4053,38 @@ START_TEST (redis_sorted_set_remove_test) {
 
   mark_point();
   res = pr_redis_sorted_set_remove(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_remove(redis, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_remove(redis, &m, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
 
   mark_point();
   res = pr_redis_sorted_set_remove(redis, &m, key);
-  fail_unless(res < 0, "Unexpectedly removed key '%s'", key);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly removed key '%s'", key);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4098,25 +4098,25 @@ START_TEST (redis_sorted_set_exists_test) {
 
   mark_point();
   res = pr_redis_sorted_set_exists(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -4124,8 +4124,8 @@ START_TEST (redis_sorted_set_exists_test) {
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -4133,32 +4133,32 @@ START_TEST (redis_sorted_set_exists_test) {
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res == FALSE, "Failed to handle nonexistent item");
+  ck_assert_msg(res == FALSE, "Failed to handle nonexistent item");
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, 1.0);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_exists(redis, &m, key, val, valsz);
-  fail_unless(res == TRUE, "Failed to handle existing item");
+  ck_assert_msg(res == TRUE, "Failed to handle existing item");
 
   mark_point();
   res = pr_redis_sorted_set_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4173,25 +4173,25 @@ START_TEST (redis_sorted_set_add_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(NULL, NULL, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, NULL, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -4199,8 +4199,8 @@ START_TEST (redis_sorted_set_add_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -4208,8 +4208,8 @@ START_TEST (redis_sorted_set_add_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -4217,22 +4217,22 @@ START_TEST (redis_sorted_set_add_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res < 0, "Failed to handle duplicates");
-  fail_unless(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
+  ck_assert_msg(res < 0, "Failed to handle duplicates");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)", EEXIST,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4248,25 +4248,25 @@ START_TEST (redis_sorted_set_count_test) {
 
   mark_point();
   res = pr_redis_sorted_set_count(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_count(redis, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_count(redis, &m, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -4276,15 +4276,15 @@ START_TEST (redis_sorted_set_count_test) {
 
   mark_point();
   res = pr_redis_sorted_set_count(redis, &m, key, NULL);
-  fail_unless(res < 0, "Failed to handle null count");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null count");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to handle get sorted set count: %s",
+  ck_assert_msg(res == 0, "Failed to handle get sorted set count: %s",
     strerror(errno));
-  fail_unless(count == 0, "Expected 0, got %lu", (unsigned long) count);
+  ck_assert_msg(count == 0, "Expected 0, got %lu", (unsigned long) count);
 
   val = "testval";
   valsz = strlen(val);
@@ -4292,21 +4292,21 @@ START_TEST (redis_sorted_set_count_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_count(redis, &m, key, &count);
-  fail_unless(res == 0, "Failed to handle get set count: %s", strerror(errno));
-  fail_unless(count == 1, "Expected 1, got %lu", (unsigned long) count);
+  ck_assert_msg(res == 0, "Failed to handle get set count: %s", strerror(errno));
+  ck_assert_msg(count == 1, "Expected 1, got %lu", (unsigned long) count);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4321,25 +4321,25 @@ START_TEST (redis_sorted_set_delete_test) {
 
   mark_point();
   res = pr_redis_sorted_set_delete(NULL, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, &m, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -4347,8 +4347,8 @@ START_TEST (redis_sorted_set_delete_test) {
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, &m, key, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -4356,28 +4356,28 @@ START_TEST (redis_sorted_set_delete_test) {
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res < 0, "Failed to handle nonexistent item");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent item");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   score = 1.23;
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_delete(redis, &m, key, val, valsz);
-  fail_unless(res == 0, "Failed to delete item from set: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to delete item from set: %s", strerror(errno));
 
   /* Note that we add this item back, just so that the set is NOT empty when
    * we go to remove it entirely.
@@ -4385,16 +4385,16 @@ START_TEST (redis_sorted_set_delete_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4410,31 +4410,31 @@ START_TEST (redis_sorted_set_getn_test) {
 
   mark_point();
   res = pr_redis_sorted_set_getn(NULL, NULL, NULL, NULL, 0, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, NULL, NULL, NULL, 0, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, NULL, NULL, 0, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, NULL, 0, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -4442,21 +4442,21 @@ START_TEST (redis_sorted_set_getn_test) {
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 0, 0, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 0, 0, &values, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 0, 0, &values, &valueszs,
     0);
-  fail_unless(res < 0, "Failed to handle invalid flags value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid flags value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
@@ -4465,7 +4465,7 @@ START_TEST (redis_sorted_set_getn_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   val = "bar";
@@ -4474,7 +4474,7 @@ START_TEST (redis_sorted_set_getn_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   val = "baz";
@@ -4483,46 +4483,46 @@ START_TEST (redis_sorted_set_getn_test) {
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add item to key '%s': %s", key,
+  ck_assert_msg(res == 0, "Failed to add item to key '%s': %s", key,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 0, 3, &values, &valueszs,
     PR_REDIS_SORTED_SET_FL_DESC);
-  fail_unless(res == 0, "Failed to get items in sorted set: %s",
+  ck_assert_msg(res == 0, "Failed to get items in sorted set: %s",
     strerror(errno));
-  fail_unless(values != NULL, "Expected values, got null");
-  fail_unless(valueszs != NULL, "Expected valueszs, got null");
-  fail_unless(values->nelts == 3, "Expected 3, got %u", values->nelts);
-  fail_unless(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
+  ck_assert_msg(values != NULL, "Expected values, got null");
+  ck_assert_msg(valueszs != NULL, "Expected valueszs, got null");
+  ck_assert_msg(values->nelts == 3, "Expected 3, got %u", values->nelts);
+  ck_assert_msg(valueszs->nelts == 3, "Expected 3, got %u", valueszs->nelts);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 1, 2, &values, &valueszs,
     PR_REDIS_SORTED_SET_FL_ASC);
-  fail_unless(res == 0, "Failed to get items in sorted set: %s",
+  ck_assert_msg(res == 0, "Failed to get items in sorted set: %s",
     strerror(errno));
-  fail_unless(values != NULL, "Expected values, got null");
-  fail_unless(valueszs != NULL, "Expected valueszs, got null");
-  fail_unless(values->nelts == 2, "Expected 2, got %u", values->nelts);
-  fail_unless(valueszs->nelts == 2, "Expected 2, got %u", valueszs->nelts);
+  ck_assert_msg(values != NULL, "Expected values, got null");
+  ck_assert_msg(valueszs != NULL, "Expected valueszs, got null");
+  ck_assert_msg(values->nelts == 2, "Expected 2, got %u", values->nelts);
+  ck_assert_msg(valueszs->nelts == 2, "Expected 2, got %u", valueszs->nelts);
 
   mark_point();
   res = pr_redis_sorted_set_getn(p, redis, &m, key, 1, 10, &values, &valueszs,
     PR_REDIS_SORTED_SET_FL_ASC);
-  fail_unless(res == 0, "Failed to get items in sorted set: %s",
+  ck_assert_msg(res == 0, "Failed to get items in sorted set: %s",
     strerror(errno));
-  fail_unless(values != NULL, "Expected values, got null");
-  fail_unless(valueszs != NULL, "Expected valueszs, got null");
-  fail_unless(values->nelts == 2, "Expected 2, got %u", values->nelts);
-  fail_unless(valueszs->nelts == 2, "Expected 2, got %u", valueszs->nelts);
+  ck_assert_msg(values != NULL, "Expected values, got null");
+  ck_assert_msg(valueszs != NULL, "Expected valueszs, got null");
+  ck_assert_msg(values->nelts == 2, "Expected 2, got %u", values->nelts);
+  ck_assert_msg(valueszs->nelts == 2, "Expected 2, got %u", valueszs->nelts);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4537,25 +4537,25 @@ START_TEST (redis_sorted_set_incr_test) {
 
   mark_point();
   res = pr_redis_sorted_set_incr(NULL, NULL, NULL, NULL, 0, 0.0, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, NULL, NULL, NULL, 0, 0.0, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, NULL, NULL, 0, 0.0, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testval";
@@ -4563,16 +4563,16 @@ START_TEST (redis_sorted_set_incr_test) {
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, key, NULL, 0, 0.0, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, key, val, 0, 0.0, NULL);
-  fail_unless(res < 0, "Failed to handle empty value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -4580,33 +4580,33 @@ START_TEST (redis_sorted_set_incr_test) {
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, key, val, valsz, incr, NULL);
-  fail_unless(res < 0, "Failed to handle null current value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null current value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, key, val, valsz, incr, &curr);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, incr);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_incr(redis, &m, key, val, valsz, -incr, &curr);
-  fail_unless(res == 0, "Failed to increment key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to increment key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4621,25 +4621,25 @@ START_TEST (redis_sorted_set_score_test) {
 
   mark_point();
   res = pr_redis_sorted_set_score(NULL, NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, NULL, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, NULL, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testval";
@@ -4647,50 +4647,50 @@ START_TEST (redis_sorted_set_score_test) {
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, key, NULL, 0, NULL);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "foo";
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, key, val, 0, NULL);
-  fail_unless(res < 0, "Failed to handle empty value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, key, val, valsz, NULL);
-  fail_unless(res < 0, "Failed to handle null score");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null score");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, key, val, valsz, &score);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, 1.0);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_score(redis, &m, key, val, valsz, &score);
-  fail_unless(res == 0, "Failed to score key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to score key '%s', val '%s': %s", key, val,
     strerror(errno));
-  fail_unless(score > 0.0, "Expected > 0.0, got %0.3f", score);
+  ck_assert_msg(score > 0.0, "Expected > 0.0, got %0.3f", score);
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4705,25 +4705,25 @@ START_TEST (redis_sorted_set_set_test) {
 
   mark_point();
   res = pr_redis_sorted_set_set(NULL, NULL, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, NULL, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, &m, NULL, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testkey";
@@ -4731,8 +4731,8 @@ START_TEST (redis_sorted_set_set_test) {
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, &m, key, NULL, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle null value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   val = "testval";
@@ -4740,8 +4740,8 @@ START_TEST (redis_sorted_set_set_test) {
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, &m, key, val, 0, 0.0);
-  fail_unless(res < 0, "Failed to handle zero valuesz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero valuesz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valsz = strlen(val);
@@ -4749,29 +4749,29 @@ START_TEST (redis_sorted_set_set_test) {
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, &m, key, val, valsz, score);
-  fail_unless(res < 0, "Failed to handle nonexistent key");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent key");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_add(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to add key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   score = 23.11;
 
   mark_point();
   res = pr_redis_sorted_set_set(redis, &m, key, val, valsz, score);
-  fail_unless(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
+  ck_assert_msg(res == 0, "Failed to set key '%s', val '%s': %s", key, val,
     strerror(errno));
 
   mark_point();
   res = pr_redis_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove key '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 
@@ -4784,25 +4784,25 @@ START_TEST (redis_sorted_set_setall_test) {
 
   mark_point();
   res = pr_redis_sorted_set_setall(NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null redis");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null redis");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   redis = pr_redis_conn_new(p, NULL, 0);
-  fail_unless(redis != NULL, "Failed to open connection to Redis: %s",
+  ck_assert_msg(redis != NULL, "Failed to open connection to Redis: %s",
     strerror(errno));
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null module");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null module");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   key = "testsetkey";
@@ -4810,32 +4810,32 @@ START_TEST (redis_sorted_set_setall_test) {
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   vals = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle empty values");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty values");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((char **) push_array(vals)) = pstrdup(p, "Some JSON here");
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   valszs = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, NULL);
-  fail_unless(res < 0, "Failed to handle empty valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("Some JSON here");
@@ -4843,32 +4843,32 @@ START_TEST (redis_sorted_set_setall_test) {
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, NULL);
-  fail_unless(res < 0, "Failed to handle mismatched values/valueszs");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle mismatched values/valueszs");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((size_t *) push_array(valszs)) = strlen("bar");
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, NULL);
-  fail_unless(res < 0, "Failed to handle null scores");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null scores");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   scores = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, scores);
-  fail_unless(res < 0, "Failed to handle empty scores");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle empty scores");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((float *) push_array(scores)) = 1.0;
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, scores);
-  fail_unless(res < 0, "Failed to handle mismatched values/scores");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle mismatched values/scores");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   *((float *) push_array(scores)) = 2.0;
@@ -4878,16 +4878,16 @@ START_TEST (redis_sorted_set_setall_test) {
 
   mark_point();
   res = pr_redis_sorted_set_setall(redis, &m, key, vals, valszs, scores);
-  fail_unless(res == 0, "Failed to set items using key '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set items using key '%s': %s",
     key, strerror(errno));
 
   mark_point();
   res = pr_redis_set_remove(redis, &m, key);
-  fail_unless(res == 0, "Failed to remove set '%s': %s", key, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove set '%s': %s", key, strerror(errno));
 
   mark_point();
   res = pr_redis_conn_destroy(redis);
-  fail_unless(res == TRUE, "Failed to close redis: %s", strerror(errno));
+  ck_assert_msg(res == TRUE, "Failed to close redis: %s", strerror(errno));
 }
 END_TEST
 

--- a/tests/api/regexp.c
+++ b/tests/api/regexp.c
@@ -55,7 +55,7 @@ START_TEST (regexp_alloc_test) {
   pr_regex_t *res;
 
   res = pr_regexp_alloc(NULL);
-  fail_unless(res != NULL, "Failed to allocate regex: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to allocate regex: %s", strerror(errno));
   pr_regexp_free(NULL, res);
 }
 END_TEST
@@ -73,20 +73,20 @@ START_TEST (regexp_error_test) {
 
   mark_point();
   res = pr_regexp_error(0, NULL, NULL, 0);
-  fail_unless(res == 0, "Failed to handle null regexp");
+  ck_assert_msg(res == 0, "Failed to handle null regexp");
 
   pre = (const pr_regex_t *) 3;
 
   mark_point();
   res = pr_regexp_error(0, pre, NULL, 0);
-  fail_unless(res == 0, "Failed to handle null buf");
+  ck_assert_msg(res == 0, "Failed to handle null buf");
 
   bufsz = 256;
   buf = pcalloc(p, bufsz);
 
   mark_point();
   res = pr_regexp_error(0, pre, buf, 0);
-  fail_unless(res == 0, "Failed to handle zero bufsz");
+  ck_assert_msg(res == 0, "Failed to handle zero bufsz");
 }
 END_TEST
 
@@ -98,44 +98,44 @@ START_TEST (regexp_compile_test) {
 
   mark_point();
   res = pr_regexp_compile(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   pre = pr_regexp_alloc(NULL);
   res = pr_regexp_compile(pre, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pattern");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pattern");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pattern = "[=foo";
   res = pr_regexp_compile(pre, pattern, 0); 
-  fail_unless(res != 0, "Successfully compiled pattern unexpectedly"); 
+  ck_assert_msg(res != 0, "Successfully compiled pattern unexpectedly"); 
 
   errstrlen = pr_regexp_error(1, NULL, NULL, 0);
-  fail_unless(errstrlen == 0, "Failed to handle null arguments");
+  ck_assert_msg(errstrlen == 0, "Failed to handle null arguments");
 
   errstrlen = pr_regexp_error(1, pre, NULL, 0);
-  fail_unless(errstrlen == 0, "Failed to handle null buffer");
+  ck_assert_msg(errstrlen == 0, "Failed to handle null buffer");
 
   errstrlen = pr_regexp_error(1, pre, errstr, 0);
-  fail_unless(errstrlen == 0, "Failed to handle zero buffer length");
+  ck_assert_msg(errstrlen == 0, "Failed to handle zero buffer length");
 
   errstrlen = pr_regexp_error(res, pre, errstr, sizeof(errstr));
-  fail_unless(errstrlen > 0, "Failed to get regex compilation error string");
+  ck_assert_msg(errstrlen > 0, "Failed to get regex compilation error string");
 
   mark_point();
   pattern = "foo";
   res = pr_regexp_compile(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   mark_point();
   pr_regexp_free(NULL, pre);
   pre = pr_regexp_alloc(NULL);
   pattern = "foo";
   res = pr_regexp_compile(pre, pattern, REG_ICASE);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
   pr_regexp_free(NULL, pre);
 }
 END_TEST
@@ -147,31 +147,31 @@ START_TEST (regexp_compile_posix_test) {
   size_t errstrlen;
 
   res = pr_regexp_compile_posix(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pre = pr_regexp_alloc(NULL);
 
   res = pr_regexp_compile_posix(pre, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pattern");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pattern");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pattern = "[=foo";
   res = pr_regexp_compile_posix(pre, pattern, 0);
-  fail_unless(res != 0, "Successfully compiled pattern unexpectedly");
+  ck_assert_msg(res != 0, "Successfully compiled pattern unexpectedly");
 
   errstrlen = pr_regexp_error(res, pre, errstr, sizeof(errstr));
-  fail_unless(errstrlen > 0, "Failed to get regex compilation error string");
+  ck_assert_msg(errstrlen > 0, "Failed to get regex compilation error string");
 
   pattern = "foo";
   res = pr_regexp_compile_posix(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   pattern = "foo";
   res = pr_regexp_compile_posix(pre, pattern, REG_ICASE);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   pr_regexp_free(NULL, pre);
 }
@@ -184,24 +184,24 @@ START_TEST (regexp_get_pattern_test) {
   char *pattern;
 
   str = pr_regexp_get_pattern(NULL);
-  fail_unless(str == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(str == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pre = pr_regexp_alloc(NULL);
 
   str = pr_regexp_get_pattern(pre);
-  fail_unless(str == NULL, "Failed to handle null pattern");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(str == NULL, "Failed to handle null pattern");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   pattern = "^foo";
   res = pr_regexp_compile(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   str = pr_regexp_get_pattern(pre);
-  fail_unless(str != NULL, "Failed to get regex pattern: %s", strerror(errno));
-  fail_unless(strcmp(str, pattern) == 0, "Expected '%s', got '%s'", pattern,
+  ck_assert_msg(str != NULL, "Failed to get regex pattern: %s", strerror(errno));
+  ck_assert_msg(strcmp(str, pattern) == 0, "Expected '%s', got '%s'", pattern,
     str);
 
   pr_regexp_free(NULL, pre);
@@ -214,17 +214,17 @@ START_TEST (regexp_set_limits_test) {
   const char *pattern, *str;
 
   res = pr_regexp_set_limits(0, 0);
-  fail_unless(res == 0, "Failed to set limits: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set limits: %s", strerror(errno));
 
   /* Set the limits, and compile/execute a regex. */
   res = pr_regexp_set_limits(1, 1);
-  fail_unless(res == 0, "Failed to set limits: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set limits: %s", strerror(errno));
 
   pre = pr_regexp_alloc(NULL);
 
   pattern = "^foo";
   res = pr_regexp_compile(pre, pattern, REG_ICASE);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   str = "fooBAR";
   (void) pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
@@ -239,48 +239,48 @@ START_TEST (regexp_exec_test) {
   char *pattern, *str;
 
   res = pr_regexp_exec(NULL, NULL, 0, NULL, 0, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pre = pr_regexp_alloc(NULL);
 
   pattern = "^foo";
   res = pr_regexp_compile(pre, pattern, REG_ICASE);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   res = pr_regexp_exec(pre, NULL, 0, NULL, 0, 0, 0);
-  fail_unless(res != 0, "Failed to handle null string");
+  ck_assert_msg(res != 0, "Failed to handle null string");
 
   str = "bar";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res != 0, "Matched string unexpectedly");
+  ck_assert_msg(res != 0, "Matched string unexpectedly");
 
   str = "foobar";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
   str = "FOOBAR";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
   pr_regexp_free(NULL, pre);
   pre = pr_regexp_alloc(NULL);
 
   pattern = "^foo";
   res = pr_regexp_compile_posix(pre, pattern, REG_ICASE);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   res = pr_regexp_exec(pre, NULL, 0, NULL, 0, 0, 0);
-  fail_unless(res != 0, "Failed to handle null string");
+  ck_assert_msg(res != 0, "Failed to handle null string");
 
   str = "BAR";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res != 0, "Matched string unexpectedly");
+  ck_assert_msg(res != 0, "Matched string unexpectedly");
 
   str = "foobar";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
 #if !defined(PR_USE_PCRE2) && \
     !defined(PR_USE_PCRE)
@@ -289,7 +289,7 @@ START_TEST (regexp_exec_test) {
    */
   str = "FOOBAR";
   res = pr_regexp_exec(pre, str, 0, NULL, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 #endif /* !PR_USE_PCRE2 and !PR_USE_PCRE */
 
   pr_regexp_free(NULL, pre);
@@ -310,14 +310,14 @@ START_TEST (regexp_capture_posix_test) {
 
   pattern = "(.*)";
   res = pr_regexp_compile_posix(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   nmatches = 10;
   matches = pcalloc(p, sizeof(regmatch_t) * nmatches);
 
   str = "foobar";
   res = pr_regexp_exec(pre, str, nmatches, matches, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
   for (i = 0; i < nmatches; i++) {
     int match_len;
@@ -331,15 +331,15 @@ START_TEST (regexp_capture_posix_test) {
     match_text = &(str[matches[i].rm_so]);
     match_len = matches[i].rm_eo - matches[i].rm_so;
 
-    fail_unless(strcmp(match_text, str) == 0,
+    ck_assert_msg(strcmp(match_text, str) == 0,
       "Expected matched text '%s', got '%s'", str, match_text);
-    fail_unless(match_len == 6,
+    ck_assert_msg(match_len == 6,
       "Expected match text len 6, got %d", match_len);
 
     captured = TRUE;
   }
 
-  fail_unless(captured == TRUE,
+  ck_assert_msg(captured == TRUE,
     "POSIX regex failed to capture expected groups");
 
   pr_regexp_free(NULL, pre);
@@ -360,14 +360,14 @@ START_TEST (regexp_capture_pcre_test) {
 
   pattern = "(.*)";
   res = pr_regexp_compile(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   nmatches = 10;
   matches = pcalloc(p, sizeof(regmatch_t) * nmatches);
 
   str = "foobar";
   res = pr_regexp_exec(pre, str, nmatches, matches, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
   for (i = 0; i < nmatches; i++) {
     int match_len;
@@ -381,15 +381,15 @@ START_TEST (regexp_capture_pcre_test) {
     match_text = &(str[matches[i].rm_so]);
     match_len = matches[i].rm_eo - matches[i].rm_so;
 
-    fail_unless(strcmp(match_text, str) == 0,
+    ck_assert_msg(strcmp(match_text, str) == 0,
       "Expected matched text '%s', got '%s' (i = %u)", str, match_text, i);
-    fail_unless(match_len == 6,
+    ck_assert_msg(match_len == 6,
       "Expected match text len 6, got %d (i = %u)", match_len, i);
 
     captured = TRUE;
   }
 
-  fail_unless(captured == TRUE,
+  ck_assert_msg(captured == TRUE,
     "PCRE regex failed to capture expected groups");
 
   pr_regexp_free(NULL, pre);
@@ -410,14 +410,14 @@ START_TEST (regexp_capture_pcre2_test) {
 
   pattern = "(.*)";
   res = pr_regexp_compile(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regex pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regex pattern '%s'", pattern);
 
   nmatches = 10;
   matches = pcalloc(p, sizeof(regmatch_t) * nmatches);
 
   str = "foobar";
   res = pr_regexp_exec(pre, str, nmatches, matches, 0, 0, 0);
-  fail_unless(res == 0, "Failed to match string");
+  ck_assert_msg(res == 0, "Failed to match string");
 
   for (i = 0; i < nmatches; i++) {
     int match_len;
@@ -431,15 +431,15 @@ START_TEST (regexp_capture_pcre2_test) {
     match_text = &(str[matches[i].rm_so]);
     match_len = matches[i].rm_eo - matches[i].rm_so;
 
-    fail_unless(strcmp(match_text, str) == 0,
+    ck_assert_msg(strcmp(match_text, str) == 0,
       "Expected matched text '%s', got '%s' (i = %u)", str, match_text, i);
-    fail_unless(match_len == 6,
+    ck_assert_msg(match_len == 6,
       "Expected match text len 6, got %d (i = %u)", match_len, i);
 
     captured = TRUE;
   }
 
-  fail_unless(captured == TRUE,
+  ck_assert_msg(captured == TRUE,
     "PCRE2 regex failed to capture expected groups");
 
   pr_regexp_free(NULL, pre);
@@ -456,17 +456,17 @@ START_TEST (regexp_cleanup_test) {
 
   pre = pr_regexp_alloc(NULL);
   res = pr_regexp_compile(pre, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regexp pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regexp pattern '%s'", pattern);
 
   pattern = "bar$";
   pre2 = pr_regexp_alloc(NULL);
   res = pr_regexp_compile(pre2, pattern, 0);
-  fail_unless(res == 0, "Failed to compile regexp pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile regexp pattern '%s'", pattern);
 
   pattern = "&baz$";
   pre3 = pr_regexp_alloc(NULL);
   res = pr_regexp_compile_posix(pre3, pattern, 0);
-  fail_unless(res == 0, "Failed to compile POSIX regexp pattern '%s'", pattern);
+  ck_assert_msg(res == 0, "Failed to compile POSIX regexp pattern '%s'", pattern);
 
   mark_point();
   pr_event_generate("core.restart", NULL);
@@ -487,38 +487,38 @@ START_TEST (regexp_set_engine_test) {
 
   mark_point();
   res = pr_regexp_set_engine(NULL);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to restore default engine: %s", strerror(errno));
 
   mark_point();
   res = pr_regexp_set_engine("foobar");
-  fail_unless(res < 0, "Failed to handle unknown engine");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle unknown engine");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_regexp_set_engine("posix");
-  fail_unless(res == 0, "Failed to handle POSIX engine: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle POSIX engine: %s", strerror(errno));
 
   mark_point();
   res = pr_regexp_set_engine("pcre");
 #if defined(PR_USE_PCRE)
-  fail_unless(res == 0, "Failed to handle PCRE engine: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle PCRE engine: %s", strerror(errno));
 #else
-  fail_unless(res < 0,
+  ck_assert_msg(res < 0,
     "Failed to handle PCRE engine when lacking PCRE support");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_PCRE */
 
   mark_point();
   res = pr_regexp_set_engine("pcre2");
 #if defined(PR_USE_PCRE2)
-  fail_unless(res == 0, "Failed to handle PCRE2 engine: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle PCRE2 engine: %s", strerror(errno));
 #else
-  fail_unless(res < 0,
+  ck_assert_msg(res < 0,
     "Failed to handle PCRE2 engine when lacking PCRE2 support");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got %s (%d)", ENOSYS,
     strerror(errno), errno);
 #endif /* PR_USE_PCRE2 */
 

--- a/tests/api/response.c
+++ b/tests/api/response.c
@@ -69,7 +69,7 @@ START_TEST (response_pool_get_test) {
   pool *res;
 
   res = pr_response_get_pool();
-  fail_unless(res == NULL, "Response pool not null as expected");
+  ck_assert_msg(res == NULL, "Response pool not null as expected");
 }
 END_TEST
 
@@ -78,7 +78,7 @@ START_TEST (response_pool_set_test) {
 
   pr_response_set_pool(p);
   res = pr_response_get_pool();
-  fail_unless(res == p, "Response pool not %p as expected", p);
+  ck_assert_msg(res == p, "Response pool not %p as expected", p);
 }
 END_TEST
 
@@ -105,15 +105,15 @@ START_TEST (response_add_test) {
   pr_response_add(NULL, "%s", resp_msg);
 
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last values: %d (%s)", errno,
+  ck_assert_msg(res == 0, "Failed to get last values: %d (%s)", errno,
     strerror(errno));
 
-  fail_unless(last_resp_code != NULL, "Last response code unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(last_resp_code != NULL, "Last response code unexpectedly null");
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
   
-  fail_unless(last_resp_msg != NULL, "Last response message unexpectedly null");
-  fail_unless(strcmp(last_resp_msg, resp_msg) == 0,
+  ck_assert_msg(last_resp_msg != NULL, "Last response message unexpectedly null");
+  ck_assert_msg(strcmp(last_resp_msg, resp_msg) == 0,
     "Expected response message '%s', got '%s'", resp_msg, last_resp_msg);
 }
 END_TEST
@@ -137,15 +137,15 @@ START_TEST (response_add_err_test) {
   pr_response_add_err(resp_code, "%s", resp_msg);
 
   res = pr_response_get_last(p, &last_resp_code, &last_resp_msg);
-  fail_unless(res == 0, "Failed to get last values: %d (%s)", errno,
+  ck_assert_msg(res == 0, "Failed to get last values: %d (%s)", errno,
     strerror(errno));
 
-  fail_unless(last_resp_code != NULL, "Last response code unexpectedly null");
-  fail_unless(strcmp(last_resp_code, resp_code) == 0,
+  ck_assert_msg(last_resp_code != NULL, "Last response code unexpectedly null");
+  ck_assert_msg(strcmp(last_resp_code, resp_code) == 0,
     "Expected response code '%s', got '%s'", resp_code, last_resp_code);
 
-  fail_unless(last_resp_msg != NULL, "Last response message unexpectedly null");
-  fail_unless(strcmp(last_resp_msg, resp_msg) == 0,
+  ck_assert_msg(last_resp_msg != NULL, "Last response message unexpectedly null");
+  ck_assert_msg(strcmp(last_resp_msg, resp_msg) == 0,
     "Expected response message '%s', got '%s'", resp_msg, last_resp_msg);
 }
 END_TEST
@@ -155,22 +155,22 @@ START_TEST (response_get_last_test) {
   const char *resp_code = NULL, *resp_msg = NULL;
 
   res = pr_response_get_last(NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected errno %d (%s), got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected errno %d (%s), got %d (%s)",
     EINVAL, strerror(EINVAL), errno, strerror(errno));
 
   res = pr_response_get_last(p, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected errno %d (%s), got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected errno %d (%s), got %d (%s)",
     EINVAL, strerror(EINVAL), errno, strerror(errno));
 
   res = pr_response_get_last(p, &resp_code, &resp_msg);
-  fail_unless(res == 0, "Failed to get last values: %d (%s)", errno,
+  ck_assert_msg(res == 0, "Failed to get last values: %d (%s)", errno,
     strerror(errno));
 
-  fail_unless(resp_code == NULL,
+  ck_assert_msg(resp_code == NULL,
     "Last response code not null as expected: %s", resp_code);
-  fail_unless(resp_msg == NULL,
+  ck_assert_msg(resp_msg == NULL,
     "Last response message not null as expected: %s", resp_msg);
 }
 END_TEST
@@ -179,15 +179,15 @@ START_TEST (response_block_test) {
   int res;
 
   res = pr_response_block(-1);
-  fail_unless(res == -1, "Failed to handle invalid argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle invalid argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)",
     EINVAL, strerror(errno), errno);
 
   res = pr_response_block(TRUE);
-  fail_unless(res == 0, "Failed to block responses: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to block responses: %s", strerror(errno));
 
   res = pr_response_block(FALSE);
-  fail_unless(res == 0, "Failed to unblock responses: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to unblock responses: %s", strerror(errno));
 }
 END_TEST
 
@@ -196,11 +196,11 @@ START_TEST (response_blocked_test) {
 
   (void) pr_response_block(TRUE);
   res = pr_response_blocked();
-  fail_unless(res == TRUE, "Failed to detect blocked responses");
+  ck_assert_msg(res == TRUE, "Failed to detect blocked responses");
 
   (void) pr_response_block(FALSE);
   res = pr_response_blocked();
-  fail_unless(res == FALSE, "Failed to detect unblocked responses");
+  ck_assert_msg(res == FALSE, "Failed to detect unblocked responses");
 }
 END_TEST
 
@@ -257,7 +257,7 @@ START_TEST (response_flush_test) {
   netio->write = response_netio_write_cb;
 
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   conn = pr_inet_create_conn(p, sockfd, NULL, INPORT_ANY, FALSE);
@@ -279,7 +279,7 @@ START_TEST (response_flush_test) {
   session.c = NULL;
   pr_unregister_netio(PR_NETIO_STRM_CTRL);
 
-  fail_unless(resp_nlines == 3, "Expected 3 response lines flushed, got %u",
+  ck_assert_msg(resp_nlines == 3, "Expected 3 response lines flushed, got %u",
     resp_nlines);
 }
 END_TEST
@@ -294,7 +294,7 @@ START_TEST (response_send_test) {
   netio->write = response_netio_write_cb;
 
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   conn = pr_inet_create_conn(p, sockfd, NULL, INPORT_ANY, FALSE);
@@ -313,7 +313,7 @@ START_TEST (response_send_test) {
   session.c = NULL;
   pr_unregister_netio(PR_NETIO_STRM_CTRL);
 
-  fail_unless(resp_nlines == 1, "Expected 1 response line flushed, got %u",
+  ck_assert_msg(resp_nlines == 1, "Expected 1 response line flushed, got %u",
     resp_nlines);
 }
 END_TEST
@@ -328,7 +328,7 @@ START_TEST (response_send_async_test) {
   netio->write = response_netio_write_cb;
 
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   conn = pr_inet_create_conn(p, sockfd, NULL, INPORT_ANY, FALSE);
@@ -347,10 +347,10 @@ START_TEST (response_send_async_test) {
   session.c = NULL;
   pr_unregister_netio(PR_NETIO_STRM_CTRL);
 
-  fail_unless(resp_nlines == 1, "Expected 1 response line flushed, got %u",
+  ck_assert_msg(resp_nlines == 1, "Expected 1 response line flushed, got %u",
     resp_nlines);
-  fail_unless(resp_line != NULL, "Expected response line");
-  fail_unless(strcmp(resp_line, "200 OK\r\n") == 0,
+  ck_assert_msg(resp_line != NULL, "Expected response line");
+  ck_assert_msg(strcmp(resp_line, "200 OK\r\n") == 0,
     "Expected '200 OK', got '%s'", resp_line);
 }
 END_TEST
@@ -365,7 +365,7 @@ START_TEST (response_send_raw_test) {
   netio->write = response_netio_write_cb;
 
   res = pr_register_netio(netio, PR_NETIO_STRM_CTRL);
-  fail_unless(res == 0, "Failed to register custom ctrl NetIO: %s",
+  ck_assert_msg(res == 0, "Failed to register custom ctrl NetIO: %s",
     strerror(errno));
 
   conn = pr_inet_create_conn(p, sockfd, NULL, INPORT_ANY, FALSE);
@@ -384,7 +384,7 @@ START_TEST (response_send_raw_test) {
   session.c = NULL;
   pr_unregister_netio(PR_NETIO_STRM_CTRL);
 
-  fail_unless(resp_nlines == 1, "Expected 1 response line flushed, got %u",
+  ck_assert_msg(resp_nlines == 1, "Expected 1 response line flushed, got %u",
     resp_nlines);
 }
 END_TEST

--- a/tests/api/rlimit.c
+++ b/tests/api/rlimit.c
@@ -46,12 +46,12 @@ START_TEST (rlimit_core_test) {
   rlim_t curr_rlim = 0, max_rlim = 0 ;
 
   res = pr_rlimit_get_core(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_rlimit_get_core(&curr_rlim, &max_rlim);
-  fail_unless(res == 0, "Failed to get core resource limits: %s",
+  ck_assert_msg(res == 0, "Failed to get core resource limits: %s",
     strerror(errno));
 
   curr_rlim = max_rlim = -1;
@@ -61,7 +61,7 @@ START_TEST (rlimit_core_test) {
    * arguments are negative.  Hence this conditional check.
    */
   if (res < 0) {
-    fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+    ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
       strerror(errno), errno);
   }
 }
@@ -72,12 +72,12 @@ START_TEST (rlimit_cpu_test) {
   rlim_t curr_rlim = 0, max_rlim = 0 ;
 
   res = pr_rlimit_get_cpu(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_rlimit_get_cpu(&curr_rlim, &max_rlim);
-  fail_unless(res == 0, "Failed to get CPU resource limits: %s",
+  ck_assert_msg(res == 0, "Failed to get CPU resource limits: %s",
     strerror(errno));
 
   curr_rlim = max_rlim = -1;
@@ -87,7 +87,7 @@ START_TEST (rlimit_cpu_test) {
    * arguments are negative.  Hence this conditional check.
    */
   if (res < 0) {
-    fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+    ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
       strerror(errno), errno);
   }
 }
@@ -98,12 +98,12 @@ START_TEST (rlimit_files_test) {
   rlim_t curr_rlim = 0, max_rlim = 0 ;
 
   res = pr_rlimit_get_files(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_rlimit_get_files(&curr_rlim, &max_rlim);
-  fail_unless(res == 0, "Failed to get file resource limits: %s",
+  ck_assert_msg(res == 0, "Failed to get file resource limits: %s",
     strerror(errno));
 
   curr_rlim = max_rlim = -1;
@@ -113,7 +113,7 @@ START_TEST (rlimit_files_test) {
    * arguments are negative.  Hence this conditional check.
    */
   if (res < 0) {
-    fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+    ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
       strerror(errno), errno);
   }
 }
@@ -124,12 +124,12 @@ START_TEST (rlimit_memory_test) {
   rlim_t curr_rlim = 0, max_rlim = 0 ;
 
   res = pr_rlimit_get_memory(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_rlimit_get_memory(&curr_rlim, &max_rlim);
-  fail_unless(res == 0, "Failed to get memory resource limits: %s",
+  ck_assert_msg(res == 0, "Failed to get memory resource limits: %s",
     strerror(errno));
 
   curr_rlim = max_rlim = -1;
@@ -139,7 +139,7 @@ START_TEST (rlimit_memory_test) {
    * arguments are negative.  Hence this conditional check.
    */
   if (res < 0) {
-    fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+    ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
       strerror(errno), errno);
   }
 }
@@ -151,12 +151,12 @@ START_TEST (rlimit_nproc_test) {
   rlim_t curr_rlim = 0, max_rlim = 0 ;
 
   res = pr_rlimit_get_nproc(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = pr_rlimit_get_nproc(&curr_rlim, &max_rlim);
-  fail_unless(res == 0, "Failed to get nproc resource limits: %s",
+  ck_assert_msg(res == 0, "Failed to get nproc resource limits: %s",
     strerror(errno));
 
   curr_rlim = max_rlim = -1;
@@ -166,7 +166,7 @@ START_TEST (rlimit_nproc_test) {
    * arguments are negative.  Hence this conditional check.
    */
   if (res < 0) {
-    fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
+    ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %s (%d)",
       strerror(errno), errno);
   }
 }

--- a/tests/api/scoreboard.c
+++ b/tests/api/scoreboard.c
@@ -225,7 +225,7 @@ START_TEST (scoreboard_open_close_test) {
     if (res == 0) {
       (void) unlink(symlink_path);
 
-      fail("Unexpectedly opened symlink scoreboard");
+      ck_abort_msg("Unexpectedly opened symlink scoreboard");
     }
 
     if (errno != EPERM) {
@@ -233,7 +233,7 @@ START_TEST (scoreboard_open_close_test) {
 
       (void) unlink(symlink_path);
 
-      fail("Failed to set errno to EPERM (got %d)", xerrno);
+      ck_abort_msg("Failed to set errno to EPERM (got %d)", xerrno);
     }
 
     (void) unlink(symlink_path);
@@ -251,7 +251,7 @@ START_TEST (scoreboard_open_close_test) {
 
     (void) unlink(symlink_path);
 
-    fail("Failed to set errno to EINVAL (got %d)", xerrno);
+    ck_abort_msg("Failed to set errno to EINVAL (got %d)", xerrno);
   }
 
   (void) unlink(test_mutex);
@@ -569,13 +569,13 @@ START_TEST (scoreboard_scrub_test) {
   if (euid != 0) {
     if (errno != EPERM &&
         errno != ENOENT) {
-      fail("Failed to set errno to EPERM/ENOENT, got %d [%s] (euid = %lu)",
+      ck_abort_msg("Failed to set errno to EPERM/ENOENT, got %d [%s] (euid = %lu)",
         errno, strerror(errno), (unsigned long) euid);
     }
 
   } else {
     if (errno != ENOENT) {
-      fail("Failed to set errno to ENOENT, got %d [%s] (euid = %lu)", errno,
+      ck_abort_msg("Failed to set errno to ENOENT, got %d [%s] (euid = %lu)", errno,
         strerror(errno), (unsigned long) euid);
     }
   }
@@ -613,7 +613,7 @@ START_TEST (scoreboard_get_daemon_pid_test) {
 
   daemon_pid = pr_scoreboard_get_daemon_pid();
   if (daemon_pid != getpid()) {
-    fail("Expected %lu, got %lu", (unsigned long) getpid(),
+    ck_abort_msg("Expected %lu, got %lu", (unsigned long) getpid(),
       (unsigned long) daemon_pid);
   }
 
@@ -626,7 +626,7 @@ START_TEST (scoreboard_get_daemon_pid_test) {
 
   daemon_pid = pr_scoreboard_get_daemon_pid();
   if (daemon_pid != 0) {
-    fail("Expected %lu, got %lu", (unsigned long) 0,
+    ck_abort_msg("Expected %lu, got %lu", (unsigned long) 0,
       (unsigned long) daemon_pid);
   }
 
@@ -659,7 +659,7 @@ START_TEST (scoreboard_get_daemon_uptime_test) {
   now = time(NULL);
 
   if (daemon_uptime > now) {
-    fail("Expected %lu, got %lu", (unsigned long) now,
+    ck_abort_msg("Expected %lu, got %lu", (unsigned long) now,
       (unsigned long) daemon_uptime);
   }
 
@@ -672,7 +672,7 @@ START_TEST (scoreboard_get_daemon_uptime_test) {
 
   daemon_uptime = pr_scoreboard_get_daemon_uptime();
   if (daemon_uptime != 0) {
-    fail("Expected %lu, got %lu", (unsigned long) 0,
+    ck_abort_msg("Expected %lu, got %lu", (unsigned long) 0,
       (unsigned long) daemon_uptime);
   }
 
@@ -804,7 +804,7 @@ START_TEST (scoreboard_entry_read_test) {
     strerror(errno));
 
   if (score->sce_pid != getpid()) {
-    fail("Failed to read expected scoreboard entry (expected PID %lu, got %lu)",
+    ck_abort_msg("Failed to read expected scoreboard entry (expected PID %lu, got %lu)",
       (unsigned long) getpid(), (unsigned long) score->sce_pid);
   }
 

--- a/tests/api/scoreboard.c
+++ b/tests/api/scoreboard.c
@@ -75,17 +75,17 @@ START_TEST (scoreboard_get_test) {
   ok = PR_RUN_DIR "/proftpd.scoreboard";
 
   res = pr_get_scoreboard();
-  fail_unless(res != NULL, "Failed to get scoreboard path: %s",
+  ck_assert_msg(res != NULL, "Failed to get scoreboard path: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ok) == 0,
+  ck_assert_msg(strcmp(res, ok) == 0,
     "Expected scoreboard path '%s', got '%s'", ok, res);
 
   ok = PR_RUN_DIR "/proftpd.scoreboard.lck";
 
   res = pr_get_scoreboard_mutex();
-  fail_unless(res != NULL, "Failed to get scoreboard mutex path: %s",
+  ck_assert_msg(res != NULL, "Failed to get scoreboard mutex path: %s",
     strerror(errno));
-  fail_unless(strcmp(res, ok) == 0,
+  ck_assert_msg(strcmp(res, ok) == 0,
     "Expected scoreboard mutex path '%s', got '%s'", ok, res);
 }
 END_TEST
@@ -96,50 +96,50 @@ START_TEST (scoreboard_set_test) {
 
   mark_point();
   res = pr_set_scoreboard(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = pr_set_scoreboard("foo");
-  fail_unless(res < 0, "Failed to handle non-path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res < 0, "Failed to handle non-path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   mark_point();
   res = pr_set_scoreboard("foo/");
-  fail_unless(res < 0, "Failed to handle relative path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res < 0, "Failed to handle relative path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   mark_point();
   res = pr_set_scoreboard("/foo");
-  fail_unless(res < 0, "Failed to handle nonexistent path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   mark_point();
   res = pr_set_scoreboard("/tmp");
-  fail_unless(res < 0, "Failed to handle nonexistent path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   mark_point();
   res = pr_set_scoreboard("/tmp/");
-  fail_unless(res < 0, "Failed to handle nonexistent path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   mark_point();
   res = pr_set_scoreboard("/tmp/foo/bar");
-  fail_unless(res < 0, "Failed to handle nonexistent path argument");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle nonexistent path argument");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = mkdir(test_dir, 0777);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to create tmp directory '%s': %s", test_dir, strerror(errno));
   res = chmod(test_dir, 0777);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to create set 0777 perms on '%s': %s", test_dir, strerror(errno));
 
   mark_point();
@@ -150,34 +150,34 @@ START_TEST (scoreboard_set_test) {
   (void) close(fd);
 
   res = pr_set_scoreboard("/tmp/foo/bar");
-  fail_unless(res < 0, "Failed to handle non-directory path argument");
-  fail_unless(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
+  ck_assert_msg(res < 0, "Failed to handle non-directory path argument");
+  ck_assert_msg(errno == ENOTDIR, "Expected ENOTDIR (%d), got %s (%d)", ENOTDIR,
     strerror(errno), errno);
   (void) unlink("/tmp/foo");
 
   mark_point();
   res = pr_set_scoreboard(test_dir);
-  fail_unless(res < 0, "Failed to handle nonexistent file argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle nonexistent file argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   res = pr_set_scoreboard("/tmp/prt-scoreboard/bar");
-  fail_unless(res < 0, "Failed to handle world-writable path argument");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res < 0, "Failed to handle world-writable path argument");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set 0775 perms on '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set 0775 perms on '%s': %s", test_dir,
     strerror(errno));
 
   mark_point();
   res = pr_set_scoreboard("/tmp/prt-scoreboard/bar");
-  fail_unless(res == 0, "Failed to set scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set scoreboard: %s", strerror(errno));
   (void) rmdir(test_dir);
 
   path = pr_get_scoreboard();
-  fail_unless(path != NULL, "Failed to get scoreboard path: %s",
+  ck_assert_msg(path != NULL, "Failed to get scoreboard path: %s",
     strerror(errno));  
-  fail_unless(strcmp("/tmp/prt-scoreboard/bar", path) == 0,
+  ck_assert_msg(strcmp("/tmp/prt-scoreboard/bar", path) == 0,
     "Expected '%s', got '%s'", "/tmp/prt-scoreboard/bar", path);
 
   (void) rmdir(test_dir);
@@ -189,16 +189,16 @@ START_TEST (scoreboard_set_mutex_test) {
   const char *path;
 
   res = pr_set_scoreboard_mutex(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_set_scoreboard_mutex("/tmp");
-  fail_unless(res == 0, "Failed to set scoreboard mutex: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set scoreboard mutex: %s", strerror(errno));
 
   path = pr_get_scoreboard_mutex();
-  fail_unless(path != NULL, "Failed to get scoreboard mutex path: %s",
+  ck_assert_msg(path != NULL, "Failed to get scoreboard mutex path: %s",
     strerror(errno));  
-  fail_unless(strcmp("/tmp", path) == 0,
+  ck_assert_msg(strcmp("/tmp", path) == 0,
     "Expected '%s', got '%s'", "/tmp", path);
 }
 END_TEST
@@ -208,15 +208,15 @@ START_TEST (scoreboard_open_close_test) {
   const char *symlink_path = "/tmp/prt-scoreboard/symlink";
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   if (symlink(symlink_path, test_file) == 0) {
@@ -239,12 +239,12 @@ START_TEST (scoreboard_open_close_test) {
     (void) unlink(symlink_path);
 
     res = pr_set_scoreboard(test_file);
-    fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+    ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
       strerror(errno));
   }
 
   res = pr_open_scoreboard(O_RDONLY);
-  fail_unless(res < 0, "Unexpectedly opened scoreboard using O_RDONLY");
+  ck_assert_msg(res < 0, "Unexpectedly opened scoreboard using O_RDONLY");
 
   if (errno != EINVAL) {
     int xerrno = errno;
@@ -257,34 +257,34 @@ START_TEST (scoreboard_open_close_test) {
   (void) unlink(test_mutex);
   (void) unlink(test_file);
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   /* Try opening the scoreboard again; it should be OK, since we are the
    * opener.
    */
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard again: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard again: %s", strerror(errno));
 
   /* Now that we have a scoreboard, try opening it again using O_RDONLY. */
   mark_point();
   pr_close_scoreboard(FALSE);
 
   res = pr_open_scoreboard(O_RDONLY);
-  fail_unless(res < 0, "Unexpectedly opened scoreboard using O_RDONLY");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly opened scoreboard using O_RDONLY");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = pr_close_scoreboard(FALSE);
-  fail_unless(res == 0, "Failed to close scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close scoreboard: %s", strerror(errno));
 
   /* Close the already-closed scoreboard, to assert that it is a no-op. */
   mark_point();
   res = pr_close_scoreboard(FALSE);
-  fail_unless(res == 0, "Failed to close scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close scoreboard: %s", strerror(errno));
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -297,16 +297,16 @@ START_TEST (scoreboard_open_invalid_header_test) {
   pr_scoreboard_header_t sch;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s': %s", test_dir,
     strerror(errno));
 
   (void) unlink(test_file);
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   /* Bad magic */
@@ -320,7 +320,7 @@ START_TEST (scoreboard_open_invalid_header_test) {
   (void) write(fd, &sch, sizeof(sch));
   (void) close(fd);
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == PR_SCORE_ERR_BAD_MAGIC,
+  ck_assert_msg(res == PR_SCORE_ERR_BAD_MAGIC,
     "Failed to handle invalid header magic; expected %d, got %d",
     PR_SCORE_ERR_BAD_MAGIC, res);
   (void) unlink(test_file);
@@ -338,7 +338,7 @@ START_TEST (scoreboard_open_invalid_header_test) {
   (void) write(fd, &sch, sizeof(sch));
   (void) close(fd);
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == PR_SCORE_ERR_OLDER_VERSION,
+  ck_assert_msg(res == PR_SCORE_ERR_OLDER_VERSION,
     "Failed to handle too-old header version; expected %d, got %d",
     PR_SCORE_ERR_OLDER_VERSION, res);
   (void) unlink(test_file);
@@ -356,7 +356,7 @@ START_TEST (scoreboard_open_invalid_header_test) {
   (void) write(fd, &sch, sizeof(sch));
   (void) close(fd);
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == PR_SCORE_ERR_NEWER_VERSION,
+  ck_assert_msg(res == PR_SCORE_ERR_NEWER_VERSION,
     "Failed to handle too-new header version; expected %d, got %d",
     PR_SCORE_ERR_NEWER_VERSION, res);
   (void) unlink(test_file);
@@ -370,47 +370,47 @@ START_TEST (scoreboard_lock_test) {
   int fd = -1, lock_type = -1, res;
 
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res < 0, "Failed to handle bad lock type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad lock type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   lock_type = F_RDLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR, S_IRUSR|S_IWUSR);
-  fail_unless(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
+  ck_assert_msg(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
 
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_WRLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_UNLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_WRLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   /* Note: apparently attempt to lock (again) a file on which a lock
    * (of the same type) is already held will succeed.  Huh.
    */
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_RDLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_UNLCK;
   res = pr_lock_scoreboard(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   (void) unlink(test_file2);
 }
@@ -421,30 +421,30 @@ START_TEST (scoreboard_delete_test) {
   struct stat st;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = stat(pr_get_scoreboard(), &st);
-  fail_unless(res == 0, "Failed to stat scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to stat scoreboard: %s", strerror(errno));
 
   pr_delete_scoreboard();
 
   res = stat(pr_get_scoreboard(), &st);
-  fail_unless(res < 0, "Unexpectedly found deleted scoreboard");
+  ck_assert_msg(res < 0, "Unexpectedly found deleted scoreboard");
 
   res = stat(pr_get_scoreboard_mutex(), &st);
-  fail_unless(res < 0, "Unexpectedly found deleted scoreboard mutex");
+  ck_assert_msg(res < 0, "Unexpectedly found deleted scoreboard mutex");
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -457,45 +457,45 @@ START_TEST (scoreboard_restore_test) {
   const char *path;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   mark_point();
   res = pr_restore_scoreboard();
-  fail_unless(res < 0, "Unexpectedly restored scoreboard");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly restored scoreboard");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   mark_point();
   res = pr_restore_scoreboard();
-  fail_unless(res < 0,
+  ck_assert_msg(res < 0,
     "Restoring scoreboard before rewind succeeded unexpectedly");
 
   mark_point();
   res = pr_rewind_scoreboard();
-  fail_unless(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
   res = pr_restore_scoreboard();
-  fail_unless(res == 0, "Failed to restore scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to restore scoreboard: %s", strerror(errno));
 
   mark_point();
   path = pr_get_scoreboard();
   res = pr_set_scoreboard("none");
-  fail_unless(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
   res = pr_restore_scoreboard();
-  fail_unless(res == 0, "Failed to restore scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to restore scoreboard: %s", strerror(errno));
   res = pr_set_scoreboard(path);
-  fail_unless(res == 0, "Failed to enable scoreboarding: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to enable scoreboarding: %s", strerror(errno));
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -508,37 +508,37 @@ START_TEST (scoreboard_rewind_test) {
   const char *path;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   mark_point();
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_rewind_scoreboard();
-  fail_unless(res < 0, "Unexpectedly rewound scoreboard");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly rewound scoreboard");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
   res = pr_rewind_scoreboard();
-  fail_unless(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
 
   mark_point();
   path = pr_get_scoreboard();
   res = pr_set_scoreboard("none");
-  fail_unless(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
   res = pr_rewind_scoreboard();
-  fail_unless(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to rewind scoreboard: %s", strerror(errno));
   res = pr_set_scoreboard(path);
-  fail_unless(res == 0, "Failed to enable scoreboarding: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to enable scoreboarding: %s", strerror(errno));
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -551,19 +551,19 @@ START_TEST (scoreboard_scrub_test) {
   int res;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_scoreboard_scrub();
-  fail_unless(res < 0, "Unexpectedly scrubbed scoreboard");
+  ck_assert_msg(res < 0, "Unexpectedly scrubbed scoreboard");
 
   euid = geteuid();
   if (euid != 0) {
@@ -581,10 +581,10 @@ START_TEST (scoreboard_scrub_test) {
   }
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = pr_scoreboard_scrub();
-  fail_unless(res == 0, "Failed to scrub scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to scrub scoreboard: %s", strerror(errno));
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -597,19 +597,19 @@ START_TEST (scoreboard_get_daemon_pid_test) {
   pid_t daemon_pid;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   daemon_pid = pr_scoreboard_get_daemon_pid();
   if (daemon_pid != getpid()) {
@@ -622,7 +622,7 @@ START_TEST (scoreboard_get_daemon_pid_test) {
   ServerType = SERVER_INETD;
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   daemon_pid = pr_scoreboard_get_daemon_pid();
   if (daemon_pid != 0) {
@@ -641,19 +641,19 @@ START_TEST (scoreboard_get_daemon_uptime_test) {
   time_t daemon_uptime, now;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   daemon_uptime = pr_scoreboard_get_daemon_uptime();
   now = time(NULL);
@@ -668,7 +668,7 @@ START_TEST (scoreboard_get_daemon_uptime_test) {
   ServerType = SERVER_INETD;
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   daemon_uptime = pr_scoreboard_get_daemon_uptime();
   if (daemon_uptime != 0) {
@@ -686,32 +686,32 @@ START_TEST (scoreboard_entry_add_test) {
   int res;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res < 0, "Unexpectedly added entry to scoreboard");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly added entry to scoreboard");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res == 0, "Failed to add entry to scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to add entry to scoreboard: %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res < 0, "Unexpectedly added entry to scoreboard");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly added entry to scoreboard");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   (void) unlink(test_mutex);
@@ -724,41 +724,41 @@ START_TEST (scoreboard_entry_del_test) {
   int res;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_scoreboard_entry_del(FALSE);
-  fail_unless(res < 0, "Unexpectedly deleted entry from scoreboard");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly deleted entry from scoreboard");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = pr_scoreboard_entry_del(FALSE);
-  fail_unless(res < 0, "Unexpectedly deleted entry from scoreboard");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly deleted entry from scoreboard");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res == 0, "Failed to add entry to scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to add entry to scoreboard: %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_del(FALSE);
-  fail_unless(res == 0, "Failed to delete entry from scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to delete entry from scoreboard: %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_del(FALSE);
-  fail_unless(res < 0, "Unexpectedly deleted entry from scoreboard");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly deleted entry from scoreboard");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(test_mutex);
@@ -772,35 +772,35 @@ START_TEST (scoreboard_entry_read_test) {
   pr_scoreboard_entry_t *score;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   score = pr_scoreboard_entry_read();
-  fail_unless(score == NULL, "Unexpectedly read scoreboard entry");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(score == NULL, "Unexpectedly read scoreboard entry");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   /* We expect NULL here because the scoreboard file should be empty. */
   score = pr_scoreboard_entry_read();
-  fail_unless(score == NULL, "Unexpectedly read scoreboard entry");
+  ck_assert_msg(score == NULL, "Unexpectedly read scoreboard entry");
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res == 0, "Failed to add entry to scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to add entry to scoreboard: %s",
     strerror(errno));
 
   score = pr_scoreboard_entry_read();
-  fail_unless(score != NULL, "Failed to read scoreboard entry: %s",
+  ck_assert_msg(score != NULL, "Failed to read scoreboard entry: %s",
     strerror(errno));
 
   if (score->sce_pid != getpid()) {
@@ -809,7 +809,7 @@ START_TEST (scoreboard_entry_read_test) {
   }
 
   score = pr_scoreboard_entry_read();
-  fail_unless(score == NULL, "Unexpectedly read scoreboard entry");
+  ck_assert_msg(score == NULL, "Unexpectedly read scoreboard entry");
 
   (void) unlink(test_mutex);
   (void) unlink(test_file);
@@ -834,42 +834,42 @@ START_TEST (scoreboard_entry_get_test) {
   };
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   val = pr_scoreboard_entry_get(-1);
-  fail_unless(val == NULL, "Unexpectedly read value from scoreboard entry");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(val == NULL, "Unexpectedly read value from scoreboard entry");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   val = pr_scoreboard_entry_get(-1);
-  fail_unless(val == NULL, "Unexpectedly read value from scoreboard entry");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(val == NULL, "Unexpectedly read value from scoreboard entry");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res == 0, "Failed to add entry to scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to add entry to scoreboard: %s",
     strerror(errno));
 
   val = pr_scoreboard_entry_get(-1);
-  fail_unless(val == NULL, "Unexpectedly read value from scoreboard entry");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(val == NULL, "Unexpectedly read value from scoreboard entry");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   for (i = 0; scoreboard_fields[i] != -1; i++) {
     val = pr_scoreboard_entry_get(scoreboard_fields[i]);
-    fail_unless(val != NULL, "Failed to read scoreboard field %d: %s",
+    ck_assert_msg(val != NULL, "Failed to read scoreboard field %d: %s",
       scoreboard_fields[i], strerror(errno));
   }
 
@@ -889,126 +889,126 @@ START_TEST (scoreboard_entry_update_test) {
   unsigned long elapsed;
 
   res = mkdir(test_dir, 0775);
-  fail_unless(res == 0, "Failed to create directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, 0775);
-  fail_unless(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to set perms on '%s' to 0775': %s", test_dir,
     strerror(errno));
 
   res = pr_set_scoreboard(test_file);
-  fail_unless(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
+  ck_assert_msg(res == 0, "Failed to set scoreboard to '%s': %s", test_file,
     strerror(errno));
 
   res = pr_scoreboard_entry_update(pid, 0);
-  fail_unless(res < 0, "Unexpectedly updated scoreboard entry");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly updated scoreboard entry");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_open_scoreboard(O_RDWR);
-  fail_unless(res == 0, "Failed to open scoreboard: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to open scoreboard: %s", strerror(errno));
 
   res = pr_scoreboard_entry_update(pid, 0);
-  fail_unless(res < 0, "Unexpectedly updated scoreboard entry");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly updated scoreboard entry");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   res = pr_scoreboard_entry_add();
-  fail_unless(res == 0, "Failed to add entry to scoreboard: %s",
+  ck_assert_msg(res == 0, "Failed to add entry to scoreboard: %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_update(pid, -1);
-  fail_unless(res < 0, "Unexpectedly updated scoreboard entry");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Unexpectedly updated scoreboard entry");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   val = "cwd";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CWD, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CWD: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CWD: %s", strerror(errno));
  
   val = pr_scoreboard_entry_get(PR_SCORE_CWD); 
-  fail_unless(val != NULL, "Failed to get entry PR_SCORE_CWD: %s",
+  ck_assert_msg(val != NULL, "Failed to get entry PR_SCORE_CWD: %s",
     strerror(errno));
-  fail_unless(strcmp(val, "cwd") == 0, "Expected 'cwd', got '%s'", val);
+  ck_assert_msg(strcmp(val, "cwd") == 0, "Expected 'cwd', got '%s'", val);
 
   val = "user";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_USER, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_USER: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_USER: %s", strerror(errno));
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '127.0.0.1': %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CLIENT_ADDR, addr, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CLIENT_ADDR: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CLIENT_ADDR: %s",
     strerror(errno));
 
   val = "remote_name";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CLIENT_NAME, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CLIENT_NAME: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CLIENT_NAME: %s",
     strerror(errno));
 
   val = "session_class";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CLASS, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CLASS: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CLASS: %s", strerror(errno));
 
   val = "USER";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CMD, "%s", val, NULL, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CMD: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CMD: %s", strerror(errno));
 
   val = "foo bar";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_CMD_ARG, "%s", val, NULL,
     NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_CMD_ARG: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_CMD_ARG: %s",
     strerror(errno));
 
   num = 77;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_SERVER_PORT, num, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_SERVER_PORT: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_SERVER_PORT: %s",
     strerror(errno));
 
   res = pr_scoreboard_entry_update(pid, PR_SCORE_SERVER_ADDR, addr, num, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_SERVER_ADDR: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_SERVER_ADDR: %s",
     strerror(errno));
 
   val = "label";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_SERVER_LABEL, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_SERVER_LABEL: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_SERVER_LABEL: %s",
     strerror(errno));
  
   now = 1;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_BEGIN_IDLE, now, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_BEGIN_IDLE: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_BEGIN_IDLE: %s",
     strerror(errno));
 
   now = 2;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_BEGIN_SESSION, now, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_BEGIN_SESSION: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_BEGIN_SESSION: %s",
     strerror(errno));
 
   len = 7;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_XFER_DONE, len, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_XFER_DONE: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_XFER_DONE: %s",
     strerror(errno));
 
   len = 8;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_XFER_SIZE, len, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_XFER_SIZE: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_XFER_SIZE: %s",
     strerror(errno));
 
   len = 9;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_XFER_LEN, len, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_XFER_LEN: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_XFER_LEN: %s",
     strerror(errno));
 
   elapsed = 1;
   res = pr_scoreboard_entry_update(pid, PR_SCORE_XFER_ELAPSED, elapsed, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_XFER_ELAPSED: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_XFER_ELAPSED: %s",
     strerror(errno));
 
   val = "protocol";
   res = pr_scoreboard_entry_update(pid, PR_SCORE_PROTOCOL, val, NULL);
-  fail_unless(res == 0, "Failed to update PR_SCORE_PROTOCOL: %s",
+  ck_assert_msg(res == 0, "Failed to update PR_SCORE_PROTOCOL: %s",
     strerror(errno));
 
   (void) unlink(test_mutex);
@@ -1023,29 +1023,29 @@ START_TEST (scoreboard_entry_kill_test) {
 
   mark_point();
   res = pr_scoreboard_entry_kill(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   sce.sce_pid = 1;
   res = pr_scoreboard_entry_kill(&sce, 0);
-  fail_unless(res < 0, "Failed to handle bad PID");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle bad PID");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   sce.sce_pid = getpid();
   res = pr_scoreboard_entry_kill(&sce, 0);
-  fail_unless(res == 0, "Failed to send signal 0 to PID %lu: %s",
+  ck_assert_msg(res == 0, "Failed to send signal 0 to PID %lu: %s",
     (unsigned long) sce.sce_pid, strerror(errno));
 
   mark_point();
   res = pr_set_scoreboard("none");
-  fail_unless(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to disable scoreboarding: %s", strerror(errno));
   sce.sce_pid = getpid();
   res = pr_scoreboard_entry_kill(&sce, 0);
-  fail_unless(res == 0, "Failed to send signal: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to send signal: %s", strerror(errno));
 }
 END_TEST
 
@@ -1053,47 +1053,47 @@ START_TEST (scoreboard_entry_lock_test) {
   int fd = -1, lock_type = -1, res;
 
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res < 0, "Failed to handle bad lock type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad lock type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   lock_type = F_RDLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res < 0, "Failed to handle bad file descriptor");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle bad file descriptor");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   fd = open(test_file2, O_CREAT|O_EXCL|O_RDWR, S_IRUSR|S_IWUSR);
-  fail_unless(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
+  ck_assert_msg(fd >= 0, "Failed to open '%s': %s", test_file2, strerror(errno));
 
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_WRLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_UNLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_WRLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   /* Note: apparently attempt to lock (again) a file on which a lock
    * (of the same type) is already held will succeed.  Huh.
    */
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_RDLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   lock_type = F_UNLCK;
   res = pr_scoreboard_entry_lock(fd, lock_type);
-  fail_unless(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to lock fd %d: %s", fd, strerror(errno));
 
   (void) unlink(test_file2);
 }
@@ -1117,54 +1117,54 @@ START_TEST (scoreboard_disabled_test) {
     pr_scoreboard_entry_t *score;
 
     res = pr_set_scoreboard(path);
-    fail_unless(res == 0, "Failed set to scoreboard to '%s': %s", path,
+    ck_assert_msg(res == 0, "Failed set to scoreboard to '%s': %s", path,
       strerror(errno));
 
     ok = PR_RUN_DIR "/proftpd.scoreboard";
 
     path = pr_get_scoreboard();
-    fail_unless(path != NULL, "Failed to get scoreboard path: %s",
+    ck_assert_msg(path != NULL, "Failed to get scoreboard path: %s",
       strerror(errno));
-    fail_unless(strcmp(path, ok) == 0,
+    ck_assert_msg(strcmp(path, ok) == 0,
       "Expected path '%s', got '%s'", ok, path);
 
     res = pr_open_scoreboard(O_RDONLY);
-    fail_unless(res == 0, "Failed to open '%s' scoreboard: %s", path,
+    ck_assert_msg(res == 0, "Failed to open '%s' scoreboard: %s", path,
       strerror(errno));
 
     res = pr_scoreboard_scrub();
-    fail_unless(res == 0, "Failed to scrub '%s' scoreboard: %s", path,
+    ck_assert_msg(res == 0, "Failed to scrub '%s' scoreboard: %s", path,
       strerror(errno));
 
     scoreboard_pid = pr_scoreboard_get_daemon_pid();
-    fail_unless(scoreboard_pid == 0,
+    ck_assert_msg(scoreboard_pid == 0,
       "Expected to get scoreboard PID 0, got %lu",
       (unsigned long) scoreboard_pid);
 
     scoreboard_uptime = pr_scoreboard_get_daemon_uptime();
-    fail_unless(scoreboard_uptime == 0,
+    ck_assert_msg(scoreboard_uptime == 0,
       "Expected to get scoreboard uptime 0, got %lu",
       (unsigned long) scoreboard_uptime);
 
     res = pr_scoreboard_entry_add();
-    fail_unless(res == 0, "Failed to add entry to '%s' scoreboard: %s", path,
+    ck_assert_msg(res == 0, "Failed to add entry to '%s' scoreboard: %s", path,
       strerror(errno));
 
     score = pr_scoreboard_entry_read();
-    fail_unless(score == NULL, "Expected null entry");
+    ck_assert_msg(score == NULL, "Expected null entry");
 
     field = pr_scoreboard_entry_get(PR_SCORE_CMD_ARG);
-    fail_unless(field == NULL, "Expected null CMD_ARG field");
+    ck_assert_msg(field == NULL, "Expected null CMD_ARG field");
 
     res = pr_scoreboard_entry_update(getpid(), PR_SCORE_CWD, "foo", NULL);
-    fail_unless(res == 0, "Failed to update CWD field: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to update CWD field: %s", strerror(errno));
 
     res = pr_scoreboard_entry_del(FALSE);
-    fail_unless(res == 0, "Failed to delete entry from '%s' scoreboard: %s",
+    ck_assert_msg(res == 0, "Failed to delete entry from '%s' scoreboard: %s",
       path, strerror(errno));
 
     res = pr_close_scoreboard(FALSE);
-    fail_unless(res == 0, "Failed to close '%s' scoreboard: %s", path,
+    ck_assert_msg(res == 0, "Failed to close '%s' scoreboard: %s", path,
       strerror(errno));
 
     /* Internal hack: even calling pr_set_scoreboard() with a NULL

--- a/tests/api/sets.c
+++ b/tests/api/sets.c
@@ -93,26 +93,26 @@ START_TEST (set_create_test) {
   xaset_t *res;
 
   res = xaset_create(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = xaset_create(p, NULL);
-  fail_unless(res != NULL, "Expected non-null result");
-  fail_unless(res->pool == p, "Expected %p, got %p", p, res->pool);
+  ck_assert_msg(res != NULL, "Expected non-null result");
+  ck_assert_msg(res->pool == p, "Expected %p, got %p", p, res->pool);
 
   permanent_pool = make_sub_pool(p);
 
   res = xaset_create(NULL, NULL);
-  fail_unless(res != NULL, "Expected non-null result");
-  fail_unless(res->pool == permanent_pool, "Expected %p, got %p",
+  ck_assert_msg(res != NULL, "Expected non-null result");
+  ck_assert_msg(res->pool == permanent_pool, "Expected %p, got %p",
     permanent_pool, res->pool);
-  fail_unless(res->xas_compare == NULL, "Expected NULL, got %p",
+  ck_assert_msg(res->xas_compare == NULL, "Expected NULL, got %p",
     res->xas_compare);
 
   res = xaset_create(p, (XASET_COMPARE) item_cmp);
-  fail_unless(res != NULL, "Expected non-null result");
-  fail_unless(res->pool == p, "Expected %p, got %p", p, res->pool);
-  fail_unless(res->xas_compare == (XASET_COMPARE) item_cmp,
+  ck_assert_msg(res != NULL, "Expected non-null result");
+  ck_assert_msg(res->pool == p, "Expected %p, got %p", p, res->pool);
+  ck_assert_msg(res->xas_compare == (XASET_COMPARE) item_cmp,
     "Expected %p, got %p", item_cmp, res->xas_compare);
 
   permanent_pool = NULL;
@@ -126,31 +126,31 @@ START_TEST (set_insert_test) {
   xasetmember_t *member;
  
   res = xaset_insert(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, NULL);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
-  fail_unless(set->xas_list == NULL, "New set has non-empty list");
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list == NULL, "New set has non-empty list");
 
   res = xaset_insert(set, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   item1 = pcalloc(p, sizeof(struct test_item));
   item1->num = 7;
   item1->str = pstrdup(p, "foo");
 
   res = xaset_insert(NULL, (xasetmember_t *) item1);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = xaset_insert(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
-  fail_unless(set->xas_list != NULL, "Set has empty list");
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list != NULL, "Set has empty list");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
+  ck_assert_msg(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
     member);
 
   item2 = pcalloc(p, sizeof(struct test_item));
@@ -158,12 +158,12 @@ START_TEST (set_insert_test) {
   item2->str = pstrdup(p, "bar");
 
   res = xaset_insert(set, (xasetmember_t *) item2);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item2, "Expected %p, got %p", item2,
+  ck_assert_msg(member == (xasetmember_t *) item2, "Expected %p, got %p", item2,
     member);
-  fail_unless(member->next == (xasetmember_t *) item1,
+  ck_assert_msg(member->next == (xasetmember_t *) item1,
     "Next item in list does not point to item1");
 }
 END_TEST
@@ -176,17 +176,17 @@ START_TEST (set_insert_end_test) {
 
   mark_point();
   res = xaset_insert_end(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, NULL);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
-  fail_unless(set->xas_list == NULL, "New set has non-empty list");
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list == NULL, "New set has non-empty list");
 
   mark_point();
   res = xaset_insert_end(set, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   item1 = pcalloc(p, sizeof(struct test_item));
   item1->num = 7;
@@ -194,15 +194,15 @@ START_TEST (set_insert_end_test) {
 
   mark_point();
   res = xaset_insert_end(NULL, (xasetmember_t *) item1);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = xaset_insert_end(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
-  fail_unless(set->xas_list != NULL, "Set has empty list");
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list != NULL, "Set has empty list");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
+  ck_assert_msg(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
     member);
 
   item2 = pcalloc(p, sizeof(struct test_item));
@@ -210,16 +210,16 @@ START_TEST (set_insert_end_test) {
   item2->str = pstrdup(p, "bar");
 
   res = xaset_insert_end(set, (xasetmember_t *) item2);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
 
   member = set->xas_list;
-  fail_unless(member != (xasetmember_t *) item2, "Expected %p, got %p", item2,
+  ck_assert_msg(member != (xasetmember_t *) item2, "Expected %p, got %p", item2,
     member);
-  fail_unless(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
+  ck_assert_msg(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
     member);
-  fail_unless(member->next == (xasetmember_t *) item2,
+  ck_assert_msg(member->next == (xasetmember_t *) item2,
     "Next item in list does not point to item2");
-  fail_unless(item2->prev == item1,
+  ck_assert_msg(item2->prev == item1,
     "Previous item in list does not point to item1");
 }
 END_TEST
@@ -231,40 +231,40 @@ START_TEST (set_insert_sort_test) {
   xasetmember_t *member;
  
   res = xaset_insert_sort(NULL, NULL, FALSE);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, NULL);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
-  fail_unless(set->xas_list == NULL, "New set has non-empty list");
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list == NULL, "New set has non-empty list");
 
   res = xaset_insert_sort(set, NULL, FALSE);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   item1 = pcalloc(p, sizeof(struct test_item));
   item1->num = 7;
   item1->str = pstrdup(p, "foo");
 
   res = xaset_insert_sort(NULL, (xasetmember_t *) item1, FALSE);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* This should fail because we specified a NULL comparator callback. */
   res = xaset_insert_sort(set, (xasetmember_t *) item1, FALSE);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, (XASET_COMPARE) item_cmp);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
-  fail_unless(set->xas_list == NULL, "New set has non-empty list");
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list == NULL, "New set has non-empty list");
 
   res = xaset_insert_sort(set, (xasetmember_t *) item1, FALSE);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
-  fail_unless(set->xas_list != NULL, "Set has empty list");
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list != NULL, "Set has empty list");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
+  ck_assert_msg(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
     member);
 
   /* Now lets try to add another item of the same value, not allowing for dups.
@@ -274,23 +274,23 @@ START_TEST (set_insert_sort_test) {
   item2->str = pstrdup(p, "bar");
 
   res = xaset_insert_sort(set, (xasetmember_t *) item2, FALSE);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
-  fail_unless(set->xas_list != NULL, "Set has empty list");
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list != NULL, "Set has empty list");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
+  ck_assert_msg(member == (xasetmember_t *) item1, "Expected %p, got %p", item1,
     member);
-  fail_unless(member->next == NULL, "Expected only one item on the list");
+  ck_assert_msg(member->next == NULL, "Expected only one item on the list");
 
   /* Add the same item again, this time allowing for dups. */
   res = xaset_insert_sort(set, (xasetmember_t *) item2, TRUE);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
-  fail_unless(set->xas_list != NULL, "Set has empty list");
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(set->xas_list != NULL, "Set has empty list");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item2, "Expected %p, got %p", item2,
+  ck_assert_msg(member == (xasetmember_t *) item2, "Expected %p, got %p", item2,
     member);
-  fail_unless(member->next != NULL, "Expected two items on the list");
+  ck_assert_msg(member->next != NULL, "Expected two items on the list");
 
   /* Add a new item, make sure it sorts properly. */
   item3 = pcalloc(p, sizeof(struct test_item));
@@ -298,18 +298,18 @@ START_TEST (set_insert_sort_test) {
   item3->str = pstrdup(p, "baz");
 
   res = xaset_insert_sort(set, (xasetmember_t *) item3, FALSE);
-  fail_unless(res == 0, "Failed to insert item to set: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to insert item to set: %s", strerror(errno));
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item3, "Expected %p, got %p", item3,
+  ck_assert_msg(member == (xasetmember_t *) item3, "Expected %p, got %p", item3,
     member);
-  fail_unless(member->next != NULL, "Expected a second item on the list");
+  ck_assert_msg(member->next != NULL, "Expected a second item on the list");
 
   member = member->next;
-  fail_unless(member->next != NULL, "Expected a third item on the list");
+  ck_assert_msg(member->next != NULL, "Expected a third item on the list");
 
   member = member->next;
-  fail_unless(member->next == NULL, "Expected only three items on the list");
+  ck_assert_msg(member->next == NULL, "Expected only three items on the list");
 }
 END_TEST
 
@@ -320,79 +320,79 @@ START_TEST (set_remove_test) {
   xasetmember_t *member;
 
   res = xaset_remove(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, NULL);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
 
   res = xaset_remove(set, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   item1 = pcalloc(p, sizeof(struct test_item));
   item1->num = 7;
   item1->str = pstrdup(p, "foo");
 
   res = xaset_remove(NULL, (xasetmember_t *) item1);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = xaset_remove(set, (xasetmember_t *) item1);
-  fail_unless(res == -1, "Failed to handle non-included item properly");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle non-included item properly");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = xaset_insert(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to insert item");
+  ck_assert_msg(res == 0, "Failed to insert item");
 
   res = xaset_remove(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to remove item");
-  fail_unless(set->xas_list == NULL, "Have non-empty list");
+  ck_assert_msg(res == 0, "Failed to remove item");
+  ck_assert_msg(set->xas_list == NULL, "Have non-empty list");
 
   item2 = pcalloc(p, sizeof(struct test_item));
   item2->num = 9;
   item2->str = pstrdup(p, "bar");
 
   res = xaset_insert(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to add item1");
+  ck_assert_msg(res == 0, "Failed to add item1");
 
   res = xaset_insert(set, (xasetmember_t *) item2);
-  fail_unless(res == 0, "Failed to add item2");
+  ck_assert_msg(res == 0, "Failed to add item2");
 
   member = (xasetmember_t *) item1;
-  fail_unless(member->next == NULL, "Expected member->next to be null");
-  fail_unless(member->prev != NULL, "Expected member->prev to not be null");
+  ck_assert_msg(member->next == NULL, "Expected member->next to be null");
+  ck_assert_msg(member->prev != NULL, "Expected member->prev to not be null");
 
   member = (xasetmember_t *) item2;
-  fail_unless(member->next != NULL, "Expected member->next to not be null");
-  fail_unless(member->prev == NULL, "Expected member->prev to be null");
+  ck_assert_msg(member->next != NULL, "Expected member->next to not be null");
+  ck_assert_msg(member->prev == NULL, "Expected member->prev to be null");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item2,
+  ck_assert_msg(member == (xasetmember_t *) item2,
     "Expected head of list to be item2 (%p), got %p", item2, member);
 
   res = xaset_remove(set, (xasetmember_t *) item2);
-  fail_unless(res == 0, "Failed to remove item2 from set: %s",
+  ck_assert_msg(res == 0, "Failed to remove item2 from set: %s",
     strerror(errno));
 
   member = (xasetmember_t *) item2;
-  fail_unless(member->next == NULL, "Expected member->next to be null");
-  fail_unless(member->prev == NULL, "Expected member->prev to be null");
+  ck_assert_msg(member->next == NULL, "Expected member->next to be null");
+  ck_assert_msg(member->prev == NULL, "Expected member->prev to be null");
 
   member = set->xas_list;
-  fail_unless(member == (xasetmember_t *) item1,
+  ck_assert_msg(member == (xasetmember_t *) item1,
     "Expected head of list to be item1 (%p), got %p", item1, member);
   
   res = xaset_remove(set, (xasetmember_t *) item1);
-  fail_unless(res == 0, "Failed to remove item1 from set: %s",
+  ck_assert_msg(res == 0, "Failed to remove item1 from set: %s",
     strerror(errno));
 
   member = (xasetmember_t *) item1;
-  fail_unless(member->next == NULL, "Expected member->next to be null");
-  fail_unless(member->prev == NULL, "Expected member->prev to be null");
+  ck_assert_msg(member->next == NULL, "Expected member->next to be null");
+  ck_assert_msg(member->prev == NULL, "Expected member->prev to be null");
 
   member = set->xas_list;
-  fail_unless(member == NULL, "Expected list to be empty, got %p", member);
+  ck_assert_msg(member == NULL, "Expected list to be empty, got %p", member);
 }
 END_TEST
 
@@ -401,15 +401,15 @@ START_TEST (set_copy_test) {
   struct test_item *item1, *item2;
 
   res = xaset_copy(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   set = xaset_create(p, NULL);
-  fail_unless(set != NULL, "Failed to create set: %s", strerror(errno));
+  ck_assert_msg(set != NULL, "Failed to create set: %s", strerror(errno));
 
   res = xaset_copy(p, set, 0, NULL);
-  fail_unless(res == NULL, "Failed to detect zero-size and null copier");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to detect zero-size and null copier");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   item1 = pcalloc(p, sizeof(struct test_item));
   item1->num = 7;
@@ -418,12 +418,12 @@ START_TEST (set_copy_test) {
   xaset_insert(set, (xasetmember_t *) item1);
 
   res = xaset_copy(p, set, sizeof(struct test_item), NULL);
-  fail_unless(res != NULL, "Failed to copy set: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to copy set: %s", strerror(errno));
 
   item2 = (struct test_item *) res->xas_list;
-  fail_unless(item2->num == item1->num,
+  ck_assert_msg(item2->num == item1->num,
     "Expected copied item num of %d, got %d", item1->num, item2->num);
-  fail_unless(item2->str == item1->str,
+  ck_assert_msg(item2->str == item1->str,
     "Expected copied item str ptr of %p, got %p", item1->str, item2->str);
 
   /* Of course, we don't want the copied set's items to point to the
@@ -433,16 +433,16 @@ START_TEST (set_copy_test) {
    */
 
   res = xaset_copy(p, set, 0, (XASET_MCOPY) item_cpy);
-  fail_unless(res != NULL, "Failed to copy set: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to copy set: %s", strerror(errno));
 
   item2 = (struct test_item *) res->xas_list;
-  fail_unless(item2->num == item1->num,
+  ck_assert_msg(item2->num == item1->num,
     "Expected copied item num of %d, got %d", item1->num, item2->num);
 
-  fail_unless(item2->str != item1->str,
+  ck_assert_msg(item2->str != item1->str,
     "Expected copied item str ptr of %p, got %p", item1->str, item2->str);
 
-  fail_unless(strcmp(item2->str, item1->str) == 0,
+  ck_assert_msg(strcmp(item2->str, item1->str) == 0,
     "Expected copied item str of '%s', got '%s'", item1->str, item2->str);
 }
 END_TEST

--- a/tests/api/stash.c
+++ b/tests/api/stash.c
@@ -50,65 +50,65 @@ START_TEST (stash_add_symbol_test) {
   authtable authtab;
   
   res = pr_stash_add_symbol(0, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_add_symbol(0, "Foo");
-  fail_unless(res == -1, "Failed to handle bad type");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle bad type");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   memset(&conftab, 0, sizeof(conftab));
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == -1, "Failed to handle null conf name");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null conf name");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == -1, "Failed to handle null cmd name");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null cmd name");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == -1, "Failed to handle null auth name");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null auth name");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   memset(&hooktab, 0, sizeof(hooktab));
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == -1, "Failed to handle null hook name");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null hook name");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == -1, "Failed to handle empty conf name");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle empty conf name");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "Foo");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "Foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "Foo");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   memset(&hooktab, 0, sizeof(hooktab));
   hooktab.command = pstrdup(p, "Foo");
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 }
 END_TEST
 
@@ -120,89 +120,89 @@ START_TEST (stash_get_symbol_test) {
   authtable authtab;
 
   sym = pr_stash_get_symbol(0, NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol(0, "foo", NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle bad type argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle bad type argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_CONF, "foo", NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent CONF symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent CONF symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_CMD, "foo", NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent CMD symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent CMD symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_AUTH, "foo", NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent AUTH symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent AUTH symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_HOOK, "foo", NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent HOOK symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent HOOK symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_CONF, "foo", NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get CONF symbol: %s", strerror(errno));
-  fail_unless(sym == &conftab, "Expected %p, got %p", &conftab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get CONF symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &conftab, "Expected %p, got %p", &conftab, sym);
 
   sym = pr_stash_get_symbol(PR_SYM_CONF, "foo", sym, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found CONF symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found CONF symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_CMD, "foo", NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get CMD symbol: %s", strerror(errno));
-  fail_unless(sym == &cmdtab, "Expected %p, got %p", &cmdtab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get CMD symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &cmdtab, "Expected %p, got %p", &cmdtab, sym);
 
   sym = pr_stash_get_symbol(PR_SYM_CMD, "foo", sym, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found CMD symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found CMD symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_AUTH, "foo", NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get AUTH symbol: %s", strerror(errno));
-  fail_unless(sym == &authtab, "Expected %p, got %p", &authtab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &authtab, "Expected %p, got %p", &authtab, sym);
 
   sym = pr_stash_get_symbol(PR_SYM_AUTH, "foo", sym, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found AUTH symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found AUTH symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&hooktab, 0, sizeof(hooktab));
   hooktab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol(PR_SYM_HOOK, "foo", NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get HOOK symbol: %s", strerror(errno));
-  fail_unless(sym == &hooktab, "Expected %p, got %p", &hooktab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &hooktab, "Expected %p, got %p", &hooktab, sym);
 
   sym = pr_stash_get_symbol(PR_SYM_HOOK, "foo", sym, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found HOOK symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found HOOK symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -215,89 +215,89 @@ START_TEST (stash_get_symbol2_test) {
   authtable authtab;
 
   sym = pr_stash_get_symbol2(0, NULL, NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol2(0, "foo", NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle bad type argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle bad type argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_CONF, "foo", NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent CONF symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent CONF symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_CMD, "foo", NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent CMD symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent CMD symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_AUTH, "foo", NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent AUTH symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent AUTH symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_HOOK, "foo", NULL, NULL, NULL);
-  fail_unless(sym == NULL, "Failed to handle nonexistent HOOK symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Failed to handle nonexistent HOOK symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_CONF, "foo", NULL, NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get CONF symbol: %s", strerror(errno));
-  fail_unless(sym == &conftab, "Expected %p, got %p", &conftab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get CONF symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &conftab, "Expected %p, got %p", &conftab, sym);
 
   sym = pr_stash_get_symbol2(PR_SYM_CONF, "foo", sym, NULL, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found CONF symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found CONF symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_CMD, "foo", NULL, NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get CMD symbol: %s", strerror(errno));
-  fail_unless(sym == &cmdtab, "Expected %p, got %p", &cmdtab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get CMD symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &cmdtab, "Expected %p, got %p", &cmdtab, sym);
 
   sym = pr_stash_get_symbol2(PR_SYM_CMD, "foo", sym, NULL, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found CMD symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found CMD symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_AUTH, "foo", NULL, NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get AUTH symbol: %s", strerror(errno));
-  fail_unless(sym == &authtab, "Expected %p, got %p", &authtab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &authtab, "Expected %p, got %p", &authtab, sym);
 
   sym = pr_stash_get_symbol2(PR_SYM_AUTH, "foo", sym, NULL, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found AUTH symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found AUTH symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   memset(&hooktab, 0, sizeof(hooktab));
   hooktab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   sym = pr_stash_get_symbol2(PR_SYM_HOOK, "foo", NULL, NULL, NULL);
-  fail_unless(sym != NULL, "Failed to get HOOK symbol: %s", strerror(errno));
-  fail_unless(sym == &hooktab, "Expected %p, got %p", &hooktab, sym);
+  ck_assert_msg(sym != NULL, "Failed to get HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(sym == &hooktab, "Expected %p, got %p", &hooktab, sym);
 
   sym = pr_stash_get_symbol2(PR_SYM_HOOK, "foo", sym, NULL, NULL);
-  fail_unless(sym == NULL, "Unexpectedly found HOOK symbol");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(sym == NULL, "Unexpectedly found HOOK symbol");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 }
 END_TEST
@@ -319,17 +319,17 @@ START_TEST (stash_dump_test) {
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "Conf");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "Cmd");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "Auth");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   memset(&m, 0, sizeof(m));
   m.name = "testsuite";
@@ -337,22 +337,22 @@ START_TEST (stash_dump_test) {
   hooktab.command = pstrdup(p, "Hook");
   hooktab.m = &m;
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   mark_point();
   pr_stash_dump(stash_dump);
 
   res = pr_stash_remove_symbol(PR_SYM_CONF, "Conf", NULL);
-  fail_unless(res > 0, "Failed to remove CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to remove CONF symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_CMD, "Cmd", NULL);
-  fail_unless(res > 0, "Failed to remove CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to remove CMD symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_AUTH, "Auth", NULL);
-  fail_unless(res > 0, "Failed to remove AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to remove AUTH symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_HOOK, "Hook", NULL);
-  fail_unless(res > 0, "Failed to remove HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res > 0, "Failed to remove HOOK symbol: %s", strerror(errno));
 
   mark_point();
   pr_stash_dump(stash_dump);
@@ -367,61 +367,61 @@ START_TEST (stash_remove_symbol_test) {
   authtable authtab;
 
   res = pr_stash_remove_symbol(0, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_symbol(0, "foo", NULL);
-  fail_unless(res == -1, "Failed to handle bad symbol type");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle bad symbol type");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_CONF, "foo", NULL);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_CONF, "foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_CMD, "foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_AUTH, "foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 
   memset(&hooktab, 0, sizeof(hooktab));
   hooktab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   res = pr_stash_remove_symbol(PR_SYM_HOOK, "foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 }
 END_TEST
 
@@ -430,23 +430,23 @@ START_TEST (stash_remove_conf_test) {
   conftable conftab;
 
   res = pr_stash_remove_conf(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_conf("foo", NULL);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   memset(&conftab, 0, sizeof(conftab));
   conftab.directive = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_CONF, &conftab);
-  fail_unless(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CONF symbol: %s", strerror(errno));
 
   res = pr_stash_remove_conf("foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 }
 END_TEST
 
@@ -455,25 +455,25 @@ START_TEST (stash_remove_cmd_test) {
   cmdtable cmdtab, cmdtab2;
 
   res = pr_stash_remove_cmd(NULL, NULL, 0, NULL, -1);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_cmd("foo", NULL, 0, NULL, -1);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   memset(&cmdtab, 0, sizeof(cmdtab));
   cmdtab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&cmdtab2, 0, sizeof(cmdtab2));
   cmdtab2.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab2);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   res = pr_stash_remove_cmd("foo", NULL, 0, NULL, -1);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 
   /* Remove only the PRE_CMD cmd handlers */
   mark_point();
@@ -481,17 +481,17 @@ START_TEST (stash_remove_cmd_test) {
   cmdtab.command = pstrdup(p, "foo");
   cmdtab.cmd_type = PRE_CMD;
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&cmdtab2, 0, sizeof(cmdtab2));
   cmdtab2.command = pstrdup(p, "foo");
   cmdtab2.cmd_type = CMD;
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab2);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   mark_point();
   res = pr_stash_remove_cmd("foo", NULL, PRE_CMD, NULL, -1);
-  fail_unless(res == 1, "Expected %d, got %d", 1, res);
+  ck_assert_msg(res == 1, "Expected %d, got %d", 1, res);
   (void) pr_stash_remove_symbol(PR_SYM_CMD, "foo", NULL);
 
   /* Remove only the G_WRITE cmd handlers */
@@ -500,16 +500,16 @@ START_TEST (stash_remove_cmd_test) {
   cmdtab.command = pstrdup(p, "foo");
   cmdtab.group = G_WRITE;
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&cmdtab2, 0, sizeof(cmdtab2));
   cmdtab2.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab2);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   mark_point();
   res = pr_stash_remove_cmd("foo", NULL, 0, G_WRITE, -1);
-  fail_unless(res == 1, "Expected %d, got %d", 1, res);
+  ck_assert_msg(res == 1, "Expected %d, got %d", 1, res);
   (void) pr_stash_remove_symbol(PR_SYM_CMD, "foo", NULL);
 
   /* Remove only the CL_SFTP cmd handlers */
@@ -518,17 +518,17 @@ START_TEST (stash_remove_cmd_test) {
   cmdtab.command = pstrdup(p, "foo");
   cmdtab.cmd_class = CL_SFTP;
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   memset(&cmdtab2, 0, sizeof(cmdtab2));
   cmdtab2.command = pstrdup(p, "foo");
   cmdtab2.cmd_class = CL_MISC;
   res = pr_stash_add_symbol(PR_SYM_CMD, &cmdtab2);
-  fail_unless(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add CMD symbol: %s", strerror(errno));
 
   mark_point();
   res = pr_stash_remove_cmd("foo", NULL, 0, NULL, CL_SFTP);
-  fail_unless(res == 1, "Expected %d, got %d", 1, res);
+  ck_assert_msg(res == 1, "Expected %d, got %d", 1, res);
   (void) pr_stash_remove_symbol(PR_SYM_CMD, "foo", NULL);
 }
 END_TEST
@@ -538,23 +538,23 @@ START_TEST (stash_remove_auth_test) {
   authtable authtab;
 
   res = pr_stash_remove_auth(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_auth("foo", NULL);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   memset(&authtab, 0, sizeof(authtab));
   authtab.name = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_AUTH, &authtab);
-  fail_unless(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add AUTH symbol: %s", strerror(errno));
 
   res = pr_stash_remove_auth("foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 }
 END_TEST
 
@@ -563,23 +563,23 @@ START_TEST (stash_remove_hook_test) {
   cmdtable hooktab;
 
   res = pr_stash_remove_hook(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_stash_remove_hook("foo", NULL);
-  fail_unless(res == 0, "Expected %d, got %d", 0, res);
+  ck_assert_msg(res == 0, "Expected %d, got %d", 0, res);
 
   memset(&hooktab, 0, sizeof(hooktab));
   hooktab.command = pstrdup(p, "foo");
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   res = pr_stash_add_symbol(PR_SYM_HOOK, &hooktab);
-  fail_unless(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add HOOK symbol: %s", strerror(errno));
 
   res = pr_stash_remove_hook("foo", NULL);
-  fail_unless(res == 2, "Expected %d, got %d", 2, res);
+  ck_assert_msg(res == 2, "Expected %d, got %d", 2, res);
 }
 END_TEST
 

--- a/tests/api/str.c
+++ b/tests/api/str.c
@@ -48,60 +48,60 @@ START_TEST (sstrncpy_test) {
 
   len = 0;
   res = sstrncpy(NULL, NULL, len);
-  fail_unless(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
 
   dst = "";
   res = sstrncpy(dst, "foo", 0);
-  fail_unless(res == 0, "Failed to handle zero length");
+  ck_assert_msg(res == 0, "Failed to handle zero length");
 
   dst = pcalloc(p, sz);
   memset(dst, 'A', sz);
 
   len = 1;
   res = sstrncpy(dst, NULL, len);
-  fail_unless(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
 
   ok = "Therefore, all progress depends on the unreasonable man";
 
   mark_point();
   res = sstrncpy(ok, ok, 1);
-  fail_unless(res == 1, "Expected result 1, got %d", len, res);
+  ck_assert_msg(res == 1, "Expected result 1, got %d", len, res);
 
   mark_point();
   memset(dst, 'A', sz);
   len = 1;
 
   res = sstrncpy(dst, ok, len);
-  fail_unless((size_t) res <= len, "Expected result %d, got %d", len, res);
-  fail_unless(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
+  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
     strlen(dst));
-  fail_unless(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
+  ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = 7;
 
   res = sstrncpy(dst, ok, len);
-  fail_unless((size_t) res <= len, "Expected result %d, got %d", len, res);
-  fail_unless(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
+  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
     strlen(dst));
-  fail_unless(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
+  ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = sz;
 
   res = sstrncpy(dst, ok, len);
-  fail_unless((size_t) res <= len, "Expected result %d, got %d", len, res);
-  fail_unless(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
+  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
     strlen(dst));
-  fail_unless(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
+  ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = sz;
 
   res = sstrncpy(dst, "", len);
-  fail_unless((size_t) res <= len, "Expected result %d, got %d", len, res);
-  fail_unless(strlen(dst) == 0, "Expected len %u, got len %u", 0, strlen(dst));
-  fail_unless(*dst == '\0', "Expected NUL, got '%c'", *dst);
+  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
+  ck_assert_msg(strlen(dst) == 0, "Expected len %u, got len %u", 0, strlen(dst));
+  ck_assert_msg(*dst == '\0', "Expected NUL, got '%c'", *dst);
 }
 END_TEST
 
@@ -110,35 +110,35 @@ START_TEST (sstrcat_test) {
   char c = 'A', src[1024], dst[1024], *res;
 
   res = sstrcat(dst, src, 0);
-  fail_unless(res == NULL, "Non-null result for zero-length strcat");
+  ck_assert_msg(res == NULL, "Non-null result for zero-length strcat");
 
   src[0] = 'f';
   src[1] = '\0';
   dst[0] = 'e';
   dst[1] = '\0';
   res = sstrcat(dst, src, 1);
-  fail_unless(res == dst, "Returned wrong destination buffer");
+  ck_assert_msg(res == dst, "Returned wrong destination buffer");
 
   /* In this case, we told sstrcat() that dst is len 1, which means that
    * sstrcat() should set dst[0] to NUL.
    */
-  fail_unless(dst[0] == 0, "Failed to terminate destination buffer");
+  ck_assert_msg(dst[0] == 0, "Failed to terminate destination buffer");
 
   src[0] = 'f';
   src[1] = '\0';
   dst[0] = 'e';
   dst[1] = '\0';
   res = sstrcat(dst, src, 2);
-  fail_unless(res == dst, "Returned wrong destination buffer");
+  ck_assert_msg(res == dst, "Returned wrong destination buffer");
 
   /* In this case, we told sstrcat() that dst is len 2, which means that
    * sstrcat() should preserve the value at 0, and set dst[1] to NUL.
    */
-  fail_unless(dst[0] == 'e',
+  ck_assert_msg(dst[0] == 'e',
     "Failed to preserve destination buffer (expected '%c' at index 0, "
     "got '%c')", 'e', dst[0]);
 
-  fail_unless(dst[1] == 0, "Failed to terminate destination buffer");
+  ck_assert_msg(dst[1] == 0, "Failed to terminate destination buffer");
 
   mark_point();
   src[0] = 'f';
@@ -146,20 +146,20 @@ START_TEST (sstrcat_test) {
   dst[0] = 'e';
   dst[1] = '\0';
   res = sstrcat(dst, src, 3);
-  fail_unless(res == dst, "Returned wrong destination buffer");
+  ck_assert_msg(res == dst, "Returned wrong destination buffer");
 
   mark_point();
-  fail_unless(dst[0] == 'e',
+  ck_assert_msg(dst[0] == 'e',
     "Failed to preserve destination buffer (expected '%c' at index 0, "
     "got '%c')", 'e', dst[0]);
 
   mark_point();
-  fail_unless(dst[1] == 'f',
+  ck_assert_msg(dst[1] == 'f',
     "Failed to copy source buffer (expected '%c' at index 1, got '%c')",
     'f', dst[1]);
 
   mark_point();
-  fail_unless(dst[2] == 0, "Failed to terminate destination buffer");
+  ck_assert_msg(dst[2] == 0, "Failed to terminate destination buffer");
 
   mark_point();
   memset(src, c, sizeof(src)-1);
@@ -175,20 +175,20 @@ START_TEST (sstrcat_test) {
   res = sstrcat(dst, src, sizeof(dst));
 
   mark_point();
-  fail_unless(res == dst, "Returned wrong destination buffer");
+  ck_assert_msg(res == dst, "Returned wrong destination buffer");
 
   mark_point();
-  fail_unless(dst[sizeof(dst)-1] == 0,
+  ck_assert_msg(dst[sizeof(dst)-1] == 0,
     "Failed to terminate destination buffer");
 
   mark_point();
-  fail_unless(strlen(dst) == (sizeof(dst)-1),
+  ck_assert_msg(strlen(dst) == (sizeof(dst)-1),
     "Failed to copy all the data (expected len %u, got len %u)",
     sizeof(dst)-1, strlen(dst));
 
   mark_point();
   for (i = 0; i < sizeof(dst)-1; i++) {
-    fail_unless(dst[i] == c, "Copied wrong value (expected '%c', got '%c')",
+    ck_assert_msg(dst[i] == c, "Copied wrong value (expected '%c', got '%c')",
       c, dst[i]);
   }
 }
@@ -199,39 +199,39 @@ START_TEST (sreplace_test) {
   char *fmt = NULL, *ok;
 
   res = sreplace(NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = sreplace(NULL, "", 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = sreplace(p, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   fmt = "%a";
   res = sreplace(p, fmt, "foo", NULL);
-  fail_unless(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
+  ck_assert_msg(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
 
   fmt = "foo %a";
   res = sreplace(p, fmt, "%b", NULL);
-  fail_unless(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
+  ck_assert_msg(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
 
   fmt = "foo %a";
   ok = "foo bar";
   res = sreplace(p, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   fmt = "foo %a %a";
   ok = "foo bar bar";
   res = sreplace(p, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   fmt = "foo %a %a %a %a %a %a %a %a";
   ok = "foo bar bar bar bar bar bar bar bar";
   res = sreplace(p, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   /* sreplace() will not handle more than 8 occurrences of the same escape
    * sequence in the same line.  Make sure this happens.
@@ -239,7 +239,7 @@ START_TEST (sreplace_test) {
   fmt = "foo %a %a %a %a %a %a %a %a %a";
   ok = "foo bar bar bar bar bar bar bar bar bar";
   res = sreplace(p, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
+  ck_assert_msg(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
 }
 END_TEST
 
@@ -255,8 +255,8 @@ START_TEST (sreplace_enospc_test) {
   fmt[bufsz] = '\0';
 
   res = sreplace(p, fmt, "%a", "foo", NULL);
-  fail_unless(res == NULL, "Failed to reject too-long buffer");
-  fail_unless(errno == ENOSPC, "Failed to set errno to ENOSPC");
+  ck_assert_msg(res == NULL, "Failed to reject too-long buffer");
+  ck_assert_msg(errno == ENOSPC, "Failed to set errno to ENOSPC");
 }
 END_TEST
 
@@ -317,7 +317,7 @@ START_TEST (sreplace_bug3614_test) {
     "%{uu}", "bar", "%{vv}", "bar", "%{ww}", "bar", "%{xx}", "bar",
     "%{yy}", "bar", "%{zz}", "bar",
     NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -327,45 +327,45 @@ START_TEST (str_replace_test) {
   int max_replace = PR_STR_MAX_REPLACEMENTS;
 
   res = pr_str_replace(NULL, max_replace, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_replace(NULL, max_replace, "", 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_replace(p, max_replace, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle invalid arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle invalid arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   fmt = "%a";
   res = pr_str_replace(p, max_replace, fmt, "foo", NULL);
-  fail_unless(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
+  ck_assert_msg(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
 
   fmt = "foo %a";
   res = pr_str_replace(p, max_replace, fmt, "%b", NULL);
-  fail_unless(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
+  ck_assert_msg(strcmp(res, fmt) == 0, "Expected '%s', got '%s'", fmt, res);
 
   fmt = "foo %a";
   ok = "foo bar";
   res = pr_str_replace(p, max_replace, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   fmt = "foo %a %a";
   ok = "foo bar bar";
   res = pr_str_replace(p, max_replace, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   fmt = "foo %a %a %a %a %a %a %a %a";
   ok = "foo bar bar bar bar bar bar bar bar";
   res = pr_str_replace(p, max_replace, fmt, "%a", "bar", NULL);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   fmt = "foo %a %a %a %a %a %a %a %a %a";
   ok = "foo bar bar bar bar bar bar bar bar bar";
   res = pr_str_replace(p, max_replace, fmt, "%a", "bar", NULL);
-  fail_unless(res == NULL, "Failed to handle too many replacements");
-  fail_unless(errno == E2BIG, "Failed to set errno to E2BIG");
+  ck_assert_msg(res == NULL, "Failed to handle too many replacements");
+  ck_assert_msg(errno == E2BIG, "Failed to set errno to E2BIG");
 }
 END_TEST
 
@@ -373,13 +373,13 @@ START_TEST (pdircat_test) {
   char *res, *ok;
 
   res = pdircat(NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pdircat(p, 0, NULL);
-  fail_unless(res != NULL,
+  ck_assert_msg(res != NULL,
     "Failed to handle empty arguments (expected '', got '%s')", res);
-  fail_unless(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
+  ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   /* Comments in the pdircat() function suggest that an empty string
    * should be treated as a leading slash.  However, that never got
@@ -388,26 +388,26 @@ START_TEST (pdircat_test) {
    */
   res = pdircat(p, "", NULL);
   ok = "";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pdircat(p, "foo", "bar", NULL);
   ok = "foo/bar";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pdircat(p, "", "foo", "bar", NULL);
   ok = "foo/bar";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pdircat(p, "/", "/foo/", "/bar/", NULL);
   ok = "/foo/bar/";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   /* Sadly, pdircat() only handles single leading/trailing slashes, not
    * an arbitrary number of leading/trailing slashes.
    */
   res = pdircat(p, "//", "//foo//", "//bar//", NULL);
   ok = "///foo///bar//";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -415,33 +415,33 @@ START_TEST (pstrcat_test) {
   char *res, *ok;
 
   res = pstrcat(NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrcat(p, 0, NULL);
-  fail_unless(res != NULL,
+  ck_assert_msg(res != NULL,
     "Failed to handle empty arguments (expected '', got '%s')", res);
-  fail_unless(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
+  ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   res = pstrcat(p, "", NULL);
   ok = "";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrcat(p, "foo", "bar", NULL);
   ok = "foobar";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrcat(p, "", "foo", "bar", NULL);
   ok = "foobar";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrcat(p, "/", "/foo/", "/bar/", NULL);
   ok = "//foo//bar/";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pdircat(p, "//", "//foo//", NULL, "//bar//", NULL);
   ok = "///foo//";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -449,22 +449,22 @@ START_TEST (pstrdup_test) {
   char *res, *ok;
 
   res = pstrdup(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrdup(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrdup(NULL, "");
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrdup(p, "foo");
   ok = "foo";
-  fail_unless(strlen(res) == strlen(ok), "Expected len %u, got len %u",
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
     strlen(ok), strlen(res));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -472,34 +472,34 @@ START_TEST (pstrndup_test) {
   char *res, *ok;
 
   res = pstrndup(NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrndup(p, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrndup(NULL, "", 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pstrndup(p, "foo", 0);
   ok = "";
-  fail_unless(strlen(res) == strlen(ok), "Expected len %u, got len %u",
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
     strlen(ok), strlen(res));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrndup(p, "foo", 1);
   ok = "f";
-  fail_unless(strlen(res) == strlen(ok), "Expected len %u, got len %u",
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
     strlen(ok), strlen(res));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrndup(p, "foo", 10);
   ok = "foo";
-  fail_unless(strlen(res) == strlen(ok), "Expected len %u, got len %u",
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
     strlen(ok), strlen(res));
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -507,44 +507,44 @@ START_TEST (strip_test) {
   const char *ok, *res, *str;
 
   res = pr_str_strip(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_strip(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_strip(NULL, "foo");
-  fail_unless(res == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "foo");
   res = pr_str_strip(p, str);
-  fail_unless(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, " \n \t foo");
   res = pr_str_strip(p, str);
-  fail_unless(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, "foo  \n \t \r");
   res = pr_str_strip(p, str);
-  fail_unless(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, "\r \n\n\t    foo  \n \t \r");
   res = pr_str_strip(p, str);
-  fail_unless(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to strip '%s': %s", str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -552,43 +552,43 @@ START_TEST (strip_end_test) {
   char *ch, *ok, *res, *str;
 
   res = pr_str_strip_end(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "foo");
 
   res = pr_str_strip_end(str, NULL);
-  fail_unless(res == NULL, "Failed to handle null char argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null char argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   ch = "\r\n";
 
   res = pr_str_strip_end(NULL, ch);
-  fail_unless(res == NULL, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_strip_end(str, ch);
-  fail_unless(res != NULL, "Failed to strip '%s' from end of '%s': %s",
+  ck_assert_msg(res != NULL, "Failed to strip '%s' from end of '%s': %s",
     ch, str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, "foo\r\n");
   res = pr_str_strip_end(str, ch);
-  fail_unless(res != NULL, "Failed to strip '%s' from end of '%s': %s",
+  ck_assert_msg(res != NULL, "Failed to strip '%s' from end of '%s': %s",
     ch, str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, "foo\r\n\r\n\r\n");
   res = pr_str_strip_end(str, ch);
-  fail_unless(res != NULL, "Failed to strip '%s' from end of '%s': %s",
+  ck_assert_msg(res != NULL, "Failed to strip '%s' from end of '%s': %s",
     ch, str, strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -596,42 +596,42 @@ START_TEST (get_token_test) {
   char *ok, *res, *str;
 
   res = pr_str_get_token(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = NULL;
   res = pr_str_get_token(&str, NULL);
-  fail_unless(res == NULL, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "foo,bar,baz");
   res = pr_str_get_token(&str, NULL);
-  fail_unless(res == NULL, "Failed to handle null sep argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null sep argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_get_token(&str, ",");
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token(&str, ",");
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "bar";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token(&str, ",");
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "baz";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token(&str, ",");
-  fail_unless(res == NULL, "Unexpectedly got token '%s'", res);
+  ck_assert_msg(res == NULL, "Unexpectedly got token '%s'", res);
 }
 END_TEST
 
@@ -640,55 +640,55 @@ START_TEST (get_token2_test) {
   size_t len = 0, ok_len;
 
   res = pr_str_get_token2(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = NULL;
   res = pr_str_get_token2(&str, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "foo,bar,bazz");
   res = pr_str_get_token2(&str, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null sep argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null sep argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_str_get_token2(&str, ",", &len);
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "foo";
   ok_len = 3;
-  fail_unless(len == ok_len, "Expected len %lu, got %lu",
+  ck_assert_msg(len == ok_len, "Expected len %lu, got %lu",
     (unsigned long) ok_len, (unsigned long) len);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token2(&str, ",", &len);
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "bar";
   ok_len = 3; 
-  fail_unless(len == ok_len, "Expected len %lu, got %lu",
+  ck_assert_msg(len == ok_len, "Expected len %lu, got %lu",
     (unsigned long) ok_len, (unsigned long) len);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token2(&str, ",", &len);
-  fail_unless(res != NULL, "Failed to get token from '%s': %s", str,
+  ck_assert_msg(res != NULL, "Failed to get token from '%s': %s", str,
     strerror(errno));
 
   ok = "bazz";
   ok_len = 4; 
-  fail_unless(len == ok_len, "Expected len %lu, got %lu",
+  ck_assert_msg(len == ok_len, "Expected len %lu, got %lu",
     (unsigned long) ok_len, (unsigned long) len);
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_token2(&str, ",", &len);
 
   ok_len = 0;
-  fail_unless(len == ok_len, "Expected len %lu, got %lu",
+  ck_assert_msg(len == ok_len, "Expected len %lu, got %lu",
     (unsigned long) ok_len, (unsigned long) len);
-  fail_unless(res == NULL, "Unexpectedly got token '%s'", res);
+  ck_assert_msg(res == NULL, "Unexpectedly got token '%s'", res);
 }
 END_TEST
 
@@ -696,80 +696,80 @@ START_TEST (get_word_test) {
   char *ok, *res, *str;
 
   res = pr_str_get_word(NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = NULL;
   res = pr_str_get_word(&str, 0);
-  fail_unless(res == NULL, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = pstrdup(p, "  ");
   res = pr_str_get_word(&str, 0);
-  fail_unless(res == NULL, "Failed to handle whitespace argument");
+  ck_assert_msg(res == NULL, "Failed to handle whitespace argument");
 
   str = pstrdup(p, " foo");
   res = pr_str_get_word(&str, PR_STR_FL_PRESERVE_WHITESPACE);
-  fail_unless(res != NULL, "Failed to handle whitespace argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle whitespace argument: %s",
     strerror(errno));
 
   ok = "";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_word(&str, PR_STR_FL_PRESERVE_WHITESPACE);
-  fail_unless(res != NULL, "Failed to handle whitespace argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle whitespace argument: %s",
     strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   str = pstrdup(p, "  # foo");
   res = pr_str_get_word(&str, 0);
-  fail_unless(res == NULL, "Failed to handle commented argument");
+  ck_assert_msg(res == NULL, "Failed to handle commented argument");
 
   res = pr_str_get_word(&str, PR_STR_FL_PRESERVE_COMMENTS);
-  fail_unless(res != NULL, "Failed to handle commented argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle commented argument: %s",
     strerror(errno));
 
   ok = "#";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_word(&str, PR_STR_FL_PRESERVE_COMMENTS);
-  fail_unless(res != NULL, "Failed to handle commented argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle commented argument: %s",
     strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   /* Test multiple embedded quotes. */
   str = pstrdup(p, "foo \"bar baz\" qux \"quz norf\"");
   res = pr_str_get_word(&str, 0);
-  fail_unless(res != NULL, "Failed to handle quoted argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle quoted argument: %s",
     strerror(errno));
 
   ok = "foo";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_word(&str, 0);
-  fail_unless(res != NULL, "Failed to handle quoted argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle quoted argument: %s",
     strerror(errno));
 
   ok = "bar baz";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_word(&str, 0);
-  fail_unless(res != NULL, "Failed to handle quoted argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle quoted argument: %s",
     strerror(errno));
 
   ok = "qux";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pr_str_get_word(&str, 0);
-  fail_unless(res != NULL, "Failed to handle quoted argument: %s",
+  ck_assert_msg(res != NULL, "Failed to handle quoted argument: %s",
     strerror(errno));
 
   ok = "quz norf";
-  fail_unless(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
+  ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
 
@@ -796,10 +796,10 @@ START_TEST (get_word_utf8_test) {
 
     nread = fread(str, sizeof(char), sz-1, fh);
     fail_if(ferror(fh), "Error reading '%s': %s", path, strerror(errno));
-    fail_unless(nread > 0, "Expected >0 bytes read, got 0");
+    ck_assert_msg(nread > 0, "Expected >0 bytes read, got 0");
 
     res = pr_str_get_word(&str, 0);
-      fail_unless(res != NULL, "Failed to handle UTF8 argument: %s",
+      ck_assert_msg(res != NULL, "Failed to handle UTF8 argument: %s",
       strerror(errno));
 
     ok = "foo";
@@ -814,37 +814,37 @@ START_TEST (is_boolean_test) {
   int res;
 
   res = pr_str_is_boolean(NULL);
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 
   res = pr_str_is_boolean("on");
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_str_is_boolean("Yes");
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_str_is_boolean("TrUe");
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_str_is_boolean("1");
-  fail_unless(res == TRUE, "Expected TRUE, got FALSE");
+  ck_assert_msg(res == TRUE, "Expected TRUE, got FALSE");
 
   res = pr_str_is_boolean("oFF");
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_str_is_boolean("no");
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_str_is_boolean("false");
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_str_is_boolean("0");
-  fail_unless(res == FALSE, "Expected FALSE, got TRUE");
+  ck_assert_msg(res == FALSE, "Expected FALSE, got TRUE");
 
   res = pr_str_is_boolean("foo");
-  fail_unless(res == -1, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
+  ck_assert_msg(res == -1, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL (got %d)",
     errno);
 }
 END_TEST
@@ -854,7 +854,7 @@ START_TEST (is_fnmatch_test) {
   char *str;
 
   res = pr_str_is_fnmatch(NULL);
-  fail_unless(res == FALSE, "Expected false for NULL");
+  ck_assert_msg(res == FALSE, "Expected false for NULL");
 
   str = "foo";
   res = pr_str_is_fnmatch(str);
@@ -906,94 +906,94 @@ START_TEST (get_nbytes_test) {
   int res;
 
   res = pr_str_get_nbytes(NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = NULL;
   res = pr_str_get_nbytes(str, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "1";
   units = "f";
   res = pr_str_get_nbytes(str, units, NULL);
-  fail_unless(res == -1, "Failed to handle bad suffix argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad suffix argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "a";
   units = "";
   res = pr_str_get_nbytes(str, units, NULL);
-  fail_unless(res == -1, "Failed to handle invalid str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle invalid str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "1 1";
   units = "";
   res = pr_str_get_nbytes(str, units, NULL);
-  fail_unless(res == -1, "Failed to handle invalid str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle invalid str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "1.1";
   units = "";
   res = pr_str_get_nbytes(str, units, NULL);
-  fail_unless(res == -1, "Failed to handle invalid str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle invalid str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "-1";
   units = "";
   res = pr_str_get_nbytes(str, units, NULL);
-  fail_unless(res == -1, "Failed to handle invalid str argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle invalid str argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* XXX Test good suffix: B, KB, MB, GB, TB */
 
   str = "1";
   units = "";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1, "Expected nbytes = 1, got %" PR_LU,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1, "Expected nbytes = 1, got %" PR_LU,
     (pr_off_t) nbytes);
 
   str = "1";
   units = "B";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1,
     "Expected nbytes = 1, got %" PR_LU, (pr_off_t) nbytes);
 
   str = "1";
   units = "KB";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1024UL,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1024UL,
     "Expected nbytes = 1024, got %" PR_LU, (pr_off_t) nbytes);
 
   str = "1";
   units = "MB";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1048576UL,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1048576UL,
     "Expected nbytes = 1048576, got %" PR_LU, (pr_off_t) nbytes);
 
   str = "1";
   units = "GB";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1073741824UL,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1073741824UL,
     "Expected nbytes = 1073741824, got %" PR_LU, (pr_off_t) nbytes);
 
   str = "1";
   units = "TB";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
-  fail_unless(nbytes == 1099511627776UL,
+  ck_assert_msg(res == 0, "Expected result 0, got %d: %s", res, strerror(errno));
+  ck_assert_msg(nbytes == 1099511627776UL,
     "Expected nbytes = 1099511627776, got %" PR_LU, (pr_off_t) nbytes);
 
   /* This should definitely trigger the ERANGE error. */
   str = "1099511627776";
   units = "TB";
   res = pr_str_get_nbytes(str, units, &nbytes);
-  fail_unless(res == -1, "Expected ERANGE failure, succeeded unexpectedly");
-  fail_unless(errno == ERANGE, "Expected %s [%d], got %s [%d]",
+  ck_assert_msg(res == -1, "Expected ERANGE failure, succeeded unexpectedly");
+  ck_assert_msg(errno == ERANGE, "Expected %s [%d], got %s [%d]",
     strerror(ERANGE), ERANGE, strerror(errno), errno);
 }
 END_TEST
@@ -1004,196 +1004,196 @@ START_TEST (get_duration_test) {
   int res;
 
   res = pr_str_get_duration(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted string '%s'", str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "-1:-1:-1";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted string '%s'", str);
-  fail_unless(errno == ERANGE, "Failed to set errno to ERANGE");
+  ck_assert_msg(errno == ERANGE, "Failed to set errno to ERANGE");
 
   str = "a:b:c";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted string '%s'", str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "111:222:333";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted string '%s'", str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* Test well-formatted hh::mm::ss strings. */
 
   str = "00:00:00";
   expected = 0;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "01:02:03";
   expected = 3723;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "99:99:99";
   expected = 362439;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   /* Test bad suffixes: -1h, -1hr, 9999foo, etc */
 
   str = "-1h";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted suffix string '%s'", str);
-  fail_unless(errno == ERANGE, "Failed to set errno to ERANGE");
+  ck_assert_msg(errno == ERANGE, "Failed to set errno to ERANGE");
 
   str = "-1hr";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted suffix string '%s'", str);
-  fail_unless(errno == ERANGE, "Failed to set errno to ERANGE");
+  ck_assert_msg(errno == ERANGE, "Failed to set errno to ERANGE");
 
   str = "99foo";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted suffix string '%s'", str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   str = "foo";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted suffix string '%s'", str);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* Test good suffices: "H"/"h"/"hr", "M"/"m"/"min", "S"/"s"/"sec" */
 
   str = "76H";
   expected = 273600;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "76h";
   expected = 273600;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "76Hr";
   expected = 273600;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "888M";
   expected = 53280;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "888m";
   expected = 53280;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "888MiN";
   expected = 53280;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "999S";
   expected = 999;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "999s";
   expected = 999;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "999sEc";
   expected = 999;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "0h";
   expected = 0;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "0M";
   expected = 0;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "0sec";
   expected = 0;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "17";
   expected = 17;
   res = pr_str_get_duration(str, &duration);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to parse well-formed time string '%s': %s", str, strerror(errno));
-  fail_unless(duration == expected,
+  ck_assert_msg(duration == expected,
     "Expected duration %d secs, got %d", expected, duration);
 
   str = "-1";
   res = pr_str_get_duration(str, NULL);
-  fail_unless(res == -1,
+  ck_assert_msg(res == -1,
     "Failed to handle badly formatted suffix string '%s'", str);
-  fail_unless(errno == ERANGE, "Failed to set errno to ERANGE");
+  ck_assert_msg(errno == ERANGE, "Failed to set errno to ERANGE");
 }
 END_TEST
 
@@ -1202,46 +1202,46 @@ START_TEST (strnrstr_test) {
   const char *s = NULL, *suffix = NULL;
 
   res = pr_strnrstr(NULL, 0, NULL, 0, flags);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_strnrstr(NULL, 0, "", 0, flags);
-  fail_unless(res == -1, "Failed to handle null s");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null s");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_strnrstr("", 0, NULL, 0, flags);
-  fail_unless(res == -1, "Failed to handle null suffix");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null suffix");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   s = suffix = "";
   res = pr_strnrstr(s, 0, suffix, 0, flags);
-  fail_unless(res == TRUE, "Expected true, got false");
+  ck_assert_msg(res == TRUE, "Expected true, got false");
 
   s = "";
   suffix = "s";
   res = pr_strnrstr(s, 0, suffix, 0, flags);
-  fail_unless(res == FALSE, "Expected false, got true");
+  ck_assert_msg(res == FALSE, "Expected false, got true");
 
   s = "food";
   suffix = "ood";
   res = pr_strnrstr(s, 0, suffix, 0, flags);
-  fail_unless(res == TRUE, "Expected true, got false");
+  ck_assert_msg(res == TRUE, "Expected true, got false");
 
   s = "food";
   suffix = "ood";
   res = pr_strnrstr(s, 4, suffix, 3, flags);
-  fail_unless(res == TRUE, "Expected true, got false");
+  ck_assert_msg(res == TRUE, "Expected true, got false");
 
   s = "FOOD";
   suffix = "ood";
   res = pr_strnrstr(s, 4, suffix, 3, flags);
-  fail_unless(res == FALSE, "Expected false, got true");
+  ck_assert_msg(res == FALSE, "Expected false, got true");
 
   flags = PR_STR_FL_IGNORE_CASE;
   s = "FOOD";
   suffix = "ood";
   res = pr_strnrstr(s, 4, suffix, 3, flags);
-  fail_unless(res == TRUE, "Expected true, got false");
+  ck_assert_msg(res == TRUE, "Expected true, got false");
 }
 END_TEST
 
@@ -1250,42 +1250,42 @@ START_TEST (bin2hex_test) {
   const unsigned char *str;
 
   res = pr_str_bin2hex(NULL, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_str_bin2hex(p, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null data argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null data argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Empty string. */
   str = (const unsigned char *) "foobar";
   expected = "";
   res = pr_str_bin2hex(p, (const unsigned char *) str, 0, 0);
-  fail_unless(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   /* default (lowercase) */
   expected = "666f6f626172";
   res = pr_str_bin2hex(p, str, strlen((char *) str), 0);
-  fail_unless(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   /* lowercase */
   expected = "666f6f626172";
   res = pr_str_bin2hex(p, str, strlen((char *) str), 0);
-  fail_unless(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   /* uppercase */
   expected = "666F6F626172";
   res = pr_str_bin2hex(p, str, strlen((char *) str), PR_STR_FL_HEX_USE_UC);
-  fail_unless(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to hexify '%s': %s", str, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 }
 END_TEST
@@ -1296,13 +1296,13 @@ START_TEST (hex2bin_test) {
   size_t expected_len, hex_len, len;
 
   res = pr_str_hex2bin(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_str_hex2bin(p, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null data argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null data argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Empty string. */
@@ -1310,8 +1310,8 @@ START_TEST (hex2bin_test) {
   hex_len = strlen((char *) hex);
   expected = (unsigned char *) "";
   res = pr_str_hex2bin(p, hex, hex_len, &len);
-  fail_unless(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
-  fail_unless(strcmp((const char *) res, (const char *) expected) == 0,
+  ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
+  ck_assert_msg(strcmp((const char *) res, (const char *) expected) == 0,
     "Expected '%s', got '%s'", expected, res);
 
   hex = (const unsigned char *) "112233";
@@ -1323,10 +1323,10 @@ START_TEST (hex2bin_test) {
   expected[2] = 51;
 
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
-  fail_unless(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
-  fail_unless(len == expected_len, "Expected len %lu, got %lu",
+  ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
+  ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
     (unsigned long) expected_len, len);
-  fail_unless(memcmp(res, expected, len) == 0,
+  ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 
   /* lowercase */
@@ -1342,10 +1342,10 @@ START_TEST (hex2bin_test) {
   expected[5] = 'r';
 
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
-  fail_unless(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
-  fail_unless(len == expected_len, "Expected len %lu, got %lu",
+  ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
+  ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
     (unsigned long) expected_len, len);
-  fail_unless(memcmp(res, expected, len) == 0,
+  ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 
   /* uppercase */
@@ -1353,18 +1353,18 @@ START_TEST (hex2bin_test) {
   hex_len = strlen((char *) hex);
 
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
-  fail_unless(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
-  fail_unless(len == expected_len, "Expected len %lu, got %lu",
+  ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
+  ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
     (unsigned long) expected_len, len);
-  fail_unless(memcmp(res, expected, len) == 0,
+  ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 
   /* Handle known not-hex data properly. */
   hex = (const unsigned char *) "Hello, World!\n";
   hex_len = strlen((char *) hex);
   res = pr_str_hex2bin(p, hex, hex_len, &len);
-  fail_unless(res == NULL, "Successfully unhexified '%s' unexpectedly", hex);
-  fail_unless(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
+  ck_assert_msg(res == NULL, "Successfully unhexified '%s' unexpectedly", hex);
+  ck_assert_msg(errno == ERANGE, "Expected ERANGE (%d), got %s (%d)", ERANGE,
     strerror(errno), errno);
 }
 END_TEST
@@ -1375,22 +1375,22 @@ START_TEST (levenshtein_test) {
 
   mark_point();
   res = pr_str_levenshtein(NULL, NULL, NULL, 0, 0, 0, 0, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_str_levenshtein(p, NULL, NULL, 0, 0, 0, 0, flags);
-  fail_unless(res < 0, "Failed to handle null a string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null a string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   a = "foo";
 
   mark_point();
   res = pr_str_levenshtein(p, a, NULL, 0, 0, 0, 0, flags);
-  fail_unless(res < 0, "Failed to handle null b string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null b string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   expected = 0;
@@ -1401,7 +1401,7 @@ START_TEST (levenshtein_test) {
   fail_if(res < 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
-  fail_unless(expected == res, "Expected distance %d, got %d", expected, res);
+  ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);
 
   expected = 3;
   b = "Foo";
@@ -1409,7 +1409,7 @@ START_TEST (levenshtein_test) {
   fail_if(res < 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
-  fail_unless(expected == res, "Expected distance %d, got %d", expected, res);
+  ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);
 
   flags = PR_STR_FL_IGNORE_CASE;
   expected = 2;
@@ -1418,7 +1418,7 @@ START_TEST (levenshtein_test) {
   fail_if(res < 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
-  fail_unless(expected == res, "Expected distance %d, got %d", expected, res);
+  ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);
 }
 END_TEST
 
@@ -1428,30 +1428,30 @@ START_TEST (similars_test) {
 
   mark_point();
   res = pr_str_get_similars(NULL, NULL, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_str_get_similars(p, NULL, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   s = "foo";
 
   mark_point();
   res = pr_str_get_similars(p, s, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null candidates");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null candidates");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   candidates = make_array(p, 5, sizeof(const char *));
 
   mark_point();
   res = pr_str_get_similars(p, s, candidates, 0, 0);
-  fail_unless(res == NULL, "Failed to handle empty candidates");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res == NULL, "Failed to handle empty candidates");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   *((const char **) push_array(candidates)) = pstrdup(p, "fools");
@@ -1461,9 +1461,9 @@ START_TEST (similars_test) {
 
   mark_point();
   res = pr_str_get_similars(p, s, candidates, 0, 0);
-  fail_unless(res != NULL, "Failed to find similar strings to '%s': %s", s,
+  ck_assert_msg(res != NULL, "Failed to find similar strings to '%s': %s", s,
     strerror(errno));
-  fail_unless(res->nelts > 0, "Expected >0 similar strings, got %u",
+  ck_assert_msg(res->nelts > 0, "Expected >0 similar strings, got %u",
     res->nelts);
 
   mark_point();
@@ -1481,17 +1481,17 @@ START_TEST (similars_test) {
 
   expected = "fools";
 
-  fail_unless(strcmp(similars[0], expected) == 0,
+  ck_assert_msg(strcmp(similars[0], expected) == 0,
     "Expected similar '%s', got '%s'", expected, similars[0]);
 
-  fail_unless(strcmp(similars[1], expected) != 0,
+  ck_assert_msg(strcmp(similars[1], expected) != 0,
     "Unexpectedly got similar '%s'", similars[1]);
 
   mark_point();
   res = pr_str_get_similars(p, s, candidates, 0, PR_STR_FL_IGNORE_CASE);
-  fail_unless(res != NULL, "Failed to find similar strings to '%s': %s", s,
+  ck_assert_msg(res != NULL, "Failed to find similar strings to '%s': %s", s,
     strerror(errno));
-  fail_unless(res->nelts > 0, "Expected >0 similar strings, got %u",
+  ck_assert_msg(res->nelts > 0, "Expected >0 similar strings, got %u",
     res->nelts);
 
   mark_point();
@@ -1509,12 +1509,12 @@ START_TEST (similars_test) {
     expected = "FOO";
   }
 
-  fail_unless(strcmp(similars[0], expected) == 0,
+  ck_assert_msg(strcmp(similars[0], expected) == 0,
     "Expected similar '%s', got '%s'", expected, similars[0]);
 
   expected = "fools";
 
-  fail_unless(strcmp(similars[1], expected) == 0,
+  ck_assert_msg(strcmp(similars[1], expected) == 0,
     "Expected similar '%s', got '%s'", expected, similars[1]);
 }
 END_TEST
@@ -1523,7 +1523,7 @@ START_TEST (str2uid_test) {
   int res;
 
   res = pr_str2uid(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
 }
 END_TEST
 
@@ -1531,7 +1531,7 @@ START_TEST (str2gid_test) {
   int res;
 
   res = pr_str2gid(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
 }
 END_TEST
 
@@ -1539,10 +1539,10 @@ START_TEST (uid2str_test) {
   const char *res;
 
   res = pr_uid2str(NULL, (uid_t) 1);
-  fail_unless(strcmp(res, "1") == 0, "Expected '1', got '%s'", res);
+  ck_assert_msg(strcmp(res, "1") == 0, "Expected '1', got '%s'", res);
 
   res = pr_uid2str(NULL, (uid_t) -1);
-  fail_unless(strcmp(res, "-1") == 0, "Expected '-1', got '%s'", res);
+  ck_assert_msg(strcmp(res, "-1") == 0, "Expected '-1', got '%s'", res);
 }
 END_TEST
 
@@ -1550,10 +1550,10 @@ START_TEST (gid2str_test) {
   const char *res;
 
   res = pr_gid2str(NULL, (gid_t) 1);
-  fail_unless(strcmp(res, "1") == 0, "Expected '1', got '%s'", res);
+  ck_assert_msg(strcmp(res, "1") == 0, "Expected '1', got '%s'", res);
 
   res = pr_gid2str(NULL, (gid_t) -1);
-  fail_unless(strcmp(res, "-1") == 0, "Expected '-1', got '%s'", res);
+  ck_assert_msg(strcmp(res, "-1") == 0, "Expected '-1', got '%s'", res);
 }
 END_TEST
 
@@ -1562,27 +1562,27 @@ START_TEST (str_quote_test) {
   char *expected, *path;
 
   res = pr_str_quote(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = pr_str_quote(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp/";
   expected = path;
   res = pr_str_quote(p, path);
-  fail_unless(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   path = "/\"tmp\"/";
   expected = "/\"\"tmp\"\"/";
   res = pr_str_quote(p, path);
-  fail_unless(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST
@@ -1592,27 +1592,27 @@ START_TEST (quote_dir_test) {
   char *expected, *path;
 
   res = quote_dir(NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = quote_dir(p, NULL);
-  fail_unless(res == NULL, "Failed to handle null path argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null path argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   path = "/tmp/";
   expected = path;
   res = quote_dir(p, path);
-  fail_unless(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   path = "/\"tmp\"/";
   expected = "/\"\"tmp\"\"/";
   res = quote_dir(p, path);
-  fail_unless(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(res != NULL, "Failed to quote '%s': %s", path, strerror(errno));
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST
@@ -1624,95 +1624,95 @@ START_TEST (text_to_array_test) {
 
   mark_point();
   res = pr_str_text_to_array(NULL, NULL, ',');
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_str_text_to_array(p, NULL, ',');
-  fail_unless(res == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = "";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
 
   mark_point();
   text = ",";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
 
   mark_point();
   text = ",,,";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 0, "Expected 0 items, got %u", res->nelts);
 
   mark_point();
   text = "foo";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 1, "Expected 1 item, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 1, "Expected 1 item, got %u", res->nelts);
   elt = ((char **) res->elts)[0];
-  fail_unless(elt != NULL, "Expected non-null item");
-  fail_unless(strcmp(elt, text) == 0, "Expected '%s', got '%s'", text, elt);
+  ck_assert_msg(elt != NULL, "Expected non-null item");
+  ck_assert_msg(strcmp(elt, text) == 0, "Expected '%s', got '%s'", text, elt);
 
   mark_point();
   text = "foo,foo,foo";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 
   mark_point();
   text = "foo,foo,foo,";
   res = pr_str_text_to_array(p, text, ',');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 
   mark_point();
   text = "foo|foo|foo";
   res = pr_str_text_to_array(p, text, '|');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 
@@ -1720,17 +1720,17 @@ START_TEST (text_to_array_test) {
   mark_point();
   text = "/foo/foo/foo";
   res = pr_str_text_to_array(p, text, '/');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 
@@ -1738,17 +1738,17 @@ START_TEST (text_to_array_test) {
   mark_point();
   text = "/foo/foo/foo/";
   res = pr_str_text_to_array(p, text, '/');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 
@@ -1756,17 +1756,17 @@ START_TEST (text_to_array_test) {
   mark_point();
   text = "foo/foo/foo";
   res = pr_str_text_to_array(p, text, '/');
-  fail_unless(res != NULL, "Failed to handle text '%s': %s", text,
+  ck_assert_msg(res != NULL, "Failed to handle text '%s': %s", text,
     strerror(errno));
-  fail_unless(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
+  ck_assert_msg(res->nelts == 3, "Expected 3 items, got %u", res->nelts);
   for (i = 0; i < res->nelts; i++) {
     char *item, *expected;
 
     item = ((char **) res->elts)[i];
-    fail_unless(item != NULL, "Expected item at index %u, got null", i);
+    ck_assert_msg(item != NULL, "Expected item at index %u, got null", i);
 
     expected = "foo";
-    fail_unless(strcmp(item, expected) == 0,
+    ck_assert_msg(strcmp(item, expected) == 0,
       "Expected '%s' at index %u, got '%s'", expected, i, item);
   }
 }
@@ -1779,22 +1779,22 @@ START_TEST (array_to_text_test) {
 
   mark_point();
   res = pr_str_array_to_text(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_str_array_to_text(p, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null items");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null items");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   items = make_array(p, 0, sizeof(char *));
 
   mark_point();
   res = pr_str_array_to_text(p, items, NULL);
-  fail_unless(res == NULL, "Failed to handle null delimiter");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null delimiter");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   delimiter = ":";
@@ -1802,9 +1802,9 @@ START_TEST (array_to_text_test) {
 
   mark_point();
   res = pr_str_array_to_text(p, items, delimiter);
-  fail_unless(res != NULL, "Error converting items to text: %s",
+  ck_assert_msg(res != NULL, "Error converting items to text: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   *((char **) push_array(items)) = pstrdup(p, "foo");
@@ -1812,9 +1812,9 @@ START_TEST (array_to_text_test) {
 
   mark_point();
   res = pr_str_array_to_text(p, items, delimiter);
-  fail_unless(res != NULL, "Error converting items to text: %s",
+  ck_assert_msg(res != NULL, "Error converting items to text: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 
   *((char **) push_array(items)) = pstrdup(p, "bar");
@@ -1822,9 +1822,9 @@ START_TEST (array_to_text_test) {
 
   mark_point();
   res = pr_str_array_to_text(p, items, delimiter);
-  fail_unless(res != NULL, "Error converting items to text: %s",
+  ck_assert_msg(res != NULL, "Error converting items to text: %s",
     strerror(errno));
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'", expected,
     res);
 }
 END_TEST

--- a/tests/api/str.c
+++ b/tests/api/str.c
@@ -65,42 +65,47 @@ START_TEST (sstrncpy_test) {
 
   mark_point();
   res = sstrncpy(ok, ok, 1);
-  ck_assert_msg(res == 1, "Expected result 1, got %d", len, res);
+  ck_assert_msg(res == 1, "Expected result 1, got %d", res);
 
   mark_point();
   memset(dst, 'A', sz);
   len = 1;
 
   res = sstrncpy(dst, ok, len);
-  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
-  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
-    strlen(dst));
+  ck_assert_msg((size_t) res <= len, "Expected result %lu, got %d",
+    (unsigned long)len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %lu, got len %lu",
+    (unsigned long)len - 1, (unsigned long)strlen(dst));
   ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = 7;
 
   res = sstrncpy(dst, ok, len);
-  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
-  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
-    strlen(dst));
+  ck_assert_msg((size_t) res <= len, "Expected result %lu, got %d",
+    (unsigned long)len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %lu, got len %lu",
+    (unsigned long)len - 1, (unsigned long)strlen(dst));
   ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = sz;
 
   res = sstrncpy(dst, ok, len);
-  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
-  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %u, got len %u", len - 1,
-    strlen(dst));
+  ck_assert_msg((size_t) res <= len, "Expected result %lu, got %d",
+    (unsigned long)len, res);
+  ck_assert_msg(strlen(dst) == (len - 1), "Expected len %lu, got len %lu",
+    (unsigned long)len - 1, (unsigned long)strlen(dst));
   ck_assert_msg(dst[len-1] == '\0', "Expected NUL, got '%c'", dst[len-1]);
 
   memset(dst, 'A', sz);
   len = sz;
 
   res = sstrncpy(dst, "", len);
-  ck_assert_msg((size_t) res <= len, "Expected result %d, got %d", len, res);
-  ck_assert_msg(strlen(dst) == 0, "Expected len %u, got len %u", 0, strlen(dst));
+  ck_assert_msg((size_t) res <= len, "Expected result %lu, got %d",
+    (unsigned long)len, res);
+  ck_assert_msg(strlen(dst) == 0, "Expected len %u, got len %lu", 0,
+    (unsigned long)strlen(dst));
   ck_assert_msg(*dst == '\0', "Expected NUL, got '%c'", *dst);
 }
 END_TEST
@@ -183,8 +188,8 @@ START_TEST (sstrcat_test) {
 
   mark_point();
   ck_assert_msg(strlen(dst) == (sizeof(dst)-1),
-    "Failed to copy all the data (expected len %u, got len %u)",
-    sizeof(dst)-1, strlen(dst));
+    "Failed to copy all the data (expected len %lu, got len %lu)",
+    (unsigned long)sizeof(dst)-1, (unsigned long)strlen(dst));
 
   mark_point();
   for (i = 0; i < sizeof(dst)-1; i++) {
@@ -378,7 +383,7 @@ START_TEST (pdircat_test) {
 
   res = pdircat(p, 0, NULL);
   ck_assert_msg(res != NULL,
-    "Failed to handle empty arguments (expected '', got '%s')", res);
+    "Failed to handle empty arguments (expected '', got NULL)");
   ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   /* Comments in the pdircat() function suggest that an empty string
@@ -420,7 +425,7 @@ START_TEST (pstrcat_test) {
 
   res = pstrcat(p, 0, NULL);
   ck_assert_msg(res != NULL,
-    "Failed to handle empty arguments (expected '', got '%s')", res);
+    "Failed to handle empty arguments (expected '', got NULL)");
   ck_assert_msg(strcmp(res, "") == 0, "Expected '%s', got '%s'", "", res);
 
   res = pstrcat(p, "", NULL);
@@ -462,8 +467,8 @@ START_TEST (pstrdup_test) {
 
   res = pstrdup(p, "foo");
   ok = "foo";
-  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
-    strlen(ok), strlen(res));
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %lu, got len %lu",
+    (unsigned long)strlen(ok), (unsigned long)strlen(res));
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST
@@ -485,20 +490,20 @@ START_TEST (pstrndup_test) {
 
   res = pstrndup(p, "foo", 0);
   ok = "";
-  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
-    strlen(ok), strlen(res));
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %lu, got len %lu",
+    (unsigned long)strlen(ok), (unsigned long)strlen(res));
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrndup(p, "foo", 1);
   ok = "f";
-  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
-    strlen(ok), strlen(res));
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %lu, got len %lu",
+    (unsigned long)strlen(ok), (unsigned long)strlen(res));
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 
   res = pstrndup(p, "foo", 10);
   ok = "foo";
-  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %u, got len %u",
-    strlen(ok), strlen(res));
+  ck_assert_msg(strlen(res) == strlen(ok), "Expected len %lu, got len %lu",
+    (unsigned long)strlen(ok), (unsigned long)strlen(res));
   ck_assert_msg(strcmp(res, ok) == 0, "Expected '%s', got '%s'", ok, res);
 }
 END_TEST

--- a/tests/api/str.c
+++ b/tests/api/str.c
@@ -795,7 +795,7 @@ START_TEST (get_word_utf8_test) {
     str = pcalloc(p, sz);
 
     nread = fread(str, sizeof(char), sz-1, fh);
-    fail_if(ferror(fh), "Error reading '%s': %s", path, strerror(errno));
+    ck_assert_msg(!ferror(fh), "Error reading '%s': %s", path, strerror(errno));
     ck_assert_msg(nread > 0, "Expected >0 bytes read, got 0");
 
     res = pr_str_get_word(&str, 0);
@@ -803,7 +803,7 @@ START_TEST (get_word_utf8_test) {
       strerror(errno));
 
     ok = "foo";
-    fail_if(strcmp(res, ok) == 0, "Did NOT expect '%s'", ok);
+    ck_assert_msg(strcmp(res, ok) != 0, "Did NOT expect '%s'", ok);
 
     fclose(fh);
   }
@@ -858,45 +858,45 @@ START_TEST (is_fnmatch_test) {
 
   str = "foo";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo?";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != TRUE, "Expected true for string '%s'", str);
+  ck_assert_msg(res == TRUE, "Expected true for string '%s'", str);
 
   str = "foo*";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != TRUE, "Expected true for string '%s'", str);
+  ck_assert_msg(res == TRUE, "Expected true for string '%s'", str);
 
   str = "foo[";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo]";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo[]";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != TRUE, "Expected true for string '%s'", str);
+  ck_assert_msg(res == TRUE, "Expected true for string '%s'", str);
 
   /* Now the fun cases using the escape character. */
 
   str = "f\\oo";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo\\";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo\\?";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != FALSE, "Expected false for string '%s'", str);
+  ck_assert_msg(res == FALSE, "Expected false for string '%s'", str);
 
   str = "foo\\??";
   res = pr_str_is_fnmatch(str);
-  fail_if(res != TRUE, "Expected true for string '%s'", str);
+  ck_assert_msg(res == TRUE, "Expected true for string '%s'", str);
 }
 END_TEST
 
@@ -1398,7 +1398,7 @@ START_TEST (levenshtein_test) {
 
   mark_point();
   res = pr_str_levenshtein(p, a, b, 0, 0, 0, 0, flags);
-  fail_if(res < 0,
+  ck_assert_msg(res >= 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
   ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);
@@ -1406,7 +1406,7 @@ START_TEST (levenshtein_test) {
   expected = 3;
   b = "Foo";
   res = pr_str_levenshtein(p, a, b, 0, 1, 1, 1, flags);
-  fail_if(res < 0,
+  ck_assert_msg(res >= 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
   ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);
@@ -1415,7 +1415,7 @@ START_TEST (levenshtein_test) {
   expected = 2;
   b = "Foo";
   res = pr_str_levenshtein(p, a, b, 0, 1, 1, 1, flags);
-  fail_if(res < 0,
+  ck_assert_msg(res >= 0,
     "Failed to compute Levenshtein distance from '%s' to '%s': %s", a, b,
     strerror(errno));
   ck_assert_msg(expected == res, "Expected distance %d, got %d", expected, res);

--- a/tests/api/str.c
+++ b/tests/api/str.c
@@ -1330,7 +1330,7 @@ START_TEST (hex2bin_test) {
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
   ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
   ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
-    (unsigned long) expected_len, len);
+    (unsigned long) expected_len, (unsigned long) len);
   ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 
@@ -1349,7 +1349,7 @@ START_TEST (hex2bin_test) {
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
   ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
   ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
-    (unsigned long) expected_len, len);
+    (unsigned long) expected_len, (unsigned long) len);
   ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 
@@ -1360,7 +1360,7 @@ START_TEST (hex2bin_test) {
   res = pr_str_hex2bin(p, (const unsigned char *) hex, hex_len, &len);
   ck_assert_msg(res != NULL, "Failed to unhexify '%s': %s", hex, strerror(errno));
   ck_assert_msg(len == expected_len, "Expected len %lu, got %lu",
-    (unsigned long) expected_len, len);
+    (unsigned long) expected_len, (unsigned long) len);
   ck_assert_msg(memcmp(res, expected, len) == 0,
     "Did not receive expected unhexified data");
 

--- a/tests/api/table.c
+++ b/tests/api/table.c
@@ -330,7 +330,7 @@ START_TEST (table_get_test) {
   res = pr_table_get(tab, "bar", &sz);
   ck_assert_msg(res != NULL, "Failed to lookup value for 'bar': %s",
     strerror(errno));
-  ck_assert_msg(sz == 4, "Expected result len of 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected result len of 4, got %lu", (unsigned long)sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
@@ -382,7 +382,7 @@ START_TEST (table_get_use_cache_test) {
   res = pr_table_get(tab, key, &sz);
   ck_assert_msg(res != NULL, "Failed to lookup value for 'bar': %s",
     strerror(errno));
-  ck_assert_msg(sz == 4, "Expected result len of 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected result len of 4, got %lu", (unsigned long)sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
@@ -506,7 +506,7 @@ START_TEST (table_remove_test) {
 
   res = pr_table_remove(tab, "foo", &sz);
   ck_assert_msg(res != NULL, "Failed to remove 'foo': %s", strerror(errno));
-  ck_assert_msg(sz == 8, "Expected value len of 8, got %u", sz);
+  ck_assert_msg(sz == 8, "Expected value len of 8, got %lu", (unsigned long)sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
@@ -571,7 +571,7 @@ START_TEST (table_set_test) {
   v = pr_table_get(tab, "foo", &sz);
   ck_assert_msg(v != NULL, "Failed to retrieve 'foo' from table: %s",
     strerror(errno));
-  ck_assert_msg(sz == 4, "Expected len 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected len 4, got %lu", (unsigned long)sz);
 
   str = pcalloc(p, sz);
   memcpy(str, v, sz);
@@ -730,7 +730,7 @@ START_TEST (table_ctl_test) {
   res = pr_table_add(tab, "baz", "quxx", 0);
   ck_assert_msg(res == -1, "Added second entry unexpectedly");
   ck_assert_msg(errno == ENOSPC,
-    "Failed to set errno to ENOSPC, received %s (%d)", errno, strerror(errno));
+    "Failed to set errno to ENOSPC, received %d (%s)", errno, strerror(errno));
 }
 END_TEST
 
@@ -741,7 +741,7 @@ START_TEST (table_load_test) {
   load = pr_table_load(tab);
   ck_assert_msg(load < 0, "Failed to handle NULL table argument");
   ck_assert_msg(errno == EINVAL,
-    "Failed to set errno to EINVAL; received %s (%d)", errno, strerror(errno));
+    "Failed to set errno to EINVAL; received %d (%s)", errno, strerror(errno));
 
   tab = pr_table_alloc(p, 0);
   load = pr_table_load(tab);

--- a/tests/api/table.c
+++ b/tests/api/table.c
@@ -80,11 +80,11 @@ START_TEST (table_alloc_test) {
   pr_table_t *tab;
 
   tab = pr_table_alloc(NULL, 0);
-  fail_unless(tab == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(tab == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
-  fail_unless(tab != NULL, "Failed to allocate table: %s", strerror(errno));
+  ck_assert_msg(tab != NULL, "Failed to allocate table: %s", strerror(errno));
 }
 END_TEST
 
@@ -92,15 +92,15 @@ START_TEST (table_nalloc_test) {
   pr_table_t *tab;
 
   tab = pr_table_nalloc(NULL, 0, 0);
-  fail_unless(tab == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(tab == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_nalloc(p, 0, 0);
-  fail_unless(tab == NULL, "Failed to handle zero chains");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(tab == NULL, "Failed to handle zero chains");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_nalloc(p, 0, 1);
-  fail_unless(tab != NULL, "Failed to allocate table: %s", strerror(errno));
+  ck_assert_msg(tab != NULL, "Failed to allocate table: %s", strerror(errno));
 }
 END_TEST
 
@@ -109,26 +109,26 @@ START_TEST (table_add_test) {
   pr_table_t *tab;
 
   res = pr_table_add(NULL, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
-  fail_unless(tab != NULL, "Failed to allocate table: %s", strerror(errno));
+  ck_assert_msg(tab != NULL, "Failed to allocate table: %s", strerror(errno));
 
   res = pr_table_add(tab, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_add(tab, "", NULL, 0);
-  fail_unless(res == 0, "Failed to add null value (len 0) for empty key");
+  ck_assert_msg(res == 0, "Failed to add null value (len 0) for empty key");
 
   res = pr_table_add(tab, "", NULL, 1);
-  fail_unless(res == -1, "Failed to handle null value (len 1) for empty key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null value (len 1) for empty key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_add(tab, "", NULL, 0);
-  fail_unless(res == -1, "Failed to handle duplicate (empty) key");
-  fail_unless(errno == EEXIST, "Failed to set errno to EEXIST");
+  ck_assert_msg(res == -1, "Failed to handle duplicate (empty) key");
+  ck_assert_msg(errno == EEXIST, "Failed to set errno to EEXIST");
 }
 END_TEST
 
@@ -137,29 +137,29 @@ START_TEST (table_add_dup_test) {
   pr_table_t *tab;
 
   res = pr_table_add_dup(NULL, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
-  fail_unless(tab != NULL, "Failed to allocate table: %s", strerror(errno));
+  ck_assert_msg(tab != NULL, "Failed to allocate table: %s", strerror(errno));
 
   res = pr_table_add_dup(tab, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_add_dup(tab, "", NULL, 0);
-  fail_unless(res == 0, "Failed to add null value (len 0) for empty key");
+  ck_assert_msg(res == 0, "Failed to add null value (len 0) for empty key");
 
   res = pr_table_add_dup(tab, "", NULL, 1);
-  fail_unless(res == -1, "Failed to handle null value (len 1) for empty key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null value (len 1) for empty key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_add_dup(tab, "", NULL, 0);
-  fail_unless(res == 0, "Failed to handle empty value: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle empty value: %s", strerror(errno));
 
   mark_point();
   res = pr_table_add_dup(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo': %s", strerror(errno));
 }
 END_TEST
 
@@ -168,28 +168,28 @@ START_TEST (table_count_test) {
   pr_table_t *tab;
 
   res = pr_table_count(NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   ok = 0;
   res = pr_table_count(tab);
-  fail_unless(res == ok, "Expected count %d, got %d", ok, res);
+  ck_assert_msg(res == ok, "Expected count %d, got %d", ok, res);
 
   res = pr_table_add(tab, "foo", NULL, 0);
-  fail_unless(res == 0, "Failed to add item to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add item to table: %s", strerror(errno));
 
   ok = 1;
   res = pr_table_count(tab);
-  fail_unless(res == ok, "Expected count %d, got %d", ok, res);
+  ck_assert_msg(res == ok, "Expected count %d, got %d", ok, res);
 
   res = pr_table_add(tab, "bar", NULL, 0);
-  fail_unless(res == 0, "Failed to add item to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add item to table: %s", strerror(errno));
 
   ok = 2;
   res = pr_table_count(tab);
-  fail_unless(res == ok, "Expected count %d, got %d", ok, res);
+  ck_assert_msg(res == ok, "Expected count %d, got %d", ok, res);
 }
 END_TEST
 
@@ -198,49 +198,49 @@ START_TEST (table_exists_test) {
   pr_table_t *tab;
 
   res = pr_table_exists(NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, PR_TABLE_FL_MULTI_VALUE);
-  fail_unless(tab != NULL, "Failed to allocate table: %s", strerror(errno));
+  ck_assert_msg(tab != NULL, "Failed to allocate table: %s", strerror(errno));
 
   res = pr_table_exists(tab, NULL);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_exists(NULL, "foo");
-  fail_unless(res == -1, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   ok = -1;
   res = pr_table_exists(tab, "foo");
-  fail_unless(res == ok, "Expected value count %d, got %d", ok, res);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == ok, "Expected value count %d, got %d", ok, res);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_table_add(tab, "foo", "a", 0);
-  fail_unless(res == 0, "Failed to add key to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add key to table: %s", strerror(errno));
 
   ok = 1;
   res = pr_table_exists(tab, "foo");
-  fail_unless(res == ok, "Expected value count %d, got %d", ok, res);
+  ck_assert_msg(res == ok, "Expected value count %d, got %d", ok, res);
 
   res = pr_table_add(tab, "foo", "b", 0);
-  fail_unless(res == 0, "Failed to add key to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add key to table: %s", strerror(errno));
 
   ok = 2;
   res = pr_table_exists(tab, "foo");
-  fail_unless(res == ok, "Expected value count %d, got %d", ok, res);
+  ck_assert_msg(res == ok, "Expected value count %d, got %d", ok, res);
 
   mark_point();
   res = pr_table_kexists(NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_table_kexists(tab, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null key_data");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null key_data");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -250,25 +250,25 @@ START_TEST (table_empty_test) {
   pr_table_t *tab;
 
   res = pr_table_empty(NULL);
-  fail_unless(res == -1, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_empty(tab);
-  fail_unless(res == 0, "Failed to empty table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to empty table: %s", strerror(errno));
 
   res = pr_table_add(tab, "foo", NULL, 0);
-  fail_unless(res == 0, "Failed to add key to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add key to table: %s", strerror(errno));
 
   res = pr_table_count(tab);
-  fail_unless(res == 1, "Expected table item count of 1, got %d", res);
+  ck_assert_msg(res == 1, "Expected table item count of 1, got %d", res);
 
   res = pr_table_empty(tab);
-  fail_unless(res == 0, "Failed to empty table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to empty table: %s", strerror(errno));
 
   res = pr_table_count(tab);
-  fail_unless(res == 0, "Expected table item count of 0, got %d", res);
+  ck_assert_msg(res == 0, "Expected table item count of 0, got %d", res);
 }
 END_TEST
 
@@ -277,21 +277,21 @@ START_TEST (table_free_test) {
   pr_table_t *tab;
 
   res = pr_table_free(NULL);
-  fail_unless(res == -1, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_free(tab);
-  fail_unless(res == 0, "Failed to free table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to free table: %s", strerror(errno));
 
   tab = pr_table_alloc(p, 0);
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add item to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add item to table: %s", strerror(errno));
 
   res = pr_table_free(tab);
-  fail_unless(res == -1, "Failed to handle non-empty table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle non-empty table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 }
 END_TEST
 
@@ -303,45 +303,45 @@ START_TEST (table_get_test) {
   size_t sz;
 
   res = pr_table_get(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_get(tab, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null key");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   ok = pr_table_add(tab, "foo", NULL, 0);
-  fail_unless(ok == 0, "Failed to add null value to table: %s",
+  ck_assert_msg(ok == 0, "Failed to add null value to table: %s",
     strerror(errno));
 
   errno = xerrno = 0;
   res = pr_table_get(tab, "foo", &sz);
   xerrno = errno;
 
-  fail_unless(res == NULL, "Failed to lookup null value: %s", strerror(errno));
-  fail_unless(xerrno == 0, "Expected errno 0, got %d (%s)", xerrno,
+  ck_assert_msg(res == NULL, "Failed to lookup null value: %s", strerror(errno));
+  ck_assert_msg(xerrno == 0, "Expected errno 0, got %d (%s)", xerrno,
     strerror(xerrno));
 
   ok = pr_table_add(tab, "bar", "baz", 0);
-  fail_unless(ok == 0, "Failed to add 'bar' to table: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add 'bar' to table: %s", strerror(errno));
 
   res = pr_table_get(tab, "bar", &sz);
-  fail_unless(res != NULL, "Failed to lookup value for 'bar': %s",
+  ck_assert_msg(res != NULL, "Failed to lookup value for 'bar': %s",
     strerror(errno));
-  fail_unless(sz == 4, "Expected result len of 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected result len of 4, got %u", sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
 
-  fail_unless(strcmp(str, "baz") == 0,
+  ck_assert_msg(strcmp(str, "baz") == 0,
     "Expected value '%s', got '%s'", "baz", str);
 
   mark_point();
   res = pr_table_kget(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -359,8 +359,8 @@ START_TEST (table_get_use_cache_test) {
   size_t sz;
 
   res = pr_table_get(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, PR_TABLE_FL_USE_CACHE);
 
@@ -369,33 +369,33 @@ START_TEST (table_get_use_cache_test) {
    */
 
   ok = pr_table_ctl(tab, PR_TABLE_CTL_SET_KEY_HASH, cache_key_hash);
-  fail_unless(ok == 0, "Failed to set key hash function for table: %s",
+  ck_assert_msg(ok == 0, "Failed to set key hash function for table: %s",
     strerror(errno));
 
   res = pr_table_get(tab, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null key");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   ok = pr_table_add(tab, key, "baz", 0);
-  fail_unless(ok == 0, "Failed to add 'bar' to table: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add 'bar' to table: %s", strerror(errno));
 
   res = pr_table_get(tab, key, &sz);
-  fail_unless(res != NULL, "Failed to lookup value for 'bar': %s",
+  ck_assert_msg(res != NULL, "Failed to lookup value for 'bar': %s",
     strerror(errno));
-  fail_unless(sz == 4, "Expected result len of 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected result len of 4, got %u", sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
 
-  fail_unless(strcmp(str, "baz") == 0,
+  ck_assert_msg(strcmp(str, "baz") == 0,
     "Expected value '%s', got '%s'", "baz", str);
 
   /* With the USE_CACHE flag on, we should still receive NULL here. */
   errno = xerrno = 0;
   res = pr_table_get(tab, key, &sz);
-  fail_unless(res == NULL, "Failed to return null next value: %s",
+  ck_assert_msg(res == NULL, "Failed to return null next value: %s",
     strerror(errno));
-  fail_unless(xerrno == 0, "Expected errno 0, got %d (%s)", xerrno,
+  ck_assert_msg(xerrno == 0, "Expected errno 0, got %d (%s)", xerrno,
     strerror(xerrno));
 
 }
@@ -408,37 +408,37 @@ START_TEST (table_next_test) {
   pr_table_t *tab;
 
   res = pr_table_next(NULL);
-  fail_unless(res == NULL, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_next(tab);
-  fail_unless(res == NULL, "Failed to handle empty table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle empty table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   ok = pr_table_add(tab, "foo", NULL, 0);
-  fail_unless(ok == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_next(tab);
-  fail_unless(res != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(strcmp(res, "foo") == 0,
+  ck_assert_msg(res != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "foo") == 0,
     "Expected key '%s', got '%s'", "foo", res);
 
   res = pr_table_next(tab);
-  fail_unless(res == NULL, "Expected no more keys, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected no more keys, got '%s'", res);
 
   pr_table_rewind(tab);
 
   res = pr_table_knext(tab, &sz);
-  fail_unless(res != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(sz == 4, "Expected 4, got %lu", (unsigned long) sz);
-  fail_unless(strcmp(res, "foo") == 0,
+  ck_assert_msg(res != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(sz == 4, "Expected 4, got %lu", (unsigned long) sz);
+  ck_assert_msg(strcmp(res, "foo") == 0,
     "Expected key '%s', got '%s'", "foo", res);
 
   sz = 0;
   res = pr_table_knext(tab, &sz);
-  fail_unless(res == NULL, "Expected no more keys, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected no more keys, got '%s'", res);
 }
 END_TEST
 
@@ -448,35 +448,35 @@ START_TEST (table_rewind_test) {
   pr_table_t *tab;
 
   res = pr_table_rewind(NULL);
-  fail_unless(res == -1, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_rewind(tab);
-  fail_unless(res == 0, "Failed to handle empty table");
+  ck_assert_msg(res == 0, "Failed to handle empty table");
 
   res = pr_table_add(tab, "foo", NULL, 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   key = pr_table_next(tab);
-  fail_unless(key != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(strcmp(key, "foo") == 0,
+  ck_assert_msg(key != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(strcmp(key, "foo") == 0,
     "Expected key '%s', got '%s'", "foo", key);
 
   key = pr_table_next(tab);
-  fail_unless(key == NULL, "Expected no more keys, got '%s'", key);
+  ck_assert_msg(key == NULL, "Expected no more keys, got '%s'", key);
 
   res = pr_table_rewind(tab);
-  fail_unless(res == 0, "Failed to rewind table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to rewind table: %s", strerror(errno));
 
   key = pr_table_next(tab);
-  fail_unless(key != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(strcmp(key, "foo") == 0,
+  ck_assert_msg(key != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(strcmp(key, "foo") == 0,
     "Expected key '%s', got '%s'", "foo", key);
 
   key = pr_table_next(tab);
-  fail_unless(key == NULL, "Expected no more keys, got '%s'", key);
+  ck_assert_msg(key == NULL, "Expected no more keys, got '%s'", key);
 }
 END_TEST
 
@@ -488,49 +488,49 @@ START_TEST (table_remove_test) {
   size_t sz;
 
   res = pr_table_remove(NULL, NULL, NULL);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_remove(tab, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_remove(tab, "foo", &sz);
-  fail_unless(res == NULL, "Failed to handle absent value");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == NULL, "Failed to handle absent value");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   ok = pr_table_add(tab, "foo", "bar baz", 0);
-  fail_unless(ok == 0, "Failed to add key to table: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add key to table: %s", strerror(errno));
 
   res = pr_table_remove(tab, "foo", &sz);
-  fail_unless(res != NULL, "Failed to remove 'foo': %s", strerror(errno));
-  fail_unless(sz == 8, "Expected value len of 8, got %u", sz);
+  ck_assert_msg(res != NULL, "Failed to remove 'foo': %s", strerror(errno));
+  ck_assert_msg(sz == 8, "Expected value len of 8, got %u", sz);
 
   str = pcalloc(p, sz);
   memcpy(str, res, sz);
 
-  fail_unless(strcmp(str, "bar baz") == 0,
+  ck_assert_msg(strcmp(str, "bar baz") == 0,
     "Expected value of '%s', got '%s'", "bar baz", str);
 
   ok = pr_table_count(tab);
-  fail_unless(ok == 0, "Expected table count of 0, got %d", ok);
+  ck_assert_msg(ok == 0, "Expected table count of 0, got %d", ok);
 
   res = pr_table_remove(tab, "foo", &sz);
-  fail_unless(res == NULL, "Failed to handle absent value");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == NULL, "Failed to handle absent value");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   mark_point();
   res = pr_table_kremove(NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_table_kremove(tab, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null key data");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null key data");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -543,40 +543,40 @@ START_TEST (table_set_test) {
   size_t sz;
 
   res = pr_table_set(NULL, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_set(tab, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_set(tab, "foo", NULL, 1);
-  fail_unless(res == -1, "Failed to handle null value (len 1)");
-  fail_unless(errno == EINVAL, "Failed to handle null value (len 1)");
+  ck_assert_msg(res == -1, "Failed to handle null value (len 1)");
+  ck_assert_msg(errno == EINVAL, "Failed to handle null value (len 1)");
 
   mark_point();
   res = pr_table_set(tab, "foo", "bar", 1);
-  fail_unless(res < 0, "Failed to handle empty table");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle empty table");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
 
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_set(tab, "foo", "BAZ", 0);
-  fail_unless(res == 0, "Failed to set 'foo' in table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set 'foo' in table: %s", strerror(errno));
 
   v = pr_table_get(tab, "foo", &sz);
-  fail_unless(v != NULL, "Failed to retrieve 'foo' from table: %s",
+  ck_assert_msg(v != NULL, "Failed to retrieve 'foo' from table: %s",
     strerror(errno));
-  fail_unless(sz == 4, "Expected len 4, got %u", sz);
+  ck_assert_msg(sz == 4, "Expected len 4, got %u", sz);
 
   str = pcalloc(p, sz);
   memcpy(str, v, sz);
 
-  fail_unless(strcmp(str, "BAZ") == 0,
+  ck_assert_msg(strcmp(str, "BAZ") == 0,
     "Expected value of '%s', got '%s'", "BAZ", str);
 }
 END_TEST
@@ -586,33 +586,33 @@ START_TEST (table_do_test) {
   pr_table_t *tab;
 
   res = pr_table_do(NULL, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_do(tab, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_do(tab, do_cb, NULL, 0);
-  fail_unless(res == 0, "Failed to handle empty table");
+  ck_assert_msg(res == 0, "Failed to handle empty table");
 
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_add(tab, "bar", "baz", 0);
-  fail_unless(res == 0, "Failed to add 'bar' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'bar' to table: %s", strerror(errno));
 
   res = pr_table_do(tab, do_cb, NULL, 0);
-  fail_unless(res == -1, "Expected res %d, got %d", -1, res);
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
-  fail_unless(b_val_count == 1, "Expected count %u, got %u", 1, b_val_count);
+  ck_assert_msg(res == -1, "Expected res %d, got %d", -1, res);
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(b_val_count == 1, "Expected count %u, got %u", 1, b_val_count);
 
   b_val_count = 0;
   res = pr_table_do(tab, do_cb, NULL, PR_TABLE_DO_FL_ALL);
-  fail_unless(res == 0, "Failed to do table: %s", strerror(errno));
-  fail_unless(b_val_count == 2, "Expected count %u, got %u", 2, b_val_count);
+  ck_assert_msg(res == 0, "Failed to do table: %s", strerror(errno));
+  ck_assert_msg(b_val_count == 2, "Expected count %u, got %u", 2, b_val_count);
 }
 END_TEST
 
@@ -623,15 +623,15 @@ START_TEST (table_do_with_remove_test) {
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_add(tab, "bar", "baz", 0);
-  fail_unless(res == 0, "Failed to add 'bar' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'bar' to table: %s", strerror(errno));
 
   b_val_count = 0;
   res = pr_table_do(tab, do_with_remove_cb, tab, PR_TABLE_DO_FL_ALL);
-  fail_unless(res == 0, "Failed to do table: %s", strerror(errno));
-  fail_unless(b_val_count == 2, "Expected count %u, got %u", 2, b_val_count);
+  ck_assert_msg(res == 0, "Failed to do table: %s", strerror(errno));
+  ck_assert_msg(b_val_count == 2, "Expected count %u, got %u", 2, b_val_count);
 }
 END_TEST
 
@@ -642,94 +642,94 @@ START_TEST (table_ctl_test) {
   unsigned int max_ents = 0, nchains = 0;
 
   res = pr_table_ctl(NULL, 0, NULL);
-  fail_unless(res == -1, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
  
   mark_point();
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_ENT_INSERT, NULL);
-  fail_unless(res == 0, "Failed to set entry insert callback: %s",
+  ck_assert_msg(res == 0, "Failed to set entry insert callback: %s",
     strerror(errno));
 
   mark_point();
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_ENT_REMOVE, NULL);
-  fail_unless(res == 0, "Failed to set entry removal callback: %s",
+  ck_assert_msg(res == 0, "Failed to set entry removal callback: %s",
     strerror(errno));
 
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   mark_point();
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_MAX_ENTS, 0);
-  fail_unless(res < 0, "Failed to handle SET_MAX_ENTS smaller than table");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle SET_MAX_ENTS smaller than table");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   res = pr_table_ctl(tab, 0, NULL);
-  fail_unless(res == -1, "Failed to handle non-empty table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle non-empty table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   res = pr_table_empty(tab);
-  fail_unless(res == 0, "Failed to empty table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to empty table: %s", strerror(errno));
 
   res = pr_table_ctl(tab, 0, NULL);
-  fail_unless(res == -1, "Failed to handle unknown ctl");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle unknown ctl");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_FLAGS, NULL);
-  fail_unless(res == -1, "Failed to handle SET_FLAGS, null args");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle SET_FLAGS, null args");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_FLAGS, &flags);
-  fail_unless(res == 0, "Failed to handle SET_FLAGS: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle SET_FLAGS: %s", strerror(errno));
 
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_NCHAINS, NULL);
-  fail_unless(res == -1, "Failed to handle SET_NCHAINS, null args");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle SET_NCHAINS, null args");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
   
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_NCHAINS, &nchains);
-  fail_unless(res == -1, "Failed to handle SET_NCHAINS, zero args");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle SET_NCHAINS, zero args");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
  
   nchains = 1; 
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_NCHAINS, &nchains);
-  fail_unless(res == 0, "Failed to handle SET_NCHAINS: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle SET_NCHAINS: %s", strerror(errno));
 
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_MAX_ENTS, &max_ents);
-  fail_unless(res == -1, "Failed to handle SET_MAX_ENTS, zero args");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle SET_MAX_ENTS, zero args");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* Add two entries, then try to set MAX_ENTS to one.  We should get an
    * EPERM back for that.
    */
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_add(tab, "baz", "quxx", 0);
-  fail_unless(res == 0, "Failed to add 'baz' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'baz' to table: %s", strerror(errno));
 
   max_ents = 1;
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_MAX_ENTS, &max_ents);
-  fail_unless(res == -1, "Failed to handle SET_MAX_ENTS on non-empty table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle SET_MAX_ENTS on non-empty table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   /* Now empty the table, set the MAX_ENTS to one, then try add two entries. */
 
   res = pr_table_empty(tab);
-  fail_unless(res == 0, "Failed to empty table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to empty table: %s", strerror(errno));
 
   max_ents = 1;
   res = pr_table_ctl(tab, PR_TABLE_CTL_SET_MAX_ENTS, &max_ents);
-  fail_unless(res == 0, "Failed to handle SET_MAX_ENTS to %d: %s",
+  ck_assert_msg(res == 0, "Failed to handle SET_MAX_ENTS to %d: %s",
     max_ents, strerror(errno));
 
   res = pr_table_add(tab, "foo", "bar", 0);
-  fail_unless(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add 'foo' to table: %s", strerror(errno));
 
   res = pr_table_add(tab, "baz", "quxx", 0);
-  fail_unless(res == -1, "Added second entry unexpectedly");
-  fail_unless(errno == ENOSPC,
+  ck_assert_msg(res == -1, "Added second entry unexpectedly");
+  ck_assert_msg(errno == ENOSPC,
     "Failed to set errno to ENOSPC, received %s (%d)", errno, strerror(errno));
 }
 END_TEST
@@ -739,13 +739,13 @@ START_TEST (table_load_test) {
   float load;
 
   load = pr_table_load(tab);
-  fail_unless(load < 0, "Failed to handle NULL table argument");
-  fail_unless(errno == EINVAL,
+  ck_assert_msg(load < 0, "Failed to handle NULL table argument");
+  ck_assert_msg(errno == EINVAL,
     "Failed to set errno to EINVAL; received %s (%d)", errno, strerror(errno));
 
   tab = pr_table_alloc(p, 0);
   load = pr_table_load(tab);
-  fail_unless(load >= 0.0, "Failed to calculate load properly; load = %0.3f",
+  ck_assert_msg(load >= 0.0, "Failed to calculate load properly; load = %0.3f",
     load);
 }
 END_TEST
@@ -767,21 +767,21 @@ START_TEST (table_pcalloc_test) {
   pr_table_t *tab;
 
   res = pr_table_pcalloc(NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   tab = pr_table_alloc(p, 0);
 
   res = pr_table_pcalloc(tab, 0);
-  fail_unless(res == NULL, "Failed to handle zero len argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle zero len argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_pcalloc(NULL, 1);
-  fail_unless(res == NULL, "Failed to handle null table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_table_pcalloc(tab, 2);
-  fail_unless(res != NULL, "Failed to allocate len 2 from table: %s",
+  ck_assert_msg(res != NULL, "Failed to allocate len 2 from table: %s",
     strerror(errno));
 }
 END_TEST

--- a/tests/api/timers.c
+++ b/tests/api/timers.c
@@ -87,34 +87,34 @@ START_TEST (timer_add_test) {
   unsigned int ok = 0;
 
   res = pr_timer_add(-1, 0, NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle negative seconds");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle negative seconds");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_timer_add(0, 0, NULL, NULL, NULL);
-  fail_unless(res == -1, "Failed to handle null description");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null description");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_timer_add(0, 0, NULL, NULL, "test");
-  fail_unless(res == -1, "Failed to handle zero count");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle zero count");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_timer_add(1, 0, NULL, NULL, "test");
-  fail_unless(res == -1, "Failed to handle null callback");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null callback");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_timer_add(1, 0, NULL, timers_test_cb, "test");
-  fail_unless(res == 0, "Failed to allocate timer: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to allocate timer: %s", strerror(errno));
 
   res = pr_timer_add(1, 0, NULL, timers_test_cb, "test");
-  fail_unless(res == -1, "Failed to handle duplicate timer: %s",
+  ck_assert_msg(res == -1, "Failed to handle duplicate timer: %s",
     strerror(errno));
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   sleep(2);
   timers_handle_signals();
 
   ok = 1;
-  fail_unless(timer_triggered_count == ok ||
+  ck_assert_msg(timer_triggered_count == ok ||
               timer_triggered_count == (ok - 1),
     "Timer failed to fire (expected count %u, got %u)", ok,
     timer_triggered_count);
@@ -125,7 +125,7 @@ START_TEST (timer_add_test) {
    * starting with 1024, if the input timer ID is -1.
    */
   res = pr_timer_add(1, -1, NULL, timers_test_cb, "test");
-  fail_unless(res == 1024, "Failed to allocate timer: %s", strerror(errno));
+  ck_assert_msg(res == 1024, "Failed to allocate timer: %s", strerror(errno));
 
   sleep(1);
   timers_handle_signals();
@@ -135,7 +135,7 @@ START_TEST (timer_add_test) {
    */
 
   ok = 2;
-  fail_unless(timer_triggered_count == ok ||
+  ck_assert_msg(timer_triggered_count == ok ||
               timer_triggered_count == (ok + 1) ||
               timer_triggered_count == (ok - 1),
     "Timer failed to fire (expected count %u, got %u)", ok,
@@ -145,7 +145,7 @@ START_TEST (timer_add_test) {
   timers_handle_signals();
 
   ok = 3;
-  fail_unless(timer_triggered_count == ok ||
+  ck_assert_msg(timer_triggered_count == ok ||
               timer_triggered_count == (ok + 1) ||
               timer_triggered_count == (ok - 1),
     "Timer failed to fire (expected count %u, got %u)", ok,
@@ -157,20 +157,20 @@ START_TEST (timer_remove_test) {
   int res;
 
   res = pr_timer_remove(0, NULL);
-  fail_unless(res == 0, "Failed to remove timer: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to remove timer: %s", strerror(errno));
 
   res = pr_timer_add(1, 0, NULL, timers_test_cb, "test");
-  fail_unless(res == 0, "Failed to add timer (%d): %s", res, strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add timer (%d): %s", res, strerror(errno));
 
   res = pr_timer_remove(1, NULL);
-  fail_unless(res == -1, "Failed to return -1 for non-matching timer ID");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to return -1 for non-matching timer ID");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_timer_remove(0, NULL);
-  fail_unless(res == 0, "Failed to remove timer (%d): %s", res,
+  ck_assert_msg(res == 0, "Failed to remove timer (%d): %s", res,
     strerror(errno));
 
-  fail_unless(timer_triggered_count == 0,
+  ck_assert_msg(timer_triggered_count == 0,
     "Expected trigger count of 0, got %u", timer_triggered_count);
 }
 END_TEST
@@ -184,19 +184,19 @@ START_TEST (timer_remove_multi_test) {
    * 1024.
    */
   res = pr_timer_add(3, -1, &m, timers_test_cb, "test1");
-  fail_unless(res >= 1024, "Failed to add timer (%d): %s", res,
+  ck_assert_msg(res >= 1024, "Failed to add timer (%d): %s", res,
     strerror(errno));
 
   res = pr_timer_add(3, -1, &m, timers_test_cb, "test2");
-  fail_unless(res >= 1024, "Failed to add timer (%d): %s", res,
+  ck_assert_msg(res >= 1024, "Failed to add timer (%d): %s", res,
     strerror(errno));
 
   res = pr_timer_add(3, -1, &m, timers_test_cb, "test3");
-  fail_unless(res >= 1024, "Failed to add timer (%d): %s", res,
+  ck_assert_msg(res >= 1024, "Failed to add timer (%d): %s", res,
     strerror(errno));
 
   res = pr_timer_remove(-1, &m);
-  fail_unless(res == 3, "Failed to remove timers (%d): %s", res,
+  ck_assert_msg(res == 3, "Failed to remove timers (%d): %s", res,
     strerror(errno));
 }
 END_TEST
@@ -207,33 +207,33 @@ START_TEST (timer_reset_test) {
 
   mark_point();
   res = pr_timer_reset(0, NULL);
-  fail_unless(res == -1, "Failed to handle empty timer list");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle empty timer list");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   mark_point();
   res = pr_timer_add(2, 1, NULL, timers_test_cb, "test");
-  fail_unless(res == 1, "Failed to add timer: %s", strerror(errno));
+  ck_assert_msg(res == 1, "Failed to add timer: %s", strerror(errno));
 
   mark_point();
   res = pr_timer_reset(2, NULL);
-  fail_unless(res == 0, "Expected timer ID 1, got %d", res);
+  ck_assert_msg(res == 0, "Expected timer ID 1, got %d", res);
 
   sleep(1);
   timers_handle_signals();
 
   mark_point();
-  fail_unless(timer_triggered_count == ok,
+  ck_assert_msg(timer_triggered_count == ok,
     "Timer fired unexpectedly (expected count %u, got %u)", ok,
     timer_triggered_count);
 
   mark_point();
   res = pr_timer_reset(1, NULL);
-  fail_unless(res == 1, "Failed to reset timer");
+  ck_assert_msg(res == 1, "Failed to reset timer");
 
   sleep(1);
   timers_handle_signals();
 
-  fail_unless(timer_triggered_count == ok,
+  ck_assert_msg(timer_triggered_count == ok,
     "Timer fired unexpectedly (expected count %u, got %u)", ok,
     timer_triggered_count);
 
@@ -241,7 +241,7 @@ START_TEST (timer_reset_test) {
   timers_handle_signals();
 
   ok = 1;
-  fail_unless(timer_triggered_count == ok ||
+  ck_assert_msg(timer_triggered_count == ok ||
               timer_triggered_count == (ok - 1),
     "Timer failed to fire (expected count %u, got %u)", ok,
     timer_triggered_count);
@@ -252,18 +252,18 @@ START_TEST (timer_sleep_test) {
   int res;
 
   res = pr_timer_sleep(0);
-  fail_unless(res == -1, "Failed to handle sleep len of zero");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle sleep len of zero");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   pr_alarms_block();
   res = pr_timer_sleep(1);
-  fail_unless(res == -1, "Failed to handle blocked alarms when sleeping");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle blocked alarms when sleeping");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   pr_alarms_unblock();
 
   res = pr_timer_sleep(1);
-  fail_unless(res == 0, "Failed to sleep: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to sleep: %s", strerror(errno));
 }
 END_TEST
 
@@ -271,11 +271,11 @@ START_TEST (timer_usleep_test) {
   int res;
 
   res = pr_timer_usleep(0);
-  fail_unless(res == -1, "Failed to handle sleep len of zero");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle sleep len of zero");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_timer_usleep(500000);
-  fail_unless(res == 0, "Failed to sleep: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to sleep: %s", strerror(errno));
 }
 END_TEST
 

--- a/tests/api/trace.c
+++ b/tests/api/trace.c
@@ -57,29 +57,29 @@ START_TEST (trace_set_levels_test) {
   const char *channel;
 
   res = pr_trace_set_levels(NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null channel, no table");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null channel, no table");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   channel = "foo";
   min_level = 3;
   max_level = 1;
   res = pr_trace_set_levels(channel, min_level, max_level);
-  fail_unless(res < 0, "Failed to handle min level > max level");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle min level > max level");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   min_level = 1;
   max_level = 2; 
   res = pr_trace_set_levels(channel, min_level, max_level);
-  fail_unless(res == 0, "Failed to handle valid channel and levels: %s",
+  ck_assert_msg(res == 0, "Failed to handle valid channel and levels: %s",
     strerror(errno));
 
   res = pr_trace_set_levels(PR_TRACE_DEFAULT_CHANNEL, 1, 5);
-  fail_unless(res == 0, "Failed to set default channels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set default channels: %s", strerror(errno));
 
   res = pr_trace_set_levels(PR_TRACE_DEFAULT_CHANNEL, 0, 0);
-  fail_unless(res == 0, "Failed to set default channels: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set default channels: %s", strerror(errno));
 }
 END_TEST
 
@@ -87,14 +87,14 @@ START_TEST (trace_get_table_test) {
   pr_table_t *res;
 
   res = pr_trace_get_table();
-  fail_unless(res == NULL, "Failed to handle uninitialized Trace API");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res == NULL, "Failed to handle uninitialized Trace API");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   pr_trace_set_levels("foo", 1, 2);
 
   res = pr_trace_get_table();
-  fail_unless(res != NULL, "Did not get Trace API table as expected: %s",
+  ck_assert_msg(res != NULL, "Did not get Trace API table as expected: %s",
     strerror(errno));
 }
 END_TEST
@@ -108,26 +108,26 @@ START_TEST (trace_get_max_level_test) {
   max_level = 2;
 
   res = pr_trace_get_max_level(NULL);
-  fail_unless(res < 0, "Failed to handle null channel");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null channel");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_max_level("bar");
-  fail_unless(res < 0, "Failed to handle unset channels/levels");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unset channels/levels");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_set_levels(channel, min_level, max_level);
-  fail_unless(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
+  ck_assert_msg(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
     max_level, strerror(errno));
 
   res = pr_trace_get_max_level("bar");
-  fail_unless(res < 0, "Failed to handle unknown channel");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unknown channel");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_max_level(channel);
-  fail_unless(res == max_level, "Failed to get level %d for channel '%s': %s",
+  ck_assert_msg(res == max_level, "Failed to get level %d for channel '%s': %s",
     max_level, channel, strerror(errno));
 }
 END_TEST
@@ -141,26 +141,26 @@ START_TEST (trace_get_min_level_test) {
   max_level = 2;
 
   res = pr_trace_get_min_level(NULL);
-  fail_unless(res < 0, "Failed to handle null channel");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null channel");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_min_level("bar");
-  fail_unless(res < 0, "Failed to handle unset channels/levels");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unset channels/levels");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_set_levels(channel, min_level, max_level);
-  fail_unless(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
+  ck_assert_msg(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
     max_level, strerror(errno));
 
   res = pr_trace_get_min_level("bar");
-  fail_unless(res < 0, "Failed to handle unknown channel");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unknown channel");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_min_level(channel);
-  fail_unless(res == min_level, "Failed to get level %d for channel '%s': %s",
+  ck_assert_msg(res == min_level, "Failed to get level %d for channel '%s': %s",
     min_level, channel, strerror(errno));
 }
 END_TEST
@@ -174,26 +174,26 @@ START_TEST (trace_get_level_test) {
   max_level = 2;
 
   res = pr_trace_get_level(NULL);
-  fail_unless(res < 0, "Failed to handle null channel");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null channel");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_level("bar");
-  fail_unless(res < 0, "Failed to handle unset channels/levels");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unset channels/levels");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_set_levels(channel, min_level, max_level);
-  fail_unless(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
+  ck_assert_msg(res == 0, "Failed to set '%s:%d-%d': %s", channel, min_level,
     max_level, strerror(errno));
 
   res = pr_trace_get_level("bar");
-  fail_unless(res < 0, "Failed to handle unknown channel");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle unknown channel");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_get_level(channel);
-  fail_unless(res == max_level, "Failed to get level %d for channel '%s': %s",
+  ck_assert_msg(res == max_level, "Failed to get level %d for channel '%s': %s",
     max_level, channel, strerror(errno));
 }
 END_TEST
@@ -203,25 +203,25 @@ START_TEST (trace_parse_levels_test) {
   char *level_str;
 
   res = pr_trace_parse_levels(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   res = pr_trace_parse_levels("", &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle empty string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle empty string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = "foo";
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle invalid levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle invalid levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "-7");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle negative levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle negative levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   /* Overflow the int data type, in order to get a negative number without
@@ -229,32 +229,32 @@ START_TEST (trace_parse_levels_test) {
    */
   level_str = pstrdup(p, "2147483653");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle negative levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle negative levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "0");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res == 0, "Failed to handle single level zero string");
-  fail_unless(min_level == 0, "Expected min level 0, got %d", max_level);
-  fail_unless(max_level == 0, "Expected max level 0, got %d", max_level);
+  ck_assert_msg(res == 0, "Failed to handle single level zero string");
+  ck_assert_msg(min_level == 0, "Expected min level 0, got %d", max_level);
+  ck_assert_msg(max_level == 0, "Expected max level 0, got %d", max_level);
 
   level_str = pstrdup(p, "7");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res == 0, "Failed to handle single level string");
-  fail_unless(min_level == 1, "Expected min level 1, got %d", max_level);
-  fail_unless(max_level == 7, "Expected max level 7, got %d", max_level);
+  ck_assert_msg(res == 0, "Failed to handle single level string");
+  ck_assert_msg(min_level == 1, "Expected min level 1, got %d", max_level);
+  ck_assert_msg(max_level == 7, "Expected max level 7, got %d", max_level);
 
   level_str = pstrdup(p, "abc-def");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle invalid levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle invalid levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "1-def");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle invalid levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle invalid levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   /* Overflow the int data type, in order to get a negative number without
@@ -262,39 +262,39 @@ START_TEST (trace_parse_levels_test) {
    */
   level_str = pstrdup(p, "2147483653-10");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle negative levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle negative levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "10-2147483653");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle negative levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle negative levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "-7-5");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle negative levels string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle negative levels string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "0--1");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle single level zero string");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle single level zero string");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "8-7");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res < 0, "Failed to handle max level < min level");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
+  ck_assert_msg(res < 0, "Failed to handle max level < min level");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %d (%s)",
     errno, strerror(errno));
 
   level_str = pstrdup(p, "1-7");
   res = pr_trace_parse_levels(level_str, &min_level, &max_level);
-  fail_unless(res == 0, "Failed to handle levels string");
-  fail_unless(min_level == 1, "Expected min level 1, got %d", max_level);
-  fail_unless(max_level == 7, "Expected max level 7, got %d", max_level);
+  ck_assert_msg(res == 0, "Failed to handle levels string");
+  ck_assert_msg(min_level == 1, "Expected min level 1, got %d", max_level);
+  ck_assert_msg(max_level == 7, "Expected max level 7, got %d", max_level);
 }
 END_TEST
 
@@ -303,22 +303,22 @@ START_TEST (trace_msg_test) {
   char *channel, msg[16384];
 
   res = pr_trace_msg(NULL, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   channel = "testsuite";
 
   mark_point();
   res = pr_trace_msg(channel, -1, NULL);
-  fail_unless(res < 0, "Failed to handle bad level");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad level");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = pr_trace_msg(channel, 1, NULL);
-  fail_unless(res < 0, "Failed to handle null message");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null message");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -331,17 +331,17 @@ START_TEST (trace_msg_test) {
 
   mark_point();
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
   session.c->local_addr = session.c->remote_addr =
     pr_netaddr_get_addr(p, "127.0.0.1", NULL);
 
   mark_point();
   res = pr_trace_set_options(PR_TRACE_OPT_LOG_CONN_IPS|PR_TRACE_OPT_USE_TIMESTAMP_MILLIS);
-  fail_unless(res == 0, "Failed to set options: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set options: %s", strerror(errno));
   pr_trace_msg(channel, 5, "%s", "alef bet vet?");
 
   res = pr_trace_set_options(0);
-  fail_unless(res == 0, "Failed to set options: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set options: %s", strerror(errno));
   pr_trace_msg(channel, 5, "%s", "alef bet vet?");
 
   pr_inet_close(p, session.c);
@@ -357,20 +357,20 @@ START_TEST (trace_set_file_test) {
 
   path = "/";
   res = pr_trace_set_file(path);
-  fail_unless(res < 0, "Failed to handle path '%s'", path);
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle path '%s'", path);
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   path = "/tmp";
   res = pr_trace_set_file(path);
-  fail_unless(res < 0, "Failed to handle path '%s'", path);
-  fail_unless(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
+  ck_assert_msg(res < 0, "Failed to handle path '%s'", path);
+  ck_assert_msg(errno == EISDIR, "Expected EISDIR (%d), got %s (%d)", EISDIR,
     strerror(errno), errno);
 
   mark_point();
   path = trace_path;
   res = pr_trace_set_file(path);
-  fail_unless(res == 0, "Failed to set trace file '%s': %s", path,
+  ck_assert_msg(res == 0, "Failed to set trace file '%s': %s", path,
     strerror(errno));
   pr_trace_set_levels("foo", 1, 20);
 
@@ -380,17 +380,17 @@ START_TEST (trace_set_file_test) {
 
   mark_point();
   res = pr_trace_set_options(PR_TRACE_OPT_LOG_CONN_IPS|PR_TRACE_OPT_USE_TIMESTAMP_MILLIS);
-  fail_unless(res == 0, "Failed to set options: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set options: %s", strerror(errno));
 
   pr_trace_msg("foo", 1, "quxx?");
   pr_trace_msg("foo", 1, "QUZZ!");
 
   res = pr_trace_set_options(PR_TRACE_OPT_DEFAULT);
-  fail_unless(res == 0, "Failed to set default options: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set default options: %s", strerror(errno));
 
   pr_trace_set_levels("foo", 0, 0);
   res = pr_trace_set_file(NULL);
-  fail_unless(res == 0, "Failed to reset trace file: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to reset trace file: %s", strerror(errno));
 
   (void) unlink(trace_path);
 }

--- a/tests/api/var.c
+++ b/tests/api/var.c
@@ -63,66 +63,66 @@ START_TEST (var_set_test) {
   (void) var_free();
 
   res = pr_var_set(NULL, NULL, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle uninitialized Var table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle uninitialized Var table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   (void) var_init();
 
   res = pr_var_set(NULL, NULL, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_set(p, NULL, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "fo";
 
   res = pr_var_set(p, key, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == -1, "Failed to handle null val");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null val");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_set(p, key, NULL, 0, "bar", NULL, 0);
-  fail_unless(res == -1, "Failed to handle bad key name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad key name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "fooo";
 
   res = pr_var_set(p, key, NULL, 0, "bar", NULL, 0);
-  fail_unless(res == -1, "Failed to handle bad key name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad key name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "%{foo";
 
   res = pr_var_set(p, key, NULL, 0, "bar", NULL, 0);
-  fail_unless(res == -1, "Failed to handle bad key name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad key name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "%{}";
 
   res = pr_var_set(p, key, NULL, 0, "bar", NULL, 0);
-  fail_unless(res == -1, "Failed to handle bad key name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle bad key name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "%{foo}";
 
   res = pr_var_set(p, key, NULL, 0, "bar", NULL, 0);
-  fail_unless(res == -1, "Failed to handle unknown type");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle unknown type");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_set(p, key, NULL, PR_VAR_TYPE_STR, "bar", "bar", 0);
-  fail_unless(res == -1, "Failed to handle data with zero len");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle data with zero len");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_set(p, key, NULL, PR_VAR_TYPE_STR, "bar", NULL, 1);
-  fail_unless(res == -1, "Failed to handle null data with non-zero len");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null data with non-zero len");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_set(p, key, NULL, PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(res == 0, "Failed to add str var: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add str var: %s", strerror(errno));
 
   res = pr_var_set(p, key, "test", PR_VAR_TYPE_FUNC, var_cb, NULL, 0);
-  fail_unless(res == 0, "Failed to add cb var: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add cb var: %s", strerror(errno));
 }
 END_TEST
 
@@ -133,28 +133,28 @@ START_TEST (var_delete_test) {
   (void) var_free();
 
   res = pr_var_delete(NULL);
-  fail_unless(res == -1, "Failed to handle uninitialized Var table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle uninitialized Var table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   (void) var_init();
 
   res = pr_var_delete(NULL);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   res = pr_var_delete(key);
-  fail_unless(res == -1, "Failed to handle absent key");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle absent key");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = pr_var_set(p, key, "test", PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(res == 0, "Failed to add var: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add var: %s", strerror(errno));
 
   res = pr_var_delete(key);
-  fail_unless(res == 0, "Failed to delete var: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to delete var: %s", strerror(errno));
 
   res = pr_var_delete(key);
-  fail_unless(res == -1, "Failed to handle absent key");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == -1, "Failed to handle absent key");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 }
 END_TEST
 
@@ -165,24 +165,24 @@ START_TEST (var_exists_test) {
   (void) var_free();
 
   res = pr_var_exists(NULL);
-  fail_unless(res == -1, "Failed to handle uninitialized Var table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == -1, "Failed to handle uninitialized Var table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   (void) var_init();
 
   res = pr_var_exists(NULL);
-  fail_unless(res == -1, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == -1, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "%{foo}";
   res = pr_var_exists(key);
-  fail_unless(res == FALSE, "Failed to handle absent key");
+  ck_assert_msg(res == FALSE, "Failed to handle absent key");
 
   res = pr_var_set(p, key, NULL, PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(res == 0, "Failed to add var: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to add var: %s", strerror(errno));
 
   res = pr_var_exists(key);
-  fail_unless(res == TRUE, "Failed to detect present key");
+  ck_assert_msg(res == TRUE, "Failed to detect present key");
 }
 END_TEST
 
@@ -193,34 +193,34 @@ START_TEST (var_get_test) {
   (void) var_free();
 
   res = pr_var_get(NULL);
-  fail_unless(res == NULL, "Failed to handle uninitialized Var table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle uninitialized Var table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   (void) var_init();
 
   res = pr_var_get(NULL);
-  fail_unless(res == NULL, "Failed to handle null key");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(res == NULL, "Failed to handle null key");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   key = "%{foo}";
 
   res = pr_var_get(key);
-  fail_unless(res == NULL, "Failed to absent key");
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(res == NULL, "Failed to absent key");
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   ok = pr_var_set(p, key, NULL, PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(ok == 0, "Failed to add str var: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add str var: %s", strerror(errno));
 
   res = pr_var_get(key);
-  fail_unless(res != NULL, "Failed to get str var: %s", strerror(errno));
-  fail_unless(strcmp(res, "bar") == 0, "Expected '%s', got '%s'", "bar", res);
+  ck_assert_msg(res != NULL, "Failed to get str var: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "bar") == 0, "Expected '%s', got '%s'", "bar", res);
 
   ok = pr_var_set(p, key, "test", PR_VAR_TYPE_FUNC, var_cb, NULL, 0);
-  fail_unless(ok == 0, "Failed to add cb var: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add cb var: %s", strerror(errno));
 
   res = pr_var_get(key);
-  fail_unless(res != NULL, "Failed to get str var: %s", strerror(errno));
-  fail_unless(strcmp(res, "baz") == 0, "Expected '%s', got '%s'", "baz", res);
+  ck_assert_msg(res != NULL, "Failed to get str var: %s", strerror(errno));
+  ck_assert_msg(strcmp(res, "baz") == 0, "Expected '%s', got '%s'", "baz", res);
 }
 END_TEST
 
@@ -231,23 +231,23 @@ START_TEST (var_next_test) {
   (void) var_free();
 
   res = pr_var_next(NULL);
-  fail_unless(res == NULL, "Failed to handle uninitialized Var table");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(res == NULL, "Failed to handle uninitialized Var table");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   (void) var_init();
 
   res = pr_var_next(NULL);
-  fail_unless(res == NULL, "Failed to handle empty table");
+  ck_assert_msg(res == NULL, "Failed to handle empty table");
 
   ok = pr_var_set(p, "%{foo}", NULL, PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(ok == 0, "Failed to add var: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add var: %s", strerror(errno));
 
   res = pr_var_next(&desc);
-  fail_unless(res != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(desc == NULL, "Expected no desc, got '%s'", desc);
+  ck_assert_msg(res != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(desc == NULL, "Expected no desc, got '%s'", desc);
 
   res = pr_var_next(&desc);
-  fail_unless(res == NULL, "Expected no more keys, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected no more keys, got '%s'", res);
 }
 END_TEST
 
@@ -265,27 +265,27 @@ START_TEST (var_rewind_test) {
   pr_var_rewind();
 
   ok = pr_var_set(p, "%{foo}", "test", PR_VAR_TYPE_STR, "bar", NULL, 0);
-  fail_unless(ok == 0, "Failed to add var: %s", strerror(errno));
+  ck_assert_msg(ok == 0, "Failed to add var: %s", strerror(errno));
 
   res = pr_var_next(&desc);
-  fail_unless(res != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(desc != NULL, "Expected non-null desc");
-  fail_unless(strcmp(desc, "test") == 0, "Expected desc '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(desc != NULL, "Expected non-null desc");
+  ck_assert_msg(strcmp(desc, "test") == 0, "Expected desc '%s', got '%s'",
     "test", desc);
 
   res = pr_var_next(&desc);
-  fail_unless(res == NULL, "Expected no more keys, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected no more keys, got '%s'", res);
 
   pr_var_rewind();
 
   res = pr_var_next(&desc);
-  fail_unless(res != NULL, "Failed to get next key: %s", strerror(errno));
-  fail_unless(desc != NULL, "Expected non-null desc");
-  fail_unless(strcmp(desc, "test") == 0, "Expected desc '%s', got '%s'",
+  ck_assert_msg(res != NULL, "Failed to get next key: %s", strerror(errno));
+  ck_assert_msg(desc != NULL, "Expected non-null desc");
+  ck_assert_msg(strcmp(desc, "test") == 0, "Expected desc '%s', got '%s'",
     "test", desc);
 
   res = pr_var_next(&desc);
-  fail_unless(res == NULL, "Expected no more keys, got '%s'", res);
+  ck_assert_msg(res == NULL, "Expected no more keys, got '%s'", res);
 }
 END_TEST
 

--- a/tests/api/version.c
+++ b/tests/api/version.c
@@ -31,7 +31,7 @@ START_TEST (version_get_module_api_number_test) {
 
   res = pr_version_get_module_api_number();
   fail_if(res == 0, "Expected value, got zero");
-  fail_unless(res == PR_MODULE_API_VERSION, "Expected %lu, got %lu",
+  ck_assert_msg(res == PR_MODULE_API_VERSION, "Expected %lu, got %lu",
     PR_MODULE_API_VERSION, res);
 }
 END_TEST
@@ -41,7 +41,7 @@ START_TEST (version_get_number_test) {
 
   res = pr_version_get_number();
   fail_if(res == 0, "Expected value, got zero");
-  fail_unless(res == PROFTPD_VERSION_NUMBER, "Expected %lu, got %lu",
+  ck_assert_msg(res == PROFTPD_VERSION_NUMBER, "Expected %lu, got %lu",
     PROFTPD_VERSION_NUMBER, res);
 }
 END_TEST
@@ -51,7 +51,7 @@ START_TEST (version_get_str_test) {
 
   res = pr_version_get_str();
   fail_if(res == NULL, "Expected string, got null");
-  fail_unless(strcmp(res, PROFTPD_VERSION_TEXT) == 0, "Expected '%s', '%s'",
+  ck_assert_msg(strcmp(res, PROFTPD_VERSION_TEXT) == 0, "Expected '%s', '%s'",
     PROFTPD_VERSION_TEXT, res);
 }
 END_TEST

--- a/tests/api/version.c
+++ b/tests/api/version.c
@@ -30,7 +30,7 @@ START_TEST (version_get_module_api_number_test) {
   unsigned long res;
 
   res = pr_version_get_module_api_number();
-  fail_if(res == 0, "Expected value, got zero");
+  ck_assert_msg(res != 0, "Expected value, got zero");
   ck_assert_msg(res == PR_MODULE_API_VERSION, "Expected %lu, got %lu",
     PR_MODULE_API_VERSION, res);
 }
@@ -40,7 +40,7 @@ START_TEST (version_get_number_test) {
   unsigned long res;
 
   res = pr_version_get_number();
-  fail_if(res == 0, "Expected value, got zero");
+  ck_assert_msg(res != 0, "Expected value, got zero");
   ck_assert_msg(res == PROFTPD_VERSION_NUMBER, "Expected %lu, got %lu",
     PROFTPD_VERSION_NUMBER, res);
 }
@@ -50,7 +50,7 @@ START_TEST (version_get_str_test) {
   const char *res;
 
   res = pr_version_get_str();
-  fail_if(res == NULL, "Expected string, got null");
+  ck_assert_msg(res != NULL, "Expected string, got null");
   ck_assert_msg(strcmp(res, PROFTPD_VERSION_TEXT) == 0, "Expected '%s', '%s'",
     PROFTPD_VERSION_TEXT, res);
 }

--- a/tests/api/version.c
+++ b/tests/api/version.c
@@ -31,7 +31,7 @@ START_TEST (version_get_module_api_number_test) {
 
   res = pr_version_get_module_api_number();
   ck_assert_msg(res != 0, "Expected value, got zero");
-  ck_assert_msg(res == PR_MODULE_API_VERSION, "Expected %lu, got %lu",
+  ck_assert_msg(res == PR_MODULE_API_VERSION, "Expected %d, got %lu",
     PR_MODULE_API_VERSION, res);
 }
 END_TEST
@@ -41,7 +41,7 @@ START_TEST (version_get_number_test) {
 
   res = pr_version_get_number();
   ck_assert_msg(res != 0, "Expected value, got zero");
-  ck_assert_msg(res == PROFTPD_VERSION_NUMBER, "Expected %lu, got %lu",
+  ck_assert_msg(res == PROFTPD_VERSION_NUMBER, "Expected %d, got %lu",
     PROFTPD_VERSION_NUMBER, res);
 }
 END_TEST


### PR DESCRIPTION
`fail()` replaced by `ck_abort_msg()`
`fail_unless()` replaced by `ck_assert_msg()`
`fail_if()` replaced by `ck_assert_msg()` and inverting the sense of the assertion

Having made those changes, I then cleared up some mismatches between the format strings used in the assertions and the supplied parameters. Mostly this was to handle objects of type `size_t`, by using the format `%lu` and casting the parameter to an `unsigned long`. There were a few other things though, such as missing parameters, `errno` and `strerror(errno)` having their parameters the wrong way around, etc.