### PR TITLE
Address many of the OpenSSL-related const-ness warnings.

### DIFF
--- a/contrib/mod_digest.c
+++ b/contrib/mod_digest.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_digest - File hashing/checksumming module
  * Copyright (c) Mathias Berchtold <mb@smartftp.com>
- * Copyright (c) 2016-2019 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2021 TJ Saunders <tj@castaglia.org>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -389,7 +389,7 @@ static const EVP_MD crc32_md = {
 #endif /* Older OpenSSLs */
 
 static const EVP_MD *EVP_crc32(void) {
-  const EVP_MD *md;
+  EVP_MD *md;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)

--- a/contrib/mod_sftp/msg.c
+++ b/contrib/mod_sftp/msg.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp message format
- * Copyright (c) 2008-2020 TJ Saunders
+ * Copyright (c) 2008-2021 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -234,7 +234,7 @@ uint64_t sftp_msg_read_long(pool *p, unsigned char **buf, uint32_t *buflen) {
 }
 
 uint32_t sftp_msg_read_mpint2(pool *p, unsigned char **buf, uint32_t *buflen,
-    BIGNUM **mpint) {
+    const BIGNUM **mpint) {
   unsigned char *mpint_data = NULL;
   const unsigned char *data = NULL, *ptr = NULL;
   uint32_t datalen = 0, mpint_len = 0, len = 0, total_len = 0;
@@ -295,8 +295,9 @@ uint32_t sftp_msg_read_mpint2(pool *p, unsigned char **buf, uint32_t *buflen,
   return total_len;
 }
 
-BIGNUM *sftp_msg_read_mpint(pool *p, unsigned char **buf, uint32_t *buflen) {
-  BIGNUM *mpint = NULL;
+const BIGNUM *sftp_msg_read_mpint(pool *p, unsigned char **buf,
+    uint32_t *buflen) {
+  const BIGNUM *mpint = NULL;
   uint32_t len;
 
   len = sftp_msg_read_mpint2(p, buf, buflen, &mpint);

--- a/contrib/mod_sftp/msg.h
+++ b/contrib/mod_sftp/msg.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp message format
- * Copyright (c) 2008-2020 TJ Saunders
+ * Copyright (c) 2008-2021 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,7 +36,7 @@ EC_POINT *sftp_msg_read_ecpoint(pool *, unsigned char **, uint32_t *,
 #endif /* PR_USE_OPENSSL_ECC */
 uint32_t sftp_msg_read_int(pool *, unsigned char **, uint32_t *);
 uint64_t sftp_msg_read_long(pool *, unsigned char **, uint32_t *);
-BIGNUM *sftp_msg_read_mpint(pool *, unsigned char **, uint32_t *);
+const BIGNUM *sftp_msg_read_mpint(pool *, unsigned char **, uint32_t *);
 char *sftp_msg_read_string(pool *, unsigned char **, uint32_t *);
 
 /* Variant of the Message Read API whose return value indicates the number
@@ -52,7 +52,8 @@ uint32_t sftp_msg_read_ecpoint2(pool *, unsigned char **, uint32_t *,
 #endif /* PR_USE_OPENSSL_ECC */
 uint32_t sftp_msg_read_int2(pool *, unsigned char **, uint32_t *, uint32_t *);
 uint32_t sftp_msg_read_long2(pool *, unsigned char **, uint32_t *, uint64_t *);
-uint32_t sftp_msg_read_mpint2(pool *, unsigned char **, uint32_t *, BIGNUM **);
+uint32_t sftp_msg_read_mpint2(pool *, unsigned char **, uint32_t *,
+  const BIGNUM **);
 uint32_t sftp_msg_read_string2(pool *, unsigned char **, uint32_t *, char **);
 
 uint32_t sftp_msg_write_byte(unsigned char **, uint32_t *, unsigned char);


### PR DESCRIPTION
This will quell these compiler warnings when using _e.g._ OpenSSL-1.1.x, but
will cause these warnings to appear when using older OpenSSL versions.