### PR TITLE
NLST command handler should treat paths beginning with './' as local (relative to cwd)

### DIFF
--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -3211,7 +3211,7 @@ MODRET ls_nlst(cmd_rec *cmd) {
       p = *path;
       path++;
 
-      if (*p == '.' && (!opt_A || is_dotdir(p))) {
+      if (opt_A == 0 && *p == '.' && is_dotdir(p)) {
         continue;
       }
 


### PR DESCRIPTION
running ftp NLST command we obtain different results
for those commands `ls test/...` vs. `ls ./test/...`:

```
ftp> ls test/TEST????.dat
200 PORT command successful
150 Opening ASCII mode data connection for file list
test/TEST0001.dat
test/TEST0006.dat
test/TEST0008.dat
test/TEST0009.dat
test/TEST0007.dat
test/TEST0000.dat
test/TEST0003.dat
test/TEST0004.dat
test/TEST0005.dat
test/TEST0002.dat
226 Transfer complete
remote: test/TEST????.dat
190 bytes received in 0.0033 seconds (55.61 Kbytes/s)
ftp> ls ./test/TEST????.dat
200 PORT command successful
150 Opening ASCII mode data connection for file list
226 Transfer complete
```

output should be same in this case.

the proposed fix seems to solve the glitch (at least for me). I'm not familiar with proftpd code enough to tell the change is correct. there might be better way to fix it.