### PR TITLE
Issue #1282: When an interface/device name is configured, as for `<Vi…

### DIFF
--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2020 The ProFTPD Project team
+ * Copyright (c) 2001-2021 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2582,7 +2582,12 @@ int fixup_servers(xaset_t *list) {
       }
  
     } else {
-      s->addr = pr_netaddr_get_addr(s->pool, s->ServerAddress, NULL);
+      int flags = PR_NETADDR_GET_ADDR_FL_INCL_DEVICE;
+
+      /* Make sure we properly handle a ServerAddress that is an
+       * interface/device name here (Issue #1282).
+       */
+      s->addr = pr_netaddr_get_addr2(s->pool, s->ServerAddress, NULL, flags);
     }
 
     if (s->addr == NULL) {


### PR DESCRIPTION
…rtualHost>`, make sure we properly handle that name everywhere.

There was a place, in `fixup_servers()`, where we were still treating the
configured name as a DNS name/IP address, and *not* handling the case where
the name could be an interface/device.