### PR TITLE
Bug #4443: Change the default behavior of mod_tls, such that TLS rene…

### DIFF
--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -1431,7 +1431,7 @@ speed up entropy gathering when the daemon starts up again.
 <strong>Compatibility:</strong> 1.2.7rc1 and later
 
 <p>
-The <code>TLSRenegotiate</code> directive is used to configure when SSL
+The <code>TLSRenegotiate</code> directive is used to configure when SSL/TLS
 renegotiations are to occur.  Renegotiations, and thus this directive, are
 only supported by <code>mod_tls</code> if the version of OpenSSL installed
 is 0.9.7 or greater.
@@ -1503,6 +1503,13 @@ Examples:
   # To disable renegotiations entirely
   TLSRenegotiate none
 </pre>
+
+<p>
+<b>Note</b> that in ProFTPD 1.3.8rc2 and later, the <em>default</em> behavior
+of <code>TLSRenegotiate</code> changed, such that <code>mod_tls</code> will
+not request SSL/TLS renegotiations <em>at all</em> for control <i>or</i>
+data connections.  If renegotiations are <i>explicitly</i> configured via
+<code>TLSRenegotiate</code>, they will be used.
 
 <p>
 <hr>


### PR DESCRIPTION
…gotiations on ctrl/data connections are not requested by default.

TLS renegotiations have a long and sordid history; many SSL/TLS libraries no
longer implement them, or disable them by default.