### PR TITLE
Rather than trying to link with our base `libsupp.a` library as a lib…

### DIFF
--- a/Make.rules.in
+++ b/Make.rules.in
@@ -104,14 +104,14 @@ STATIC_MODULE_OBJS=@STATIC_MODULE_OBJS@
 STATIC_MODULE_SRCS=@STATIC_MODULE_SRCS@
 
 BUILD_STATIC_MODULE_ARCHIVES=@BUILD_STATIC_MODULE_ARCHIVES@
-BUILD_STATIC_MODULE_OBJS=@BUILD_STATIC_MODULE_OBJS@ modules/module_glue.o
+BUILD_STATIC_MODULE_OBJS=@BUILD_STATIC_MODULE_OBJS@ modules/module_glue.o lib/prbase.a
 
 FTPCOUNT_OBJS=ftpcount.o scoreboard.o misc.o
 BUILD_FTPCOUNT_OBJS=utils/ftpcount.o utils/scoreboard.o utils/misc.o
 
 FTPDCTL_OBJS=ftpdctl.o pool.o netaddr.o log.o ctrls.o
 BUILD_FTPDCTL_OBJS=src/ftpdctl.o src/pool.o src/str.o src/netaddr.o src/log.o \
-  src/ctrls.o
+  src/ctrls.o lib/prbase.a
 
 FTPSCRUB_OBJS=ftpscrub.o scoreboard.o misc.o
 BUILD_FTPSCRUB_OBJS=utils/ftpscrub.o utils/scoreboard.o utils/misc.o
@@ -123,4 +123,4 @@ FTPTOP_OBJS=ftptop.o scoreboard.o misc.o
 BUILD_FTPTOP_OBJS=utils/ftptop.o utils/scoreboard.o utils/misc.o
 
 FTPWHO_OBJS=ftpwho.o scoreboard.o misc.o
-BUILD_FTPWHO_OBJS=utils/ftpwho.o utils/scoreboard.o utils/misc.o
+BUILD_FTPWHO_OBJS=utils/ftpwho.o utils/scoreboard.o utils/misc.o lib/prbase.a

--- a/configure
+++ b/configure
@@ -17255,8 +17255,6 @@ $as_echo "#define PR_USE_PCRE 1" >>confdefs.h
       # fiddle with CPPFLAGS, LDFLAGS
       CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
       LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-            LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="$LIBS -lpcre -lpcreposix"
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PCRE's pcre_free_study" >&5
@@ -17303,7 +17301,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-      # restore CPPFLAGS, LDFLAGS
+      # restore CPPFLAGS, LDFLAGS, LIBS
       CPPFLAGS="$saved_cppflags"
       LDFLAGS="$saved_ldflags"
       LIBS="$saved_libs"
@@ -17337,8 +17335,6 @@ fi
       # fiddle with CPPFLAGS, LDFLAGS
       CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
       LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-            LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="$LIBS -lhiredis"
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Hiredis' redisReconnect" >&5
@@ -17382,7 +17378,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-      # restore CPPFLAGS, LDFLAGS
+      # restore CPPFLAGS, LDFLAGS, LIBS
       CPPFLAGS="$saved_cppflags"
       LDFLAGS="$saved_ldflags"
       LIBS="$saved_libs"
@@ -23876,8 +23872,6 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 
-LIBS="-lsupp $LIBS"
-
 ac_shared_module_dirs=
 ac_static_module_dirs=
 
@@ -24031,8 +24025,6 @@ if test x"$pr_use_mysql" = xyes; then
 
     CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
   LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lm -lmysqlclient -lz"
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for mysql_get_option" >&5
@@ -24365,8 +24357,6 @@ $as_echo "#define PR_USE_OPENSSL 1" >>confdefs.h
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL is compiled with FIPS support" >&5
 $as_echo_n "checking whether OpenSSL is compiled with FIPS support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lcrypto"
 
   if test "$cross_compiling" = yes; then :
@@ -24406,8 +24396,6 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions succeeds" >&5
 $as_echo_n "checking whether linking with OpenSSL functions succeeds... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24474,8 +24462,6 @@ rm -f core conftest.err conftest.$ac_objext \
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions requires -lz" >&5
 $as_echo_n "checking whether linking with OpenSSL functions requires -lz... " >&6; }
       saved_libs="$LIBS"
-
-            LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="-lcrypto -lz $LIBS"
 
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24522,8 +24508,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has complete ECC support" >&5
 $as_echo_n "checking whether OpenSSL has complete ECC support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24572,8 +24556,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has EVP_CipherInit_ex support" >&5
 $as_echo_n "checking whether OpenSSL has EVP_CipherInit_ex support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24613,8 +24595,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has ALPN support" >&5
 $as_echo_n "checking whether OpenSSL has ALPN support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24661,8 +24641,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has NPN support" >&5
 $as_echo_n "checking whether OpenSSL has NPN support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24709,8 +24687,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has OCSP support" >&5
 $as_echo_n "checking whether OpenSSL has OCSP support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24759,8 +24735,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has SSL num tickets support" >&5
 $as_echo_n "checking whether OpenSSL has SSL num tickets support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24800,8 +24774,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has SSL read ahead support" >&5
 $as_echo_n "checking whether OpenSSL has SSL read ahead support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24841,8 +24813,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has SSL session ID context set support" >&5
 $as_echo_n "checking whether OpenSSL has SSL session ID context set support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24882,8 +24852,6 @@ rm -f core conftest.err conftest.$ac_objext \
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has SSL session ticket callback support" >&5
 $as_echo_n "checking whether OpenSSL has SSL session ticket callback support... " >&6; }
   saved_libs="$LIBS"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -24974,8 +24942,6 @@ fi
 
 
     saved_libs="$LIBS"
-
-        LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
     LIBS="-lcrypto -lssl $LIBS"
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for redisInitiateSSL in -lhiredis_ssl" >&5
 $as_echo_n "checking for redisInitiateSSL in -lhiredis_ssl... " >&6; }
@@ -25035,8 +25001,6 @@ if test x"$pr_use_postgres" = xyes; then
   # fiddle with CPPFLAGS, LDFLAGS
   CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
   LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lm -lpq"
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Postgres's PQescapeStringConn" >&5
@@ -25176,7 +25140,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-  # restore CPPFLAGS, LDFLAGS
+  # restore CPPFLAGS, LDFLAGS, LIBS
   CPPFLAGS="$saved_cppflags"
   LDFLAGS="$saved_ldflags"
   LIBS="$saved_libs"

--- a/configure.in
+++ b/configure.in
@@ -863,9 +863,6 @@ AC_ARG_ENABLE(pcre,
       # fiddle with CPPFLAGS, LDFLAGS
       CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
       LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-      dnl Splice out -lsupp, since that library hasn't been built yet
-      LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="$LIBS -lpcre -lpcreposix"
 
       AC_MSG_CHECKING([for PCRE's pcre_free_study])
@@ -894,7 +891,7 @@ AC_ARG_ENABLE(pcre,
         ]
       )
 
-      # restore CPPFLAGS, LDFLAGS
+      # restore CPPFLAGS, LDFLAGS, LIBS
       CPPFLAGS="$saved_cppflags"
       LDFLAGS="$saved_ldflags"
       LIBS="$saved_libs"
@@ -922,9 +919,6 @@ AC_ARG_ENABLE(redis,
       # fiddle with CPPFLAGS, LDFLAGS
       CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
       LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-      dnl Splice out -lsupp, since that library hasn't been built yet
-      LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="$LIBS -lhiredis"
 
       AC_MSG_CHECKING([for Hiredis' redisReconnect])
@@ -950,7 +944,7 @@ AC_ARG_ENABLE(redis,
         ]
       )
 
-      # restore CPPFLAGS, LDFLAGS
+      # restore CPPFLAGS, LDFLAGS, LIBS
       CPPFLAGS="$saved_cppflags"
       LDFLAGS="$saved_ldflags"
       LIBS="$saved_libs"
@@ -2995,9 +2989,6 @@ AC_TRY_RUN(
   AC_MSG_RESULT(cross-compiling); AC_DEFINE(HAVE_LU, 1, [Define if you have %lu support])
 )
 
-dnl Add the proftpd support library
-LIBS="-lsupp $LIBS"
-
 dnl Module handling.
 ac_shared_module_dirs=
 ac_static_module_dirs=
@@ -3158,9 +3149,6 @@ if test x"$pr_use_mysql" = xyes; then
   dnl Fiddle with CPPFLAGS, LDFLAGS
   CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
   LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-  dnl Splice out -lsupp FROM LIBS, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lm -lmysqlclient -lz"
 
   AC_MSG_CHECKING([for mysql_get_option])
@@ -3355,7 +3343,7 @@ if test x"$pr_use_mysql" = xyes; then
     ]
   )
 
-  dnl Restore CPPFLAGS, LDFLAGS
+  dnl Restore CPPFLAGS, LDFLAGS, LIBS
   CPPFLAGS="$saved_cppflags"
   LDFLAGS="$saved_ldflags"
   LIBS="$saved_libs"
@@ -3367,9 +3355,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL is compiled with FIPS support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lcrypto"
 
   AC_TRY_RUN(
@@ -3392,9 +3377,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether linking with OpenSSL functions succeeds])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   AC_TRY_LINK(
@@ -3432,9 +3414,6 @@ if test x"$pr_use_openssl" = xyes; then
 
       AC_MSG_CHECKING([whether linking with OpenSSL functions requires -lz])
       saved_libs="$LIBS"
-
-      dnl Splice out -lsupp, since that library hasn't been built yet
-      LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
       LIBS="-lcrypto -lz $LIBS"
 
       AC_TRY_LINK(
@@ -3462,9 +3441,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has complete ECC support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   AC_TRY_LINK(
@@ -3495,9 +3471,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has EVP_CipherInit_ex support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto $LIBS"
 
   AC_TRY_LINK(
@@ -3519,9 +3492,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has ALPN support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3550,9 +3520,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has NPN support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3581,9 +3548,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has OCSP support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3614,9 +3578,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has SSL num tickets support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3638,9 +3599,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has SSL read ahead support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3662,9 +3620,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has SSL session ID context set support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3686,9 +3641,6 @@ if test x"$pr_use_openssl" = xyes; then
 
   AC_MSG_CHECKING([whether OpenSSL has SSL session ticket callback support])
   saved_libs="$LIBS"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="-lcrypto -lssl $LIBS"
 
   AC_TRY_LINK(
@@ -3757,9 +3709,6 @@ if test x"$pr_use_openssl" = xyes; then
     )
 
     saved_libs="$LIBS"
-
-    dnl Splice out -lsupp, since that library hasn't been built yet
-    LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
     LIBS="-lcrypto -lssl $LIBS"
     AC_CHECK_LIB(hiredis_ssl, redisInitiateSSL,
       [AC_DEFINE(HAVE_HIREDIS_REDISINITIATESSL, 1, [Define if hiredis_ssl has redisInitiateSSL function.])
@@ -3779,9 +3728,6 @@ if test x"$pr_use_postgres" = xyes; then
   # fiddle with CPPFLAGS, LDFLAGS
   CPPFLAGS="$CPPFLAGS $ac_build_addl_includes"
   LDFLAGS="$LDFLAGS $ac_build_addl_libdirs"
-
-  dnl Splice out -lsupp, since that library hasn't been built yet
-  LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
   LIBS="$LIBS -lm -lpq"
 
   AC_MSG_CHECKING([for Postgres's PQescapeStringConn])
@@ -3867,7 +3813,7 @@ if test x"$pr_use_postgres" = xyes; then
     ]
   )
 
-  # restore CPPFLAGS, LDFLAGS
+  # restore CPPFLAGS, LDFLAGS, LIBS
   CPPFLAGS="$saved_cppflags"
   LDFLAGS="$saved_ldflags"
   LIBS="$saved_libs"

--- a/contrib/mod_auth_otp/Makefile.in
+++ b/contrib/mod_auth_otp/Makefile.in
@@ -19,7 +19,8 @@ SHARED_MODULE_OBJS=mod_auth_otp.lo base32.lo otp.lo crypto.lo db.lo
 UTILS_LIBS=@UTILS_LIBS@
 UTILS_OBJS=base32.o otp.o crypto.o auth-otp.o
 UTILS_API_OBJS=../../src/pool.o \
-  ../../src/str.o
+  ../../src/str.o \
+  ../../lib/prbase.a
 
 # Necessary redefinitions
 INCLUDES=-I. -I../.. -I../../include -I$(top_srcdir)/../../include @INCLUDES@

--- a/contrib/mod_auth_otp/configure
+++ b/contrib/mod_auth_otp/configure
@@ -3669,7 +3669,7 @@ fi
 done
 
 
-UTILS_LIBS="-lsupp -lcrypto"
+UTILS_LIBS="-lcrypto"
 
 # Check whether --enable-devel was given.
 if test "${enable_devel+set}" = set; then :
@@ -3771,8 +3771,6 @@ LIBS="$LIBS -lcrypto"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions requires -ldl" >&5
 $as_echo_n "checking whether linking with OpenSSL functions requires -ldl... " >&6; }
 saved_libs="$LIBS"
-
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -ldl $LIBS"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -3811,8 +3809,6 @@ rm -f core conftest.err conftest.$ac_objext \
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions requires -lz" >&5
 $as_echo_n "checking whether linking with OpenSSL functions requires -lz... " >&6; }
 saved_libs="$LIBS"
-
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -lz $LIBS"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -3852,11 +3848,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL supports SHA256" >&5
 $as_echo_n "checking whether OpenSSL supports SHA256... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3893,11 +3888,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL supports SHA512" >&5
 $as_echo_n "checking whether OpenSSL supports SHA512... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/contrib/mod_auth_otp/configure.in
+++ b/contrib/mod_auth_otp/configure.in
@@ -1,5 +1,5 @@
 dnl ProFTPD - mod_auth_otp
-dnl Copyright (c) 2015-2017 TJ Saunders <tj@castaglia.org>
+dnl Copyright (c) 2015-2021 TJ Saunders <tj@castaglia.org>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ AC_HEADER_STDC
 
 AC_CHECK_HEADERS(stdlib.h unistd.h limits.h fcntl.h)
 
-UTILS_LIBS="-lsupp -lcrypto"
+UTILS_LIBS="-lcrypto"
 
 dnl Need to support/handle the --enable-devel option, to see if coverage
 dnl is being used
@@ -137,9 +137,6 @@ LIBS="$LIBS -lcrypto"
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -ldl])
 saved_libs="$LIBS"
-
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -ldl $LIBS"
 
 AC_TRY_LINK(
@@ -159,9 +156,6 @@ AC_TRY_LINK(
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -lz])
 saved_libs="$LIBS"
-
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -lz $LIBS"
 
 AC_TRY_LINK(
@@ -183,11 +177,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL supports SHA256])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL supports SHA256])
 AC_TRY_LINK(
   [
     #include <openssl/evp.h>
@@ -207,11 +199,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL supports SHA512])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL supports SHA512])
 AC_TRY_LINK(
   [
     #include <openssl/evp.h>

--- a/contrib/mod_sftp/configure
+++ b/contrib/mod_sftp/configure
@@ -3664,8 +3664,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions requires -ldl" >&5
 $as_echo_n "checking whether linking with OpenSSL functions requires -ldl... " >&6; }
 saved_libs="$LIBS"
-
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -ldl $LIBS"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -3703,8 +3701,6 @@ rm -f core conftest.err conftest.$ac_objext \
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether linking with OpenSSL functions requires -lz" >&5
 $as_echo_n "checking whether linking with OpenSSL functions requires -lz... " >&6; }
 saved_libs="$LIBS"
-
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -lz $LIBS"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -3743,11 +3739,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has crippled AES support" >&5
 $as_echo_n "checking whether OpenSSL has crippled AES support... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
  #ifdef HAVE_STRING_H
@@ -3787,11 +3782,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL supports SHA256" >&5
 $as_echo_n "checking whether OpenSSL supports SHA256... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3828,11 +3822,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL supports SHA512" >&5
 $as_echo_n "checking whether OpenSSL supports SHA512... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3869,11 +3862,10 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
-LIBS="-lcrypto $LIBS"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL supports EVP_aes_256_ctr" >&5
 $as_echo_n "checking whether OpenSSL supports EVP_aes_256_ctr... " >&6; }
+LIBS="-lcrypto $LIBS"
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/contrib/mod_sftp/configure.in
+++ b/contrib/mod_sftp/configure.in
@@ -1,5 +1,5 @@
 dnl ProFTPD - mod_sftp
-dnl Copyright (c) 2012-2020 TJ Saunders <tj@castaglia.org>
+dnl Copyright (c) 2012-2021 TJ Saunders <tj@castaglia.org>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -83,9 +83,6 @@ dnl to linker errors.
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -ldl])
 saved_libs="$LIBS"
-
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -ldl $LIBS"
 
 AC_TRY_LINK(
@@ -104,9 +101,6 @@ AC_TRY_LINK(
 
 AC_MSG_CHECKING([whether linking with OpenSSL functions requires -lz])
 saved_libs="$LIBS"
-
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
 LIBS="-lcrypto -lz $LIBS"
 
 AC_TRY_LINK(
@@ -127,11 +121,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL has crippled AES support])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL has crippled AES support])
 AC_TRY_LINK(
   [ #ifdef HAVE_STRING_H
     # include <string.h>
@@ -154,11 +146,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL supports SHA256])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL supports SHA256])
 AC_TRY_LINK(
   [
     #include <openssl/evp.h>
@@ -178,11 +168,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL supports SHA512])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL supports SHA512])
 AC_TRY_LINK(
   [
     #include <openssl/evp.h>
@@ -202,11 +190,9 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Splice out -lsupp, since that library hasn't been built yet
-LIBS=`echo "$LIBS" | sed -e 's/-lsupp//g'`;
+AC_MSG_CHECKING([whether OpenSSL supports EVP_aes_256_ctr])
 LIBS="-lcrypto $LIBS"
 
-AC_MSG_CHECKING([whether OpenSSL supports EVP_aes_256_ctr])
 AC_TRY_LINK(
   [
     #include <openssl/evp.h>

--- a/include/base.h
+++ b/include/base.h
@@ -29,8 +29,8 @@
 
 /* ProFTPD support library definitions. */
 
-#ifndef PR_LIBSUPP_H
-#define PR_LIBSUPP_H
+#ifndef PR_BASE_H
+#define PR_BASE_H
 
 #include <glibc-glob.h>
 
@@ -102,4 +102,4 @@ void pr_os_already_has_vsnprintf(void);
 void pr_os_already_has_snprintf_and_vsnprintf(void);
 #endif /* !HAVE_VSNPRINTF || !HAVE_SNPRINTF */
 
-#endif /* PR_LIBSUPP_H */
+#endif /* PR_BASE_H */

--- a/include/conf.h
+++ b/include/conf.h
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2020 The ProFTPD Project team
+ * Copyright (c) 2001-2021 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -64,6 +64,7 @@
  * not for the support library.
  */
 
+#include "base.h"
 #include "pool.h"
 #include "str.h"
 #include "ascii.h"
@@ -101,7 +102,6 @@
 #include "scoreboard.h"
 #include "data.h"
 #include "display.h"
-#include "libsupp.h"
 #include "fsio.h"
 #include "mkhome.h"
 #include "ctrls.h"

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -27,16 +27,16 @@ Makefile: Makefile.in ../config.status
 libltdl: dummy
 	cd libltdl/ && $(MAKE)
 
-libsupp.a: $(LIB_OBJS)
-	$(AR) rc libsupp.a $(LIB_OBJS)
-	$(RANLIB) libsupp.a
+prbase.a: $(LIB_OBJS)
+	$(AR) rc prbase.a $(LIB_OBJS)
+	$(RANLIB) prbase.a
 
-lib: libsupp.a $(LIB_DEPS)
+lib: prbase.a $(LIB_DEPS)
 
 install:
 
 clean:
-	$(RM) *.o libsupp.a
+	$(RM) *.o prbase.a
 	$(LIBTOOL) --mode=clean $(RM) `echo $(LIB_OBJS) | sed 's/\.o$\/.lo/g'`
 	test -z $(LIB_DEPS) || (cd libltdl/ && $(MAKE) clean)
 

--- a/lib/glibc-hstrerror.c
+++ b/lib/glibc-hstrerror.c
@@ -46,8 +46,8 @@
 
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-#include <libsupp.h>
+#include "conf.h"
+#include "base.h"
 
 #ifndef HAVE_HSTRERROR
 

--- a/lib/glibc-mkstemp.c
+++ b/lib/glibc-mkstemp.c
@@ -18,8 +18,8 @@
 
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-#include <libsupp.h>
+#include "conf.h"
+#include "base.h"
 
 #ifndef HAVE_MKSTEMP
 

--- a/lib/pr_fnmatch.c
+++ b/lib/pr_fnmatch.c
@@ -54,8 +54,8 @@ char *alloca ();
 
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-#include <libsupp.h>
+#include "conf.h"
+#include "base.h"
 
 #if 0 /* Not used in ProFTPD */
 /* Enable GNU extensions in fnmatch.h.  */

--- a/lib/pwgrent.c
+++ b/lib/pwgrent.c
@@ -21,8 +21,8 @@ Suite 500, Boston, MA 02110-1335, USA.  */
 
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-#include "libsupp.h"
+#include "conf.h"
+#include "base.h"
 
 /* From log.c/log.h */
 #define PR_LOG_ERR LOG_ERR

--- a/lib/sstrncpy.c
+++ b/lib/sstrncpy.c
@@ -37,7 +37,7 @@
 # include <string.h>
 #endif
 
-#include "libsupp.h"
+#include "base.h"
 
 /* "safe" strncpy, saves room for \0 at end of dest, and refuses to copy
  * more than "n" bytes.  Returns the number of bytes copied, or -1 if there

--- a/lib/strsep.c
+++ b/lib/strsep.c
@@ -21,9 +21,8 @@ Suite 500, Boston, MA 02110-1335, USA.  */
 
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-
-#include <libsupp.h>
+#include "conf.h"
+#include "base.h"
 
 #undef _LIBC
 #undef __GNU_LIBRARY__

--- a/lib/vsnprintf.c
+++ b/lib/vsnprintf.c
@@ -20,8 +20,8 @@
  */
 #define __PROFTPD_SUPPORT_LIBRARY
 
-#include <conf.h>
-#include <libsupp.h>
+#include "conf.h"
+#include "base.h"
 
 #include <ctype.h>
 

--- a/locale/files.txt
+++ b/locale/files.txt
@@ -146,6 +146,7 @@
 ../contrib/mod_wrap2_sql.c
 ../include/ascii.h
 ../include/auth.h
+../include/base.h
 ../include/bindings.h
 ../include/buildstamp.h
 ../include/ccan-json.h
@@ -177,7 +178,6 @@
 ../include/jot.h
 ../include/json.h
 ../include/lastlog.h
-../include/libsupp.h
 ../include/log.h
 ../include/logfmt.h
 ../include/memcache.h

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -11,6 +11,7 @@ include $(top_builddir)/Make.rules
 EXEEXT=@EXEEXT@
 
 TEST_API_DEPS=\
+  $(top_builddir)/lib/prbase.a \
   $(top_builddir)/src/pool.o \
   $(top_builddir)/src/privs.o \
   $(top_builddir)/src/str.o \

--- a/tests/fuzzing/oss_fuzz_build.sh
+++ b/tests/fuzzing/oss_fuzz_build.sh
@@ -19,9 +19,10 @@ find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
 $NEW_CC_FLAG -c $SRC/fuzzer.c -o fuzzer.o
 $CC $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer \
 	src/scoreboard.o \
+	lib/prbase.a \
 	fuzz_lib.a \
 	-L/src/proftpd/lib \
-	-lsupp -lcrypt -pthread
+	-lcrypt -pthread
 
 # Build seed corpus
 cd $SRC


### PR DESCRIPTION
…rary, link with it as a static `.a` archive.

And, to help differentiate it, rename it from `libsupp.a` to `prbase.a`.