### PR TITLE
As a follow-on to Issue #1300, make it possible to tell ProFTPD to ha…

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,6 +6,14 @@ This file contains a description of the major changes to ProFTPD for the
 releases.  More information on these changes can be found in the NEWS and
 ChangeLog files.
 
+1.3.8rc2
+---------
+
+  + Changed Directives
+
+    RegexOptions Engine (Issue #1300)
+
+
 1.3.8rc1
 ---------
 

--- a/doc/modules/mod_core.html
+++ b/doc/modules/mod_core.html
@@ -2136,7 +2136,7 @@ The currently known/supported protocols include:
 <p>
 <hr>
 <h3><a name="RegexOptions">RegexOptions</a></h3>
-<strong>Syntax:</strong> RegexOptions <em>[MatchLimit limit] [MatchRecursionLimit limit]</em><br>
+<strong>Syntax:</strong> RegexOptions <em>[Engine engine] [MatchLimit limit] [MatchRecursionLimit limit]</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_core<br>
@@ -2160,6 +2160,21 @@ Note, however, that these limits are only used when
 <a href="http://pcre.org/">PCRE</a> support is enabled (via the
 <code>--enable-pcre</code> build-time option).  If PCRE support is <em>not</em>
 enabled, this directive has no effect.
+
+<p>
+The <em>Engine</em> parameter configures the particular implementation
+&quot;engine&quot; used for regular expressions; the value can be one of the
+following:
+<ul>
+  <li>PCRE
+  <li>POSIX
+</ul>
+This is most useful for specifying that ProFTPD should handle all regular
+expressions as POSIX expressions, regardless of any PCRE support, as there may
+be issues with the PCRE implementation.
+
+<p>
+Support for the <em>Engine</em> parameter first appeared in ProFTPD 1.3.8rc2.
 
 <p>
 <hr>

--- a/include/regexp.h
+++ b/include/regexp.h
@@ -89,6 +89,13 @@ int pr_regexp_exec(pr_regex_t *pre, const char *str, size_t nmatches,
 int pr_regexp_set_limits(unsigned long match_limit,
   unsigned long match_limit_recursion);
 
+/* Set the "engine" to use for regular expressions, e.g. "POSIX" or "PCRE".
+ * The engine value is handled case-insensitively.  This is useful for treating
+ * all regular expressions as POSIX expressions, regardless of PCRE support,
+ * as when there are PCRE implementation issues.
+ */
+int pr_regexp_set_engine(const char *engine);
+
 /* For internal use only */
 void init_regexp(void);
 

--- a/tests/t/config/regexoptions.t
+++ b/tests/t/config/regexoptions.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use lib qw(t/lib);
+use strict;
+
+use Test::Unit::HarnessUnit;
+
+$| = 1;
+
+my $r = Test::Unit::HarnessUnit->new();
+$r->start("ProFTPD::Tests::Config::RegexOptions");

--- a/tests/t/lib/ProFTPD/Tests/Config/RegexOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RegexOptions.pm
@@ -1,0 +1,149 @@
+package ProFTPD::Tests::Config::RegexOptions;
+
+use lib qw(t/lib);
+use base qw(ProFTPD::TestSuite::Child);
+use strict;
+
+use File::Path qw(mkpath);
+use File::Spec;
+use IO::Handle;
+
+use ProFTPD::TestSuite::FTP;
+use ProFTPD::TestSuite::Utils qw(:auth :config :running :test :testsuite);
+
+$| = 1;
+
+my $order = 0;
+
+my $TESTS = {
+  regexoptions_posix_engine_issue1300 => {
+    order => ++$order,
+    test_class => [qw(feature_pcre forking)],
+  },
+
+};
+
+sub new {
+  return shift()->SUPER::new(@_);
+}
+
+sub list_tests {
+  return testsuite_get_runnable_tests($TESTS);
+}
+
+sub regexoptions_posix_engine_issue1300 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'regexp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    DefaultChdir => '~',
+
+    DenyFilter => '\*.*/',
+    RegexOptions => 'Engine POSIX',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Allow server startup
+      sleep(1);
+
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $engine_ok = 0;
+      my $filter_ok = 0;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /<regexp:\d+>: changed regexp engine from PCRE to POSIX/) {
+          $engine_ok = 1;
+        }
+
+        if ($line =~ /<regexp:\d+>: executing POSIX regex .*? against subject/) {
+          $filter_ok = 1;
+        }
+
+        if ($engine_ok && $filter_ok) {
+          last;
+        }
+      }
+
+      close($fh);
+
+      $self->assert($engine_ok,
+        test_msg("Did not see expected regexp engine TraceLog message"));
+      $self->assert($filter_ok,
+        test_msg("Did not see expected regexp filter TraceLog message"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+1;

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -162,6 +162,7 @@ if (scalar(@ARGV) > 0) {
     t/config/pathdenyfilter.t
     t/config/pidfile.t
     t/config/protocols.t
+    t/config/regexoptions.t
     t/config/requirevalidshell.t
     t/config/rewritehome.t
     t/config/rlimitchroot.t


### PR DESCRIPTION
…ndle

all regular expressions as POSIX, regardless of PCRE support.