### PR TITLE
Improve documentation regarding the usage of Device/Interface name in <VirtualHost>, MasqueradeAddress, and DefaultAddress.

### DIFF
--- a/doc/Configuration.html
+++ b/doc/Configuration.html
@@ -5863,7 +5863,7 @@ CLASS="COMMAND"
 >DefaultAddress</B
 >  [  <CODE
 CLASS="OPTION"
->dns-names|ip-addresses seperated with spaces</CODE
+>ip-address|dns-name|device/interface-name [ip-address|dns-name|device/interface-name ...]</CODE
 >]</P
 ><P
 ></P
@@ -5908,7 +5908,7 @@ CLASS="SYNOPSIS"
 ></DT
 ><DD
 ><P
->1.2.7rc1 and later</P
+>1.2.7rc1 and later (Device/interface name only supported in 1.3.5rc1 and later)</P
 ></DD
 ></DL
 ></DIV
@@ -5926,7 +5926,8 @@ to, the default behaviour is to select whatever IP the system reports
 as being the primary IP.</P
 ><P
 >Starting with ProFTPD 1.3.0rc1 it's possible to use more than one FQDN or IP
-Address. With this change the old Bind directive has been deprecated.</P
+Address. With this change the old Bind directive has been deprecated. 
+ProFTPD 1.3.5rc1 added support for specifying teh device/interface name.</P
 ></DIV
 ><DIV
 CLASS="REFSECT1"
@@ -5957,7 +5958,10 @@ Port&nbsp;21<br>
 DefaultAddress&nbsp;192.168.10.30<br>
 <br>
 ##&nbsp;Since&nbsp;1.3.0rc1&nbsp;it's&nbsp;also&nbsp;possible&nbsp;to&nbsp;use&nbsp;the&nbsp;following:<br>
-#&nbsp;DefaultAddress&nbsp;192.168.10.30&nbsp;my.domain.tld</P
+#&nbsp;DefaultAddress&nbsp;192.168.10.30&nbsp;my.domain.tld<br>
+<br>
+##&nbsp;Since&nbsp;1.3.5rc1&nbsp;it's&nbsp;also&nbsp;possible&nbsp;to&nbsp;use&nbsp;the&nbsp;following:<br>
+#&nbsp;DefaultAddress&nbsp;eth0&nbsp;192.168.10.30&nbsp;my.domain.tld</P
 ></DIV
 ><H1
 ><A
@@ -15805,7 +15809,7 @@ CLASS="COMMAND"
 >MasqueradeAddress</B
 >  [  <CODE
 CLASS="OPTION"
->MasqueradeAddress ip-address|dns-hostname</CODE
+>MasqueradeAddress ip-address|dns-name|device/interface-name</CODE
 >]</P
 ><P
 ></P
@@ -15850,7 +15854,7 @@ CLASS="SYNOPSIS"
 ></DT
 ><DD
 ><P
->1.2.2 and later</P
+>1.2.2 and later (device/interface name only supported in 1.3.5rc1 and later)</P
 ></DD
 ></DL
 ></DIV
@@ -15887,7 +15891,10 @@ NAME="AEN5789"
 >Examples</H2
 ><P
 CLASS="LITERALLAYOUT"
->&nbsp;&nbsp;&nbsp;&nbsp;MasqueradeAddress&nbsp;nat-gw.mydomain.com</P
+>&nbsp;&nbsp;&nbsp;&nbsp;MasqueradeAddress&nbsp;nat-gw.mydomain.com<br>
+<br>
+##&nbsp;Since&nbsp;1.3.5rc1&nbsp;it's&nbsp;also&nbsp;possible&nbsp;to&nbsp;use&nbsp;the&nbsp;following:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;MasqueradeAddress&nbsp;eth0</P
 ><P
 ></P
 ></DIV
@@ -32914,7 +32921,7 @@ CLASS="COMMAND"
 >VirtualHost</B
 >  [  <CODE
 CLASS="OPTION"
->&lt;VirtualHost addresses seperated by spaces&gt;</CODE
+>&lt;VirtualHost ip-address|dns-name|device/interface-name [ip-address|dns-name|device/interface-name ...]&gt;</CODE
 >]</P
 ><P
 ></P
@@ -32959,7 +32966,7 @@ CLASS="SYNOPSIS"
 ></DT
 ><DD
 ><P
->0.99.0 and later</P
+>0.99.0 and later (Device/interface name only supported in 1.3.7c and later)</P
 ></DD
 ></DL
 ></DIV
@@ -33031,7 +33038,13 @@ NAME="AEN12495"
 ><P
 >&lt;VirtualHost host1.domain.com host2.domain.com&gt;
             ...
-&lt;/VirtualHost&gt;</P
+&lt;/VirtualHost&gt;<br>
+<br>
+&nbsp;Since&nbsp;1.3.5rc1&nbsp;it's&nbsp;also&nbsp;possible&nbsp;to&nbsp;use&nbsp;the&nbsp;following:<br>
+&lt;VirtualHost&nbsp;eth0&nbsp;192.168.10.30&nbsp;host1.domain.com&nbsp;host2.domain.com&gt;
+            ...
+&lt;/VirtualHost&gt;
+</P
 ></DIV
 ><H1
 ><A

--- a/doc/modules/mod_core.html
+++ b/doc/modules/mod_core.html
@@ -614,11 +614,11 @@ greater detail.
 <p>
 <hr>
 <h3><a name="DefaultAddress">DefaultAddress</a></h3>
-<strong>Syntax:</strong> DefaultAddress <em>ip-address|dns-name</em> <em>[ip-address|dns-name ...]</em><br>
+<strong>Syntax:</strong> DefaultAddress <em>ip-address|dns-name|device/interface-name [ip-address|dns-name|device/interface-name ...]</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config<br>
 <strong>Module:</strong> mod_core<br>
-<strong>Compatibility:</strong> 1.2.7rc1 and later
+<strong>Compatibility:</strong> 1.2.7rc1 and later (Device/interface name only supported in 1.3.5rc1 and later)
 
 <p>
 The <code>DefaultAddress</code> directive sets the the address to which the
@@ -1688,11 +1688,11 @@ examples, can be found in the <a href="../howto/Limit.html"><code>&lt;Limit&gt;<
 <p>
 <hr>
 <h3><a name="MasqueradeAddress">MasqueradeAddress</a></h3>
-<strong>Syntax:</strong> MasqueradeAddress <em>ip-address|dns-name|device-name</em><br>
+<strong>Syntax:</strong> MasqueradeAddress <em>ip-address|dns-name|device/interface-name</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_core<br>
-<strong>Compatibility:</strong> 1.2.2 and later
+<strong>Compatibility:</strong> 1.2.2 and later (device/interface name only supported in 1.3.5rc1 and later)
 
 <p>
 The <code>MasqueradeAddress</code> directive causes the server to display the
@@ -3189,11 +3189,11 @@ See also: <a href="#GroupOwner"><code>GroupOwner</code></a>
 <p>
 <hr>
 <h3><a name="VirtualHost">&lt;VirtualHost&gt;</a></h3>
-<strong>Syntax:</strong> &lt;VirtualHost <em>ip-address|dns-name [ip-address|dns-name ...]</em>&gt;<br>
+<strong>Syntax:</strong> &lt;VirtualHost <em>ip-address|dns-name|device/interface-name [ip-address|dns-name|device/interface-name ...]</em>&gt;<br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config<br>
 <strong>Module:</strong> mod_core<br>
-<strong>Compatibility:</strong> 0.99.0 and later
+<strong>Compatibility:</strong> 0.99.0 and later (Device/interface name only supported in 1.3.7c and later)
 
 <p>
 The <code>&lt;VirtualHost&gt;</code> configuration section is used to create


### PR DESCRIPTION
Added more information regarding the possibility of using the device/interface name for VirtualHost, MasqueradeAddress, and DefaultAddress.

Note that I was unable to determine how to adjust [http://www.proftpd.org/docs/directives/linked/config_ref_context_VirtualHost.html](http://www.proftpd.org/docs/directives/linked/config_ref_context_VirtualHost.html)
In addition, it appears as though there is no direct way to access `mod_core.html`, but I updated that as well.

I also found other issues which I was unable to determine how to address.  Specifically at [http://www.proftpd.org/docs/](http://www.proftpd.org/docs/)  the in `Directives list`, it offers access via a `single file` as a `ps` or a `pdf` file, but neither of those links work.

Let me know what you think of my suggested changes. 🙂