### PR TITLE
Generate a `core.added-config` event, for any config_recs added.

### DIFF
--- a/src/configdb.c
+++ b/src/configdb.c
@@ -105,6 +105,11 @@ config_rec *pr_config_add_set(xaset_t **set, const char *name, int flags) {
     xaset_insert_end(*set, (xasetmember_t *) c);
   }
 
+  /* Generate an event about the added config, for any interested parties.
+   * This is useful for tracking the origins of the config tree.
+   */
+  pr_event_generate("core.added-config", c);
+
   return c;
 }
 


### PR DESCRIPTION
This can be used by listeners (via third-party modules) to watch which configs
are added, and when, to become part of the config tree.