### PR TITLE
Bug #3308: Install the generated build rules (in the `Make.rules`) fi…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,6 +146,7 @@ install-libs: $(DESTDIR)$(libdir)/proftpd
 
 install-headers: $(DESTDIR)$(includedir)/proftpd
 	$(INSTALL_MAN) $(top_builddir)/config.h $(DESTDIR)$(includedir)/proftpd/config.h
+	$(INSTALL_MAN) $(top_builddir)/Make.rules $(DESTDIR)$(includedir)/proftpd/Make.rules
 	cd include/ && $(MAKE) install
 
 install-pkgconfig: $(DESTDIR)$(pkgconfigdir)


### PR DESCRIPTION
…le along with the other development headers.

This will allow `prxs` to build third-party modules with use multiple source
files; such modules usually have their own Makefiles, which reference these
build rules from the core build.