### PR TITLE
Issue #1260: Support an `--enable-devel=fortify` configure option, fo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
         run: |
-          ./configure LIBS="-lodbc -lm -lsubunit -lrt -pthread" --enable-devel=coverage --enable-ctrls --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-redis --enable-tests --with-modules=$PROFTPD_MODULES
+          ./configure LIBS="-lodbc -lm -lsubunit -lrt -pthread" --enable-devel=coverage:fortify --enable-ctrls --enable-facl --enable-memcache --enable-nls --enable-pcre --enable-redis --enable-tests --with-modules=$PROFTPD_MODULES
           make
 
       - name: Run unit tests

--- a/configure
+++ b/configure
@@ -17823,6 +17823,15 @@ $as_echo "no" >&6; }
         pr_devel_libs="--coverage $pr_devel_libs"
       fi
 
+      if test `echo $enableval | grep -c fortify` = "1" ; then
+        pr_devel_cflags="-D_FORTIFY_SOURCE=2 $pr_devel_cflags"
+
+        # In order for `-D_FORTIFY_SOURCE=2` to work, we also need to
+        # disable some of the default --enable-devel flags, specifically `-O0`;
+        # we can use `-O2` instead.
+        pr_devel_cflags=`echo "$pr_devel_cflags" | sed -e 's/-O0/-O2/'`
+      fi
+
       if test `echo $enableval | grep -c nodaemon` = "1" ; then
         pr_devel_cflags="-DPR_DEVEL_NO_DAEMON $pr_devel_cflags"
       fi

--- a/configure.in
+++ b/configure.in
@@ -1121,6 +1121,15 @@ AC_ARG_ENABLE(devel,
         pr_devel_libs="--coverage $pr_devel_libs"
       fi
 
+      if test `echo $enableval | grep -c fortify` = "1" ; then
+        pr_devel_cflags="-D_FORTIFY_SOURCE=2 $pr_devel_cflags"
+
+        # In order for `-D_FORTIFY_SOURCE=2` to work, we also need to
+        # disable some of the default --enable-devel flags, specifically `-O0`;
+        # we can use `-O2` instead.
+        pr_devel_cflags=`echo "$pr_devel_cflags" | sed -e 's/-O0/-O2/'`
+      fi
+
       if test `echo $enableval | grep -c nodaemon` = "1" ; then
         pr_devel_cflags="-DPR_DEVEL_NO_DAEMON $pr_devel_cflags"
       fi

--- a/contrib/mod_sftp/keys.c
+++ b/contrib/mod_sftp/keys.c
@@ -5390,7 +5390,7 @@ int sftp_keys_send_hostkeys(pool *p) {
   res = sftp_keys_have_ecdsa_hostkey(tmp_pool, &nids);
 #if defined(PR_USE_OPENSSL_ECC)
   if (res > 0) {
-    register unsigned int i;
+    register int i;
 
     for (i = 0; i < res; i++) {
       enum sftp_key_type_e key_type;

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -443,7 +443,7 @@ static int regexp_exec_pcre(pr_regex_t *pre, const char *text,
 
   if (ovector_count > 0) {
     /* Populate the provided POSIX regmatch_t array with the PCRE data. */
-    register unsigned int i;
+    register int i;
 
     for (i = 0; i < res; i++) {
       matches[i].rm_so = ovector[i * 2];

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2020 The ProFTPD Project team
+ * Copyright (c) 2020-2021 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -655,7 +655,7 @@ START_TEST (ctrls_recv_request_invalid_test) {
   }
 
   cl->cl_fd = fd;
-  write(fd, "a", 1);
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid status (too short)");
@@ -670,8 +670,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   status = 0;
-  write(fd, &status, sizeof(status));
-  write(fd, "a", 1);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid nreqargs (too short)");
@@ -686,8 +686,8 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   nreqargs = 100;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid nreqargs (too many)");
@@ -702,9 +702,9 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   nreqargs = 1;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, "a", 1);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid actionlen (too short)");
@@ -719,9 +719,9 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   actionlen = 256;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid actionlen (too long)");
@@ -736,10 +736,10 @@ START_TEST (ctrls_recv_request_invalid_test) {
 
   mark_point();
   actionlen = 4;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, "a", 1);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle invalid reqarg (too short)");
@@ -755,10 +755,10 @@ START_TEST (ctrls_recv_request_invalid_test) {
   mark_point();
   action = "test";
   actionlen = strlen(action);
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle unknown action");
@@ -797,10 +797,10 @@ START_TEST (ctrls_recv_request_actions_test) {
   status = 0;
   nreqargs = 1;
   actionlen = strlen(action);
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle known action: %s", strerror(errno));
@@ -821,11 +821,11 @@ START_TEST (ctrls_recv_request_actions_test) {
   cl->cl_fd = fd;
 
   nreqargs = 2;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, "a", 1);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle too-short reqarglen: %s",
@@ -847,11 +847,11 @@ START_TEST (ctrls_recv_request_actions_test) {
   cl->cl_fd = fd;
 
   reqarglen = 0;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle zero-length reqarg: %s",
@@ -873,11 +873,11 @@ START_TEST (ctrls_recv_request_actions_test) {
   cl->cl_fd = fd;
 
   reqarglen = 500;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res < 0, "Failed to handle too-long reqarg");
@@ -895,12 +895,12 @@ START_TEST (ctrls_recv_request_actions_test) {
   cl->cl_fd = fd;
 
   reqarglen = 4;
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
-  write(fd, "a", 1);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
@@ -923,12 +923,12 @@ START_TEST (ctrls_recv_request_actions_test) {
 
   reqarg = "next";
   reqarglen = strlen(reqarg);
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
-  write(fd, reqarg, reqarglen);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
@@ -958,12 +958,12 @@ START_TEST (ctrls_recv_request_actions_test) {
 
   reqarg = "next";
   reqarglen = strlen(reqarg);
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
-  write(fd, reqarg, reqarglen);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle truncated reqarg: %s",
@@ -1032,7 +1032,7 @@ START_TEST (ctrls_recv_response_test) {
     return;
   }
 
-  write(fd, "a", 1);
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle truncated status");
@@ -1046,8 +1046,8 @@ START_TEST (ctrls_recv_response_test) {
   }
 
   retval = 1;
-  write(fd, &retval, sizeof(retval));
-  write(fd, "a", 1);
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle truncated nrespargc");
@@ -1061,8 +1061,8 @@ START_TEST (ctrls_recv_response_test) {
   }
 
   respargc = 2000;
-  write(fd, &retval, sizeof(retval));
-  write(fd, &respargc, sizeof(respargc));
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, &respargc, sizeof(respargc));
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle too-many respargc");
@@ -1076,9 +1076,9 @@ START_TEST (ctrls_recv_response_test) {
   }
 
   respargc = 1;
-  write(fd, &retval, sizeof(retval));
-  write(fd, &respargc, sizeof(respargc));
-  write(fd, "a", 1);
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, &respargc, sizeof(respargc));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle truncated resparglen");
@@ -1092,9 +1092,9 @@ START_TEST (ctrls_recv_response_test) {
   }
 
   resparglen = (PR_TUNABLE_BUFFER_SIZE * 10);
-  write(fd, &retval, sizeof(retval));
-  write(fd, &respargc, sizeof(respargc));
-  write(fd, &resparglen, sizeof(resparglen));
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, &respargc, sizeof(respargc));
+  (void) write(fd, &resparglen, sizeof(resparglen));
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle too-long resparglen");
@@ -1108,10 +1108,10 @@ START_TEST (ctrls_recv_response_test) {
   }
 
   resparglen = 4;
-  write(fd, &retval, sizeof(retval));
-  write(fd, &respargc, sizeof(respargc));
-  write(fd, &resparglen, sizeof(resparglen));
-  write(fd, "a", 1);
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, &respargc, sizeof(respargc));
+  (void) write(fd, &resparglen, sizeof(resparglen));
+  (void) write(fd, "a", 1);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless(res < 0, "Failed to handle truncated resparg");
@@ -1126,10 +1126,10 @@ START_TEST (ctrls_recv_response_test) {
 
   resparg = "foobarbaz";
   resparglen = strlen(resparg);
-  write(fd, &retval, sizeof(retval));
-  write(fd, &respargc, sizeof(respargc));
-  write(fd, &resparglen, sizeof(resparglen));
-  write(fd, resparg, resparglen);
+  (void) write(fd, &retval, sizeof(retval));
+  (void) write(fd, &respargc, sizeof(respargc));
+  (void) write(fd, &resparglen, sizeof(resparglen));
+  (void) write(fd, resparg, resparglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_response(p, fd, &status, &respargv);
   fail_unless((unsigned int) res == respargc, "Failed to receive response: %s",
@@ -1400,12 +1400,12 @@ START_TEST (ctrls_run_ctrls_test) {
   actionlen = strlen(action);
   reqarg = "FOO";
   reqarglen = strlen(reqarg);
-  write(fd, &status, sizeof(status));
-  write(fd, &nreqargs, sizeof(nreqargs));
-  write(fd, &actionlen, sizeof(actionlen));
-  write(fd, action, actionlen);
-  write(fd, &reqarglen, sizeof(reqarglen));
-  write(fd, reqarg, reqarglen);
+  (void) write(fd, &status, sizeof(status));
+  (void) write(fd, &nreqargs, sizeof(nreqargs));
+  (void) write(fd, &actionlen, sizeof(actionlen));
+  (void) write(fd, action, actionlen);
+  (void) write(fd, &reqarglen, sizeof(reqarglen));
+  (void) write(fd, reqarg, reqarglen);
   rewind_fd(fd);
   res = pr_ctrls_recv_request(cl);
   fail_unless(res == 0, "Failed to handle known action: %s", strerror(errno));

--- a/tests/api/data.c
+++ b/tests/api/data.c
@@ -1409,7 +1409,7 @@ START_TEST (data_xfer_peek_nonsocket_test) {
   strm_fd = PR_NETIO_FD(session.c->instrm);
   PR_NETIO_FD(session.c->instrm) = fd;
 
-  write(fd, "FOO\r\n", 5);
+  (void) write(fd, "FOO\r\n", 5);
   rewind_fd(fd);
 
   mark_point();


### PR DESCRIPTION
…r enabling use of the `-D_FORTIFY_SOURCE=2` CFLAG along with modifying the other CFLAG values accordingly.