### PR TITLE
Mysql legacy auth

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -11,7 +11,7 @@ ChangeLog files.
 
   + Fix memory disclosure to RADIUS servers by mod_radius (Issue #1284).
 
-  + PCRE expressions with capture groups are not being handled properly
+  + PCRE expressions with capture groups were not being handled properly
     (Issue #1300).
 
   + Add support for the libidn2 library, over libidn, for e.g. mod_rewrite

--- a/contrib/mod_sql_mysql.c
+++ b/contrib/mod_sql_mysql.c
@@ -23,7 +23,7 @@
  * the source distribution.
  *
  * -----DO NOT EDIT-----
- * $Libraries: -lm -lmysqlclient -lz$
+ * $Libraries: -lm -lmysqlclient -lz -lcrypto$
  */
 
 /* INTRO:
@@ -133,6 +133,7 @@
 
 #include <mysql.h>
 #include <stdbool.h>
+#include <openssl/sha.h>
 
 /* The my_make_scrambled_password{,_323} functions are not part of the public
  * MySQL API and are not declared in any of the MySQL header files. But the
@@ -1740,7 +1741,37 @@ static int match_mysql_passwds(const char *hashed, size_t hashed_len,
 
   return matched;
 }
-static int mod_mysql_legacyauth_41(char*scrambled,const char*plaintext,size_t plaintext_len);
+
+/* double sha1 converteted to uppercase hex with an asterisk at the start */
+static int sql_mysql_legacyauth_41(char*scrambled, const char*plaintext, size_t plaintext_len) {
+	unsigned char medium[20];
+	int success = 0;
+	SHA_CTX v;
+	do {
+		if(!SHA1_Init(&v)) break;
+		if(!SHA1_Update(&v,plaintext,plaintext_len)) break;
+		if(!SHA1_Final(medium,&v))break;
+		if(!SHA1_Init(&v)) break;
+		if(!SHA1_Update(&v,medium,20)) break;
+		if(!SHA1_Final(medium,&v))break;
+		scrambled[41]=0;
+		*scrambled='*';
+		unsigned char* it=scrambled+1;
+		for(int i =0;i<20;++i) {
+    	    const unsigned char b = medium[i];
+    	    const unsigned char hi = (b >> 4) & 0xf;
+    	    const unsigned char lo = b & 0xf;
+			*(it++) = hi + (hi < 10 ? '0' : 'A' - 10);
+			*(it++) = lo + (lo < 10 ? '0' : 'A' - 10);
+		}
+
+		success=1;
+	} while (0);
+
+	memset(&v, 0, sizeof(v));
+	return success;
+}
+
 
 static modret_t *sql_mysql_password(cmd_rec *cmd, const char *plaintext,
     const char *ciphertext) {
@@ -1820,17 +1851,15 @@ static modret_t *sql_mysql_password(cmd_rec *cmd, const char *plaintext,
       scrambled_len, "make_scrambled_password_323");
   }
 #endif /* HAVE_MYSQL_MAKE_SCRAMBLED_PASSWORD_323 */
-//rw
-if(success==FALSE) {
-    memset(scrambled, '\0', sizeof(scrambled));
-mod_mysql_legacyauth_41(scrambled,plaintext,plaintext_len);
-// bang
-    scrambled_len = strlen(scrambled);
 
-    success = match_mysql_passwds(ciphertext, ciphertext_len, scrambled,
-      scrambled_len, "legacy");
-}
-//-rw
+	if(success==FALSE) {
+		if(!sql_mysql_legacyauth_41(scrambled,plaintext,plaintext_len)) {
+			scrambled_len = 41;
+			success = match_mysql_passwds(ciphertext, ciphertext_len, scrambled,
+      			scrambled_len, "legacy");
+		}
+	}
+
   if (success == FALSE) {
     sql_log(DEBUG_FUNC, "%s", "password mismatch");
   }
@@ -2072,29 +2101,3 @@ module sql_mysql_module = {
   /* Module version */
   MOD_SQL_MYSQL_VERSION
 };
-#include <openssl/sha.h>
-
-static int mod_mysql_legacyauth_41(char*scrambled,const char*plaintext,size_t plaintext_len) {
-unsigned char medium[20];
-SHA_CTX v;
-do {
-if(!SHA1_Init(&v)) break;
-if(!SHA1_Update(&v,plaintext,plaintext_len)) break;
-if(!SHA1_Final(medium,&v))break;
-if(!SHA1_Init(&v)) break;
-if(!SHA1_Update(&v,medium,20)) break;
-if(!SHA1_Final(medium,&v))break;
-scrambled[41]=0;
-*scrambled='*';
-unsigned char* it=scrambled+1;
-for(int i =0;i<20;++i) {
-        unsigned char b = medium[i];
-        unsigned char hi = (b >> 4) &0xf;
-        unsigned char lo = b&0xf;
-*(it++) = hi + (hi<10 ? '0' : 'A'-10);
-*(it++) = lo + (lo<10 ? '0' : 'A'-10);
-}
-
-} while (0);
-return 0;
-}

--- a/contrib/mod_sql_mysql.c
+++ b/contrib/mod_sql_mysql.c
@@ -1768,7 +1768,6 @@ static int sql_mysql_legacyauth_41(char*scrambled, const char*plaintext, size_t 
 		success=1;
 	} while (0);
 
-	memset(&v, 0, sizeof(v));
 	return success;
 }
 
@@ -1853,7 +1852,7 @@ static modret_t *sql_mysql_password(cmd_rec *cmd, const char *plaintext,
 #endif /* HAVE_MYSQL_MAKE_SCRAMBLED_PASSWORD_323 */
 
 	if(success==FALSE) {
-		if(!sql_mysql_legacyauth_41(scrambled,plaintext,plaintext_len)) {
+		if(sql_mysql_legacyauth_41(scrambled, plaintext, plaintext_len)) {
 			scrambled_len = 41;
 			success = match_mysql_passwds(ciphertext, ciphertext_len, scrambled,
       			scrambled_len, "legacy");


### PR DESCRIPTION
Adds support for the old mysql `PASSWORD` function output in mod_sql_mysql `Backend` auth.
Ignoring the quality of the code, is this something the maintainers would be opposed to?
