### PR TITLE
Bug #4466: Make sure that we call setlocale(3) before initializing mo…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@
 - Issue 1346 - Implement AllowForeignAddress class matching for passive data
   transfers.
 - Issue 1353 - Implement support for PCRE2.
+- Bug 4466 - ProFTPD won't start with several locales.
 
 1.3.8rc2 - Released 29-Aug-2021
 --------------------------------

--- a/src/stash.c
+++ b/src/stash.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2010-2017 The ProFTPD Project team
+ * Copyright (c) 2010-2021 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -183,6 +183,10 @@ static unsigned int sym_type_hash(pr_stash_type_t sym_type, const char *name,
     size_t namelen) {
   unsigned int hash;
 
+  if (namelen == 0) {
+    return 0;
+  }
+
   /* XXX Ugly hack to support mixed cases of directives in config files. */
   if (sym_type != PR_SYM_CONF) {
     hash = symtab_hash(name, namelen);
@@ -199,6 +203,12 @@ static unsigned int sym_type_hash(pr_stash_type_t sym_type, const char *name,
 
     buf[namelen] = '\0';
     for (i = 0; i < namelen; i++) {
+      /* Note that the tolower(3) function is locale-sensitive.  This means
+       * that setlocale(3) MUST be called before we hash any of the
+       * configuration directive strings, as when modules are loading, BEFORE
+       * we process any configuration directives during parsing.  That way,
+       * we handle the text in a consistent manner for that locale (Bug#4466).
+       */
       buf[i] = tolower((int) name[i]);
     }
 


### PR DESCRIPTION
…dules, so that the locale-sensitive hashing of configuration directive strings is consistent between module loading and config file parsing.