### PR TITLE
Bug #4467: If an upload is aborted by the client, and `HiddenStores` …

### DIFF
--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -1022,9 +1022,8 @@ static void stor_abort(pool *p) {
         } 
       }
     }
-  }
 
-  if (session.xfer.path != NULL) {
+  } else if (session.xfer.path != NULL) {
     if (delete_stores != NULL &&
         *delete_stores == TRUE) {
       pr_log_debug(DEBUG5, "removing aborted file '%s'", session.xfer.path);
@@ -1037,14 +1036,16 @@ static void stor_abort(pool *p) {
         pr_error_set_why(err, pstrcat(tmp_pool, "delete aborted file '",
           session.xfer.path, "'", NULL));
 
-        if (err != NULL) {
-          pr_log_debug(DEBUG0, "%s", pr_error_strerror(err, 0));
-          pr_error_destroy(err);
-          err = NULL;
+        if (xerrno != ENOENT) {
+          if (err != NULL) {
+            pr_log_debug(DEBUG0, "%s", pr_error_strerror(err, 0));
+            pr_error_destroy(err);
+            err = NULL;
 
-        } else {
-          pr_log_debug(DEBUG0, "error deleting aborted file '%s': %s",
-            session.xfer.path, strerror(xerrno));
+          } else {
+            pr_log_debug(DEBUG0, "error deleting aborted file '%s': %s",
+              session.xfer.path, strerror(xerrno));
+          }
         }
       }
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/DeleteAbortedStores.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DeleteAbortedStores.pm
@@ -30,12 +30,17 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
-  deleteabortedstores_timeout_idle_bug4035 => {
+  deleteabortedstores_hiddenstores_on_timeout_idle_bug4035 => {
     order => ++$order,
     test_class => [qw(bug forking)],
   },
 
-  deleteabortedstores_timeout_stalled_bug4035 => {
+  deleteabortedstores_hiddenstores_on_timeout_stalled_bug4035 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
+  deleteabortedstores_hiddenstores_on_xfer_aborted_bug4467 => {
     order => ++$order,
     test_class => [qw(bug forking)],
   },
@@ -284,7 +289,7 @@ sub deleteabortedstores_cmd_abort_ok {
         die("File $hidden_file does not exist as expected");
       }
 
-      $client->quote('ABOR');
+      eval { $client->quote('ABOR') };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
@@ -474,41 +479,10 @@ sub deleteabortedstores_conn_aborted_bug3917 {
   unlink($log_file);
 }
 
-sub deleteabortedstores_timeout_idle_bug4035 {
+sub deleteabortedstores_hiddenstores_on_timeout_idle_bug4035 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/config.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/config.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/config.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'config');
 
   my $hidden_file = File::Spec->rel2abs("$tmpdir/.in.test.txt.");
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -516,12 +490,12 @@ sub deleteabortedstores_timeout_idle_bug4035 {
   my $timeout_idle = 2;
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     DefaultChdir => '~',
 
     HiddenStores => 'on',
@@ -535,7 +509,8 @@ sub deleteabortedstores_timeout_idle_bug4035 {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -553,7 +528,7 @@ sub deleteabortedstores_timeout_idle_bug4035 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($user, $passwd);
+      $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw('test.txt');
       unless ($conn) {
@@ -589,7 +564,6 @@ sub deleteabortedstores_timeout_idle_bug4035 {
       $self->assert(!-f $hidden_file,
         test_msg("File $hidden_file exists unexpectedly"));
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -598,7 +572,7 @@ sub deleteabortedstores_timeout_idle_bug4035 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -608,55 +582,16 @@ sub deleteabortedstores_timeout_idle_bug4035 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
-sub deleteabortedstores_timeout_stalled_bug4035 {
+sub deleteabortedstores_hiddenstores_on_timeout_stalled_bug4035 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/config.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/config.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/config.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'config');
 
   my $hidden_file = File::Spec->rel2abs("$tmpdir/.in.test.txt.");
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -664,12 +599,12 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
   my $timeout_stalled = 2;
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     DefaultChdir => '~',
 
     HiddenStores => 'on',
@@ -683,7 +618,8 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -701,7 +637,7 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($user, $passwd);
+      $client->login($setup->{user}, $setup->{passwd});
 
       my $conn = $client->stor_raw('test.txt');
       unless ($conn) {
@@ -735,7 +671,6 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
       $self->assert(!-f $hidden_file,
         test_msg("File $hidden_file exists unexpectedly"));
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -744,7 +679,7 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -754,18 +689,197 @@ sub deleteabortedstores_timeout_stalled_bug4035 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $ok = 0;
 
-    die($ex);
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /removing aborted HiddenStores file '(.*?)'$/) {
+          my $hidden_path = $1;
+
+          if ($hidden_path =~ /\.in\.test\.txt\.$/) {
+            $ok = 1;
+          }
+        }
+      }
+
+      close($fh);
+      $self->assert($ok, test_msg("Did not see expected debug log messages"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
   }
 
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub deleteabortedstores_hiddenstores_on_xfer_aborted_bug4467 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my $hidden_file = File::Spec->rel2abs("$tmpdir/.in.test.txt.");
+
+  # For this bug, we ensure that this file already exists, as if we are going
+  # to overwrite it.  Our upload is to the HiddenStores file, which will be
+  # aborted (and the HiddenStores file cleaned up); we want to ensure that
+  # this actual file still remains.
+  my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
+  if (open(my $fh, "> $test_file")) {
+    unless (close($fh)) {
+      die("Can't write $test_file: $!");
+    }
+
+  } else {
+    die("Can't open $test_file: $!");
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    DefaultChdir => '~',
+
+    HiddenStores => 'on',
+    DeleteAbortedStores => 'on',
+    AllowOverwrite => 'on',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $conn = $client->stor_raw('test.txt');
+      unless ($conn) {
+        die("Failed to STOR test.txt: " . $client->response_code() . " " .
+          $client->response_msg());
+      }
+
+      my $buf = "Hello, World!\n";
+      $conn->write($buf, length($buf), 25);
+
+      unless (-f $hidden_file) {
+        die("File $hidden_file does not exist as expected");
+      }
+
+      eval { $conn->abort() };
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg, 1);
+
+      eval { $conn->close() };
+
+      $self->assert(-f $test_file,
+        test_msg("File $test_file does not exist as expected"));
+
+      $self->assert(!-f $hidden_file,
+        test_msg("File $hidden_file exists unexpectedly"));
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $hidden_path_ok = 0;
+      my $actual_path_ok = 1;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /removing aborted HiddenStores file '(.*?)'$/) {
+          my $hidden_path = $1;
+
+          if ($hidden_path =~ /\.in\.test\.txt\.$/) {
+            $hidden_path_ok = 1;
+          }
+        }
+
+        if ($line =~ /removing aborted file '(.*?)'$/) {
+          my $actual_path = $1;
+
+          if ($actual_path =~ /test\.txt$/) {
+            $actual_path_ok = 0;
+          }
+        }
+      }
+
+      close($fh);
+      $self->assert($hidden_path_ok,
+        test_msg("Did not see expected HiddenStores debug log messages"));
+      $self->assert($actual_path_ok,
+        test_msg("Saw unexpected actual path debug log messages"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 1;


### PR DESCRIPTION
…and `DeleteAbortedStores` are in effect, make sure we delete _only_ the `HiddenStores` file, and not the actual destination file.

The actual destination file may already exist from some other transfer.