### PR TITLE
Avoid error on some client using digest

### DIFF
--- a/contrib/mod_digest.c
+++ b/contrib/mod_digest.c
@@ -1955,11 +1955,11 @@ static modret_t *digest_xcmd(cmd_rec *cmd, unsigned long algo) {
     if (get_algo_md(algo) != NULL) {
       char *hex_digest;
 
-      pr_response_add(R_250, _("Computing %s digest"), get_algo_name(algo, 0));
+      /*pr_response_add(R_250, _("Computing %s digest"), get_algo_name(algo, 0));*/
       hex_digest = get_digest(cmd, algo, path, st.st_mtime, start_pos, len,
         PR_STR_FL_HEX_USE_UC, digest_progress_cb);
       if (hex_digest != NULL) {
-        pr_response_add(R_DUP, "%s", hex_digest);
+        pr_response_add(R_250, "%s", hex_digest);
         return PR_HANDLED(cmd);
       }
 


### PR DESCRIPTION
Clients like Beyond Compare do not accept unwanted data in response.