### PR TITLE
Issue #1367: When formatting `MLSD`/`MLST` responses, convert any spa…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@
   transfers.
 - Issue 1353 - Implement support for PCRE2.
 - Bug 4466 - ProFTPD won't start with several locales.
+- Issue 1367 - Auth sources providing space-bearing user/group names cause
+  compliance issues with MLSD/MLST responses.
 
 1.3.8rc2 - Released 29-Aug-2021
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -20,6 +20,8 @@ ChangeLog files.
 
   + New Directives
 
+    FactsDefault (Issue #1367)
+
     LDAPConnectTimeout (Issue #1333)
 
 
@@ -36,7 +38,7 @@ ChangeLog files.
 
     SFTPOptions NoHostkeyRotation
 
-    SocketOptions reuseport
+    SocketOptions ReusePort
 
 
 1.3.8rc2

--- a/doc/modules/mod_facts.html
+++ b/doc/modules/mod_facts.html
@@ -40,6 +40,7 @@ ProFTPD source distribution:
 <h2>Directives</h2>
 <ul>
   <li><a href="#FactsAdvertise">FactsAdvertise</a>
+  <li><a href="#FactsDefault">FactsDefault</a>
   <li><a href="#FactsOptions">FactsOptions</a>
 </ul>
 
@@ -73,6 +74,48 @@ you can disable the advertising of support for those commands using
     FactsAdvertise off
   &lt;/IfModule&gt;
 </pre>
+
+<hr>
+<h3><a name="FactsAdvertise">FactsDefault</a></h3>
+<strong>Syntax:</strong> FactsDefault <em>fact1 ...</em><br>
+<strong>Default:</strong> None</br>
+<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_facts<br>
+<strong>Compatibility:</strong> 1.3.8rc3 and later
+
+<p>
+The <code>FactsDefault</code> directive configures the default list of facts
+to include in responses to <code>MLSD</code>/<code>MLST</code> FTP commands.
+
+The supported <em>fact</em> names are:
+<ul>
+  <li><code>media-type</code> (file media type, where known)
+  <li><code>modify</code> (file modification timestamp)
+  <li><code>perm</code> (file permissions)
+  <li><code>size</code> (file size in bytes)
+  <li><code>type</code> (file type, per <a href="https://datatracker.ietf.org/doc/html/rfc3659#section-7.5.1">RFC 3659, Section 7.5.1</a>)
+  <li><code>unique</code> (unique file identifier)
+  <li><code>UNIX.group</code> (file numeric UNIX group ID)
+  <li><code>UNIX.groupname</code> (file textual UNIX group name)
+  <li><code>UNIX.mode</code> (file numeric UNIX permissions/mode)
+  <li><code>UNIX.owner</code> (file numeric UNIX user ID)
+  <li><code>UNIX.ownername</code> (file textual UNIX user name)
+</ul>
+
+<p>
+By default, the <code>mod_facts</code> module will provide the following facts:
+<ul>
+  <li><code>modify</code>
+  <li><code>perm</code>
+  <li><code>size</code>
+  <li><code>type</code>
+  <li><code>unique</code>
+  <li><code>UNIX.group</code>
+  <li><code>UNIX.groupname</code>
+  <li><code>UNIX.mode</code>
+  <li><code>UNIX.owner</code>
+  <li><code>UNIX.ownername</code>
+</ul>
 
 <hr>
 <h3><a name="FactsOptions">FactsOptions</a></h3>

--- a/modules/mod_facts.c
+++ b/modules/mod_facts.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_facts -- a module for handling "facts" [RFC3659]
- * Copyright (c) 2007-2020 The ProFTPD Project
+ * Copyright (c) 2007-2022 The ProFTPD Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 #include "privs.h"
 #include "error.h"
 
-#define MOD_FACTS_VERSION		"mod_facts/0.6"
+#define MOD_FACTS_VERSION		"mod_facts/0.7"
 
 #if PROFTPD_VERSION_NUMBER < 0x0001030101
 # error "ProFTPD 1.3.1rc1 or later required"
@@ -46,6 +46,19 @@ static unsigned long facts_opts = 0;
 #define FACTS_OPT_SHOW_MEDIA_TYPE	0x00100
 #define FACTS_OPT_SHOW_UNIX_OWNER_NAME	0x00200
 #define FACTS_OPT_SHOW_UNIX_GROUP_NAME	0x00400
+
+/* By default, we show most of the facts; see FactsDefault. */
+#define FACTS_OPT_SHOW_DEFAULT \
+  FACTS_OPT_SHOW_MODIFY|\
+  FACTS_OPT_SHOW_PERM|\
+  FACTS_OPT_SHOW_SIZE|\
+  FACTS_OPT_SHOW_TYPE|\
+  FACTS_OPT_SHOW_UNIQUE|\
+  FACTS_OPT_SHOW_UNIX_GROUP|\
+  FACTS_OPT_SHOW_UNIX_GROUP_NAME|\
+  FACTS_OPT_SHOW_UNIX_MODE|\
+  FACTS_OPT_SHOW_UNIX_OWNER|\
+  FACTS_OPT_SHOW_UNIX_OWNER_NAME
 
 static unsigned long facts_mlinfo_opts = 0;
 #define FACTS_MLINFO_FL_SHOW_SYMLINKS			0x00001
@@ -73,6 +86,54 @@ static int facts_sess_init(void);
 
 /* Support functions
  */
+
+static int facts_get_show_opt(const char *fact) {
+  if (strcasecmp(fact, "modify") == 0) {
+    return FACTS_OPT_SHOW_MODIFY;
+  }
+
+  if (strcasecmp(fact, "perm") == 0) {
+    return FACTS_OPT_SHOW_PERM;
+  }
+
+  if (strcasecmp(fact, "size") == 0) {
+    return FACTS_OPT_SHOW_SIZE;
+  }
+
+  if (strcasecmp(fact, "type") == 0) {
+    return FACTS_OPT_SHOW_TYPE;
+  }
+
+  if (strcasecmp(fact, "unique") == 0) {
+    return FACTS_OPT_SHOW_UNIQUE;
+  }
+
+  if (strcasecmp(fact, "UNIX.group") == 0) {
+    return FACTS_OPT_SHOW_UNIX_GROUP;
+  }
+
+  if (strcasecmp(fact, "UNIX.groupname") == 0) {
+    return FACTS_OPT_SHOW_UNIX_GROUP_NAME;
+  }
+
+  if (strcasecmp(fact, "UNIX.mode") == 0) {
+    return FACTS_OPT_SHOW_UNIX_MODE;
+  }
+
+  if (strcasecmp(fact, "UNIX.owner") == 0) {
+    return FACTS_OPT_SHOW_UNIX_OWNER;
+  }
+
+  if (strcasecmp(fact, "UNIX.ownername") == 0) {
+    return FACTS_OPT_SHOW_UNIX_OWNER_NAME;
+  }
+
+  if (strcasecmp(fact, "media-type") == 0) {
+    return FACTS_OPT_SHOW_MEDIA_TYPE;
+  }
+
+  return -1;
+}
 
 static int facts_filters_allow_path(cmd_rec *cmd, const char *path) {
 #ifdef PR_USE_REGEX
@@ -294,7 +355,14 @@ static size_t facts_mlinfo_fmt(struct mlinfo *info, char *buf, size_t bufsz,
 
   if (!(facts_mlinfo_opts & FACTS_MLINFO_FL_NO_NAMES)) {
     if (facts_opts & FACTS_OPT_SHOW_UNIX_GROUP_NAME) {
-      len = pr_snprintf(ptr, bufsz - buflen, "UNIX.groupname=%s;", info->group);
+      const char *group;
+
+      /* In order to be compliant with RFC 3659, Section 7.4, we must ensure
+       * that the group name NOT contain the space character.
+       */
+      group = sreplace(info->pool, info->group, " ", "_", NULL);
+
+      len = pr_snprintf(ptr, bufsz - buflen, "UNIX.groupname=%s;", group);
       buflen += len;
       ptr = buf + buflen;
     }
@@ -316,7 +384,14 @@ static size_t facts_mlinfo_fmt(struct mlinfo *info, char *buf, size_t bufsz,
 
   if (!(facts_mlinfo_opts & FACTS_MLINFO_FL_NO_NAMES)) {
     if (facts_opts & FACTS_OPT_SHOW_UNIX_OWNER_NAME) {
-      len = pr_snprintf(ptr, bufsz - buflen, "UNIX.ownername=%s;", info->user);
+      const char *user;
+
+      /* In order to be compliant with RFC 3659, Section 7.4, we must ensure
+       * that the user name NOT contain the space character.
+       */
+      user = sreplace(info->pool, info->user, " ", "_", NULL);
+
+      len = pr_snprintf(ptr, bufsz - buflen, "UNIX.ownername=%s;", user);
       buflen += len;
       ptr = buf + buflen;
     }
@@ -1848,53 +1923,53 @@ MODRET facts_opts_mlst(cmd_rec *cmd) {
   facts = cmd->argv[1];
   ptr = strchr(facts, ';');
 
-  while (ptr) {
+  while (ptr != NULL) {
     pr_signals_handle();
 
     *ptr = '\0';
 
     if (strcasecmp(facts, "modify") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_MODIFY;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "modify;", NULL);
 
     } else if (strcasecmp(facts, "perm") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_PERM;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "perm;", NULL);
 
     } else if (strcasecmp(facts, "size") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_SIZE;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "size;", NULL);
 
     } else if (strcasecmp(facts, "type") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_TYPE;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "type;", NULL);
 
     } else if (strcasecmp(facts, "unique") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIQUE;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "unique;", NULL);
 
     } else if (strcasecmp(facts, "UNIX.group") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIX_GROUP;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "UNIX.group;", NULL);
 
     } else if (strcasecmp(facts, "UNIX.groupname") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIX_GROUP_NAME;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "UNIX.groupname;", NULL);
 
     } else if (strcasecmp(facts, "UNIX.mode") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIX_MODE;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "UNIX.mode;", NULL);
 
     } else if (strcasecmp(facts, "UNIX.owner") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIX_OWNER;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "UNIX.owner;", NULL);
 
     } else if (strcasecmp(facts, "UNIX.ownername") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_UNIX_OWNER_NAME;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "UNIX.ownername;", NULL);
 
     } else if (strcasecmp(facts, "media-type") == 0) {
-      facts_opts |= FACTS_OPT_SHOW_MEDIA_TYPE;
+      facts_opts |= facts_get_show_opt(facts);
       resp_str = pstrcat(cmd->tmp_pool, resp_str, "media-type;", NULL);
 
     } else {
@@ -1932,6 +2007,38 @@ MODRET set_factsadvertise(cmd_rec *cmd) {
   c = add_config_param(cmd->argv[0], 1, NULL);
   c->argv[0] = pcalloc(c->pool, sizeof(int));
   *((int *) c->argv[0]) = bool;
+
+  return PR_HANDLED(cmd);
+}
+
+/* usage: FactsDefault fact1 ... factN */
+MODRET set_factsdefault(cmd_rec *cmd) {
+  register unsigned int i;
+  config_rec *c;
+  unsigned long opts = 0UL;
+
+  if (cmd->argc-1 == 0) {
+    CONF_ERROR(cmd, "wrong number of parameters");
+  }
+
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+
+  for (i = 1; i < cmd->argc; i++) {
+    int show_opt;
+
+    show_opt = facts_get_show_opt(cmd->argv[i]);
+    if (show_opt < 0) {
+      CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown fact '",
+        cmd->argv[i], "'", NULL));
+    }
+
+    opts |= show_opt;
+  }
+
+  c->argv[0] = palloc(c->pool, sizeof(unsigned long));
+  *((unsigned long *) c->argv[0]) = opts;
 
   return PR_HANDLED(cmd);
 }
@@ -2018,11 +2125,7 @@ static int facts_sess_init(void) {
   pr_event_register(&facts_module, "core.session-reinit",
     facts_sess_reinit_ev, NULL);
 
-  facts_opts = FACTS_OPT_SHOW_MODIFY|FACTS_OPT_SHOW_PERM|FACTS_OPT_SHOW_SIZE|
-    FACTS_OPT_SHOW_TYPE|FACTS_OPT_SHOW_UNIQUE|
-    FACTS_OPT_SHOW_UNIX_GROUP|FACTS_OPT_SHOW_UNIX_GROUP_NAME|
-    FACTS_OPT_SHOW_UNIX_MODE|FACTS_OPT_SHOW_UNIX_OWNER|
-    FACTS_OPT_SHOW_UNIX_OWNER_NAME;
+  facts_opts = FACTS_OPT_SHOW_DEFAULT;
 
   c = find_config(main_server->conf, CONF_PARAM, "FactsAdvertise", FALSE);
   if (c != NULL) {
@@ -2031,6 +2134,11 @@ static int facts_sess_init(void) {
 
   if (advertise == FALSE) {
     return 0;
+  }
+
+  c = find_config(main_server->conf, CONF_PARAM, "FactsDefault", FALSE);
+  if (c != NULL) {
+    facts_opts = *((unsigned long *) c->argv[0]);
   }
 
   c = find_config(main_server->conf, CONF_PARAM, "FactsOptions", FALSE);
@@ -2076,6 +2184,7 @@ static int facts_sess_init(void) {
 
 static conftable facts_conftab[] = {
   { "FactsAdvertise",	set_factsadvertise,	NULL },
+  { "FactsDefault",	set_factsdefault,	NULL },
   { "FactsOptions",	set_factsoptions,	NULL },
   { NULL }
 };

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_facts.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_facts.pm
@@ -22,6 +22,21 @@ my $TESTS = {
     test_class => [qw(forking)],
   },
 
+  facts_default_issue1367 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
+  facts_ownername_with_space_issue1367 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
+  facts_groupname_with_space_issue1367 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
   opts_mlst_invalid => {
     order => ++$order,
     test_class => [qw(forking)],
@@ -129,6 +144,416 @@ sub facts_advertise_off {
 
       # Even though we have "FactsAdvertise off", the MLSD results should
       # still have the default facts enabled.
+      my $expected = {
+        '.' => 1,
+        '..' => 1,
+        'facts.conf' => 1,
+        'facts.group' => 1,
+        'facts.passwd' => 1,
+        'facts.pid' => 1,
+        'facts.scoreboard' => 1,
+        'facts.scoreboard.lck' => 1,
+      };
+
+      my $ok = 1;
+      my $mismatch;
+      foreach my $name (keys(%$res)) {
+        unless (defined($expected->{$name})) {
+          $mismatch = $name;
+          $ok = 0;
+          last;
+        }
+      }
+
+      unless ($ok) {
+        die("Unexpected name '$mismatch' appeared in MLSD data")
+      }
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub facts_default_issue1367 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'facts');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'facts:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_facts.c' => {
+        FactsDefault => 'perm size unique UNIX.groupname UNIX.ownername',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+      $client->type('binary');
+
+      my $conn = $client->mlsd_raw();
+      unless ($conn) {
+        die("Failed to MLSD: " . $client->response_code() . ' ' .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 10);
+      eval { $conn->close() };
+
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Response:\n$buf\n";
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      $client->quit();
+
+      # We have to be careful of the fact that readdir returns directory
+      # entries in an unordered fashion.
+      my $res = {};
+      my $lines = [split(/\r\n/, $buf)];
+      $self->assert(scalar(@$lines) > 1,
+        test_msg("Expected several MLSD lines, got " . scalar(@$lines)));
+
+      foreach my $line (@$lines) {
+        # Directory entries will not have the "size" fact.
+
+        if ($line =~ /^perm=\S+;(size=\d+;)?unique=\S+;UNIX\.groupname=\S+;UNIX\.ownername=\S+; (.*?)$/) {
+          $res->{$2} = 1;
+        }
+      }
+
+      my $expected = {
+        '.' => 1,
+        '..' => 1,
+        'facts.conf' => 1,
+        'facts.group' => 1,
+        'facts.passwd' => 1,
+        'facts.pid' => 1,
+        'facts.scoreboard' => 1,
+        'facts.scoreboard.lck' => 1,
+      };
+
+      my $ok = 1;
+      my $mismatch;
+      foreach my $name (keys(%$res)) {
+        unless (defined($expected->{$name})) {
+          $mismatch = $name;
+          $ok = 0;
+          last;
+        }
+      }
+
+      unless ($ok) {
+        die("Unexpected name '$mismatch' appeared in MLSD data")
+      }
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub facts_ownername_with_space_issue1367 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  # To reproduce the behavior reported in Issue #1367, we deliberately
+  # use a username that includes spaces.  The current mitigation is that
+  # mod_facts replaces all whitespace characters with '_' in such cases.
+
+  my $username = 'My ProFTPD User';
+  my $setup = test_setup($tmpdir, 'facts', $username);
+
+  my $expected_ownername = $username;
+  $expected_ownername =~ s/\s/_/g;
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'facts:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+      $client->type('binary');
+
+      my $conn = $client->mlsd_raw();
+      unless ($conn) {
+        die("Failed to MLSD: " . $client->response_code() . ' ' .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 10);
+      eval { $conn->close() };
+
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Response:\n$buf\n";
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      $client->quit();
+
+      # We have to be careful of the fact that readdir returns directory
+      # entries in an unordered fashion.
+      my $res = {};
+      my $lines = [split(/\r\n/, $buf)];
+      $self->assert(scalar(@$lines) > 1,
+        test_msg("Expected several MLSD lines, got " . scalar(@$lines)));
+
+      foreach my $line (@$lines) {
+        if ($line =~ /^modify=\S+;(size=\d+;)?perm=\S+;type=\S+;unique=\S+;UNIX\.group=\d+;UNIX\.groupname=\S+;UNIX\.mode=\d+;UNIX\.owner=\d+;UNIX\.ownername=(.*?); (.*?)$/) {
+          $res->{$3} = 1;
+
+          my $facts_ownername = $2;
+          $self->assert($facts_ownername eq $expected_ownername,
+            test_msg("Expected UNIX.ownername '$expected_ownername', got '$facts_ownername' in '$line'"));
+        }
+      }
+
+      my $expected = {
+        '.' => 1,
+        '..' => 1,
+        'facts.conf' => 1,
+        'facts.group' => 1,
+        'facts.passwd' => 1,
+        'facts.pid' => 1,
+        'facts.scoreboard' => 1,
+        'facts.scoreboard.lck' => 1,
+      };
+
+      my $ok = 1;
+      my $mismatch;
+      foreach my $name (keys(%$res)) {
+        unless (defined($expected->{$name})) {
+          $mismatch = $name;
+          $ok = 0;
+          last;
+        }
+      }
+
+      unless ($ok) {
+        die("Unexpected name '$mismatch' appeared in MLSD data")
+      }
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub facts_groupname_with_space_issue1367 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+
+  # To reproduce the behavior reported in Issue #1367, we deliberately
+  # use a group name that includes spaces.  The current mitigation is that
+  # mod_facts replaces all whitespace characters with '_' in such cases.
+
+  my $groupname = 'My ProFTPD Group';
+  my $setup = test_setup($tmpdir, 'facts', undef, undef, $groupname);
+
+  my $expected_groupname = $groupname;
+  $expected_groupname =~ s/\s/_/g;
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'facts:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+      $client->type('binary');
+
+      my $conn = $client->mlsd_raw();
+      unless ($conn) {
+        die("Failed to MLSD: " . $client->response_code() . ' ' .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 10);
+      eval { $conn->close() };
+
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Response:\n$buf\n";
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      $client->quit();
+
+      # We have to be careful of the fact that readdir returns directory
+      # entries in an unordered fashion.
+      my $res = {};
+      my $lines = [split(/\r\n/, $buf)];
+      $self->assert(scalar(@$lines) > 1,
+        test_msg("Expected several MLSD lines, got " . scalar(@$lines)));
+
+      foreach my $line (@$lines) {
+        if ($line =~ /^modify=\S+;(size=\d+;)?perm=\S+;type=\S+;unique=\S+;UNIX\.group=\d+;UNIX\.groupname=(.*?);UNIX\.mode=\d+;UNIX\.owner=\d+;UNIX\.ownername=.*?; (.*?)$/) {
+          $res->{$3} = 1;
+
+          my $facts_groupname = $2;
+          $self->assert($facts_groupname eq $expected_groupname,
+            test_msg("Expected UNIX.groupname '$expected_groupname', got '$facts_groupname' in '$line'"));
+        }
+      }
+
       my $expected = {
         '.' => 1,
         '..' => 1,


### PR DESCRIPTION
…ce characters in user/group names to `_`.

Otherwise, the response is not compliant with RFC 3659.  And unfortunately,
the RFC does not specify how exactly to encode such illegal characters, leaving
it up to implementors to decide.