### PR TITLE
Fix typo about RFC number.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -844,7 +844,7 @@ static cmd_rec *make_ftp_cmd(pool *p, char *buf, size_t buflen, int flags) {
   cmd->argc++;
 
   /* Make a copy of the command argument; we need to scan through it,
-   * looking for any CR+NUL sequences, per RFC 2460, Section 3.1.
+   * looking for any CR+NUL sequences, per RFC 2640, Section 3.1.
    *
    * Note for future readers that this scanning may cause problems for
    * commands such as ADAT, ENC, and MIC.  Per RFC 2228, the arguments for


### PR DESCRIPTION
[In this comment](https://github.com/proftpd/proftpd/blob/master/src/main.c#L847), RFC 2460 is typo for RFC 2640.
RFC 2460 is about IPv6 and is not relevant.