### PR TITLE
mod_auth_file: Calculate the current buffer offset before reallocation

### DIFF
--- a/modules/mod_auth_file.c
+++ b/modules/mod_auth_file.c
@@ -385,6 +385,7 @@ static char *af_getgrentline(char **buf, int *buflen, pr_fh_t *fh,
 
     {
       char *new_buf;
+      size_t old_off = cp - *buf;
 
       new_buf = realloc(*buf, *buflen);
       if (new_buf == NULL) {
@@ -392,9 +393,9 @@ static char *af_getgrentline(char **buf, int *buflen, pr_fh_t *fh,
       }
 
       *buf = new_buf;
+      cp = *buf + old_off;
     }
 
-    cp = *buf + (cp - *buf);
     cp = strchr(cp, '\0');
   }
 


### PR DESCRIPTION
Hi. We recently upgraded to 1.3.7c and quickly noticed some crashes on login. GDB showed a `SIGSEGV` in `malloc` in `af_getgrent`. We have a big "all our ftp users have this supplementary group"-group. Easily more than 1024 chars. Since a crash in `malloc` is usually a hint for memory corruption I pocked around a bit more and stumbled upon `af_getgrentline`.

In https://github.com/proftpd/proftpd/blob/e428a379fc97db8400a497045a57a69468666901/modules/mod_auth_file.c#L397 it updates the copy pointer to the current offset inside the buffer. This calculation is obviously only meaningful if both pointers point to the same structure. However a few lines above the buffer reallocation happens and the pointer to the buffer gets updated. But the copy pointer does not. So the copy pointer still points to the old (and freed) buffer leading to garbage offset results.

This PR simply calculates the offset beforehand.