### PR TITLE
lib/Makefile.in: add -static to libtool call

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -28,7 +28,7 @@ libltdl: dummy
 	cd libltdl/ && $(MAKE)
 
 prbase.a: $(LIB_OBJS)
-	$(AR) rc prbase.a $(LIB_OBJS)
+	$(AR) rc prbase.a $(patsubst %.o,.libs/%.o,$(LIB_OBJS))
 	$(RANLIB) prbase.a
 
 lib: prbase.a $(LIB_DEPS)


### PR DESCRIPTION
Add `-static` to libtool call to avoid the following build failure raised since version 1.3.7a and https://github.com/proftpd/proftpd/commit/3b815f3306be378892d3916765659ba88e80952a on shared library systems where libtool install object files in `.libs` (https://www.gnu.org/software/libtool/manual/html_node/Creating-object-files.html):

```
libtool: compile:  /home/fabrice/buildroot/output/host/bin/arm-none-linux-gnueabi-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CONFIG_H -DLINUX -I.. -I../include -I../include -g2 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -g0 -D_FORTIFY_SOURCE=1 -Wall -fno-omit-frame-pointer -fno-strict-aliasing -c openbsd-bcrypt.c  -fPIC -DPIC -o .libs/openbsd-bcrypt.o
/home/fabrice/buildroot/output/host/bin/arm-none-linux-gnueabi-gcc-ar rc libsupp.a pr_fnmatch.o sstrncpy.o strsep.o vsnprintf.o glibc-glob.o glibc-hstrerror.o glibc-mkstemp.o pr-syslog.o pwgrent.o hanson-tpl.o ccan-json.o openbsd-blowfish.o openbsd-bcrypt.o
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/arm-none-linux-gnueabi/4.8.3/../../../../arm-none-linux-gnueabi/bin/ar: pr_fnmatch.o: No such file or directory
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>