### PR TITLE
Issue #1336: Backport the use of the `dir_best_path` fallback in the …

### DIFF
--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -2491,6 +2491,16 @@ MODRET xfer_pre_retr(cmd_rec *cmd) {
 
   pr_fs_clear_cache2(decoded_path);
   dir = dir_realpath(cmd->tmp_pool, decoded_path);
+  if (dir == NULL) {
+    /* Try using dir_best_path(), as xfer_pre_stor() does.
+     *
+     * Without this fallback, certain use cases (such as SFTP downloads using
+     * mod_sftp + mod_vroot) fail unexpectedly, with misleading
+     * "denied by <Limit> configuration" errors.
+     */
+    dir = dir_best_path(cmd->tmp_pool, decoded_path);
+  }
+
   if (dir == NULL ||
       !dir_check(cmd->tmp_pool, cmd, cmd->group, dir, NULL)) {
     int xerrno = errno;


### PR DESCRIPTION
…`PRE_RETR` handler in `mod_xfer`, for the `mod_vroot+mod_sftp` cases.