### PR TITLE
Issue #1410: When handling unknown SSH messages, implement the RFC-co…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,8 @@
   data connection.
 - Issue 1396 - ProFTPD always uses the same PassivePorts port for first
   transfer.
+- Issue 1410 - mod_sftp needs to handle unknown SSH messages in an
+  RFC-compliant manner, ignoring rather than disconnecting.
 
 1.3.8rc2 - Released 29-Aug-2021
 --------------------------------


### PR DESCRIPTION
…mpliant behavior of responding with `UNIMPLEMENTED` and otherwise ignoring them, rather than disconnecting the client.