### PR TITLE
Issue #1411: When the OpenSSH AES-GCM cipher is used, there is no MAC…

### DIFF
--- a/contrib/mod_sftp/mac.c
+++ b/contrib/mod_sftp/mac.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp MACs
- * Copyright (c) 2008-2021 TJ Saunders
+ * Copyright (c) 2008-2022 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -694,7 +694,11 @@ const char *sftp_mac_get_read_algo(void) {
     return read_macs[read_mac_idx].algo;
   }
 
-  return NULL;
+  /* It is possible for there to be no MAC, as for some ciphers such as
+   * AES-GCM.  Rather than returning NULL here, we indicate this by returning
+   * the empty string (see Issue #1411).
+   */
+  return "";
 }
 
 int sftp_mac_is_read_etm(void) {
@@ -868,7 +872,11 @@ const char *sftp_mac_get_write_algo(void) {
     return write_macs[write_mac_idx].algo;
   }
 
-  return NULL;
+  /* It is possible for there to be no MAC, as for some ciphers such as
+   * AES-GCM.  Rather than returning NULL here, we indicate this by returning
+   * the empty string (see Issue #1411).
+   */
+  return "";
 }
 
 int sftp_mac_is_write_etm(void) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -257,12 +257,12 @@ my $TESTS = {
     test_class => [qw(forking ssh2)],
   },
 
-  ssh2_ext_cipher_aes128_gcm => {
+  ssh2_ext_cipher_aes128_gcm_bug3759 => {
     order => ++$order,
     test_class => [qw(forking ssh2)],
   },
 
-  ssh2_ext_cipher_aes256_gcm => {
+  ssh2_ext_cipher_aes256_gcm_bug3759 => {
     order => ++$order,
     test_class => [qw(forking ssh2)],
   },
@@ -9530,7 +9530,7 @@ sub ssh2_cipher_s2c_none {
   unlink($log_file);
 }
 
-sub ssh2_ext_cipher_aes128_gcm {
+sub ssh2_ext_cipher_aes128_gcm_bug3759 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'sftp');
@@ -9699,7 +9699,7 @@ sub ssh2_ext_cipher_aes128_gcm {
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub ssh2_ext_cipher_aes256_gcm {
+sub ssh2_ext_cipher_aes256_gcm_bug3759 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'sftp');


### PR DESCRIPTION
…; we thus need to provide a non-NULL pointer for such cases.