### PR TITLE
Issue #1403: If we cannot determine the local character set for any r…

### DIFF
--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -2,7 +2,7 @@
  * ProFTPD: mod_sql -- SQL frontend
  * Copyright (c) 1998-1999 Johnie Ingram.
  * Copyright (c) 2001 Andrew Houghton.
- * Copyright (c) 2004-2021 TJ Saunders
+ * Copyright (c) 2004-2022 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1032,13 +1032,13 @@ static int sql_resolve_on_default(pool *p, pr_jot_ctx_t *jot_ctx,
         text_len = strlen(text);
         break;
 
+      case LOGFMT_META_BYTES_SENT:
       case LOGFMT_META_SECONDS:
         text = "0.0";
         text_len = strlen(text);
         break;
 
       case LOGFMT_META_BASENAME:
-      case LOGFMT_META_BYTES_SENT:
       case LOGFMT_META_CLASS:
       case LOGFMT_META_FILENAME:
       case LOGFMT_META_FILE_OFFSET:

--- a/contrib/mod_sql_mysql.c
+++ b/contrib/mod_sql_mysql.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_sql_mysql -- Support for connecting to MySQL databases.
  * Copyright (c) 2001 Andrew Houghton
- * Copyright (c) 2004-2021 TJ Saunders
+ * Copyright (c) 2004-2022 TJ Saunders
  *  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -416,10 +416,10 @@ MODRET cmd_open(cmd_rec *cmd) {
   conn_entry_t *entry = NULL;
   db_conn_t *conn = NULL;
   unsigned long client_flags = CLIENT_INTERACTIVE;
-#ifdef PR_USE_NLS
+#if defined(PR_USE_NLS)
   const char *encoding = NULL;
-#endif
-#ifdef HAVE_MYSQL_MYSQL_GET_SSL_CIPHER
+#endif /* PR_USE_NLS */
+#if defined(HAVE_MYSQL_MYSQL_GET_SSL_CIPHER)
   const char *ssl_cipher = NULL;
 #endif
 
@@ -598,73 +598,73 @@ MODRET cmd_open(cmd_rec *cmd) {
 
 #if defined(PR_USE_NLS)
   encoding = pr_encode_get_encoding();
-  if (encoding != NULL) {
+  if (encoding == NULL) {
+    encoding = "UTF-8";
+  }
 
 # if MYSQL_VERSION_ID >= 50007
-    /* Configure the connection for the current local character set.
-     *
-     * Note: the mysql_set_character_set() function appeared in MySQL 5.0.7,
-     * as per:
-     *
-     *  http://dev.mysql.com/doc/refman/5.0/en/mysql-set-character-set.html
-     *
-     * Yes, even though the variable names say "charset", we (and MySQL,
-     * though their documentation says otherwise) actually mean "encoding".
-     */
+  /* Configure the connection for the current local character set.
+   *
+   * Note: the mysql_set_character_set() function appeared in MySQL 5.0.7,
+   * as per:
+   *
+   *  http://dev.mysql.com/doc/refman/5.0/en/mysql-set-character-set.html
+   *
+   * Yes, even though the variable names say "charset", we (and MySQL,
+   * though their documentation says otherwise) actually mean "encoding".
+   */
 
-     if (strcasecmp(encoding, "UTF-8") == 0) {
+  if (strcasecmp(encoding, "UTF-8") == 0) {
 #  if MYSQL_VERSION_ID >= 50503
-       /* MySQL prefers the name "utf8mb4", not "UTF-8" */
-       encoding = pstrdup(cmd->tmp_pool, "utf8mb4");
+    /* MySQL prefers the name "utf8mb4", not "UTF-8" */
+    encoding = pstrdup(cmd->tmp_pool, "utf8mb4");
 #  else
-       /* MySQL prefers the name "utf8", not "UTF-8" */
-       encoding = pstrdup(cmd->tmp_pool, "utf8");
+    /* MySQL prefers the name "utf8", not "UTF-8" */
+    encoding = pstrdup(cmd->tmp_pool, "utf8");
 #  endif /* MySQL before 5.5.3 */
-     }
+  }
 
-    if (mysql_set_character_set(conn->mysql, encoding) != 0) {
-      /* Failing to set the character set should NOT be a fatal error.
-       * There are situations where, due to client/server mismatch, the
-       * requested character set may not be available.  Thus for now,
-       * we simply log the failure.
-       *
-       * A future improvement might be to implement fallback behavior,
-       * trying to set "older" character sets as needed.
-       */
-      sql_log(DEBUG_FUNC, MOD_SQL_MYSQL_VERSION
-        ": failed to set character set '%s': %s (%u)", encoding,
-        mysql_error(conn->mysql), mysql_errno(conn->mysql));
-    }
+  if (mysql_set_character_set(conn->mysql, encoding) != 0) {
+    /* Failing to set the character set should NOT be a fatal error.
+     * There are situations where, due to client/server mismatch, the
+     * requested character set may not be available.  Thus for now,
+     * we simply log the failure.
+     *
+     * A future improvement might be to implement fallback behavior,
+     * trying to set "older" character sets as needed.
+     */
+    sql_log(DEBUG_FUNC, MOD_SQL_MYSQL_VERSION
+      ": failed to set character set '%s': %s (%u)", encoding,
+      mysql_error(conn->mysql), mysql_errno(conn->mysql));
+  }
 
-    sql_log(DEBUG_FUNC, "MySQL connection character set now '%s' (from '%s')",
-      mysql_character_set_name(conn->mysql), pr_encode_get_encoding());
+  sql_log(DEBUG_FUNC, "MySQL connection character set now '%s' (from '%s')",
+    mysql_character_set_name(conn->mysql), encoding);
 
 # else
-    /* No mysql_set_character_set() API available.  But
-     * mysql_character_set_name() has been around for a while; we can use it
-     * to at least see whether there might be a character set discrepancy.
-     */
+  /* No mysql_set_character_set() API available.  But
+   * mysql_character_set_name() has been around for a while; we can use it
+   * to at least see whether there might be a character set discrepancy.
+   */
+  const char *local_charset = pr_encode_get_encoding();
+  const char *mysql_charset = mysql_character_set_name(conn->mysql);
 
-    const char *local_charset = pr_encode_get_encoding();
-    const char *mysql_charset = mysql_character_set_name(conn->mysql);
-
-    if (strcasecmp(mysql_charset, "utf8") == 0) {
-      mysql_charset = pstrdup(cmd->tmp_pool, "UTF-8");
-    }
-
-    if (local_charset &&
-        mysql_charset &&
-        strcasecmp(local_charset, mysql_charset) != 0) {
-      pr_log_pri(PR_LOG_ERR, MOD_SQL_MYSQL_VERSION
-        ": local character set '%s' does not match MySQL character set '%s', "
-        "SQL injection possible, shutting down", local_charset, mysql_charset);
-      sql_log(DEBUG_WARN, "local character set '%s' does not match MySQL "
-        "character set '%s', SQL injection possible, shutting down",
-        local_charset, mysql_charset);
-      pr_session_end(0);
-    }
-# endif /* older MySQL */
+  if (strcasecmp(mysql_charset, "utf8") == 0) {
+    mysql_charset = pstrdup(cmd->tmp_pool, "UTF-8");
   }
+
+  if (local_charset != NULL &&
+      mysql_charset != NULL &&
+      strcasecmp(local_charset, mysql_charset) != 0) {
+    pr_log_pri(PR_LOG_ERR, MOD_SQL_MYSQL_VERSION
+      ": local character set '%s' does not match MySQL character set '%s', "
+      "SQL injection possible, shutting down", local_charset, mysql_charset);
+    sql_log(DEBUG_WARN, "local character set '%s' does not match MySQL "
+      "character set '%s', SQL injection possible, shutting down",
+      local_charset, mysql_charset);
+    pr_session_end(0);
+  }
+# endif /* older MySQL */
 #endif /* !PR_USE_NLS */
 
   /* bump connections */

--- a/contrib/mod_sql_postgres.c
+++ b/contrib/mod_sql_postgres.c
@@ -375,6 +375,9 @@ MODRET cmd_open(cmd_rec *cmd) {
   conn_entry_t *entry = NULL;
   db_conn_t *conn = NULL;
   const char *server_version = NULL;
+#if defined(PR_USE_NLS)
+  const char *encoding = NULL;
+#endif /* PR_USE_NLS */
 
   sql_log(DEBUG_FUNC, "%s", "entering \tpostgres cmd_open");
 
@@ -496,21 +499,23 @@ MODRET cmd_open(cmd_rec *cmd) {
   }
 
 #if defined(PR_USE_NLS)
-  if (pr_encode_get_encoding() != NULL) {
-    const char *encoding;
-
+  encoding = pr_encode_get_encoding();
+  if (encoding != NULL) {
     encoding = get_postgres_encoding(pr_encode_get_encoding());
 
-    /* Configure the connection for the current local character set. */
-    if (PQsetClientEncoding(conn->postgres, encoding) < 0) {
-      sql_log(DEBUG_FUNC, "%s", "exiting \tpostgres cmd_open");
-      return build_error(cmd, conn);
-    }
-
-    sql_log(DEBUG_FUNC, "Postgres connection character set now '%s' "
-      "(from '%s')", pg_encoding_to_char(PQclientEncoding(conn->postgres)),
-      pr_encode_get_encoding());
+  } else {
+    encoding = "UTF8";
   }
+
+  /* Configure the connection for the current local character set. */
+  if (PQsetClientEncoding(conn->postgres, encoding) < 0) {
+    sql_log(DEBUG_FUNC, "%s", "exiting \tpostgres cmd_open");
+    return build_error(cmd, conn);
+  }
+
+  sql_log(DEBUG_FUNC, "Postgres connection character set now '%s' "
+    "(from '%s')", pg_encoding_to_char(PQclientEncoding(conn->postgres)),
+    encoding);
 #endif /* !PR_USE_NLS */
 
 #if defined(HAVE_POSTGRES_PQGETSSL)

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -3327,7 +3327,7 @@ int pr_fs_use_encoding(int bool) {
 }
 
 char *pr_fs_decode_path2(pool *p, const char *path, int flags) {
-#ifdef PR_USE_NLS
+#if defined(PR_USE_NLS)
   size_t outlen;
   char *res;
 
@@ -3337,7 +3337,7 @@ char *pr_fs_decode_path2(pool *p, const char *path, int flags) {
     return NULL;
   }
 
-  if (!use_encoding) {
+  if (use_encoding == FALSE) {
     return (char *) path;
   }
 
@@ -3355,11 +3355,11 @@ char *pr_fs_decode_path2(pool *p, const char *path, int flags) {
       size_t pathlen, raw_pathlen;
 
       pathlen = strlen(path);
-      raw_pathlen = (pathlen * 5) + 1;
+      raw_pathlen = (pathlen * 8) + 1;
       raw_path = pcalloc(p, raw_pathlen + 1);
 
       for (i = 0; i < pathlen; i++) {
-        pr_snprintf((char *) (raw_path + (i * 5)), (raw_pathlen - 1) - (i * 5),
+        pr_snprintf((char *) (raw_path + (i * 8)), (raw_pathlen - 1) - (i * 8),
           "0x%02x ", (unsigned char) path[i]);
       }
 
@@ -3430,11 +3430,11 @@ char *pr_fs_encode_path(pool *p, const char *path) {
       size_t pathlen, raw_pathlen;
       
       pathlen = strlen(path);
-      raw_pathlen = (pathlen * 5) + 1;
+      raw_pathlen = (pathlen * 8) + 1;
       raw_path = pcalloc(p, raw_pathlen + 1);
 
       for (i = 0; i < pathlen; i++) {
-        pr_snprintf((char *) (raw_path + (i * 5)), (raw_pathlen - 1) - (i * 5),
+        pr_snprintf((char *) (raw_path + (i * 8)), (raw_pathlen - 1) - (i * 8),
           "0x%02x ", (unsigned char) path[i]);
       }
 


### PR DESCRIPTION
…eason, when NLS support is enabled, assume UTF8 for our database connections.