### PR TITLE
Issue #1369: If we encounter a <VirtualHost> that uses the `ServerAli…

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -1538,6 +1538,8 @@ static void trace_ipbind_table(void) {
           namebind = elts[k];
           pr_trace_msg(trace_channel, 25, "      #%u: %p", k+1, namebind);
           pr_trace_msg(trace_channel, 25, "        name: %s",
+            namebind->nb_server->ServerName);
+          pr_trace_msg(trace_channel, 25, "        alias: %s",
             namebind->nb_name);
           pr_trace_msg(trace_channel, 25, "        server: %p",
             namebind->nb_server);

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -2548,9 +2548,16 @@ int fixup_servers(xaset_t *list) {
   fixup_globals(list);
 
   s = (server_rec *) list->xas_list;
+
   if (s != NULL &&
       s->ServerName == NULL) {
-    s->ServerName = pstrdup(s->pool, "ProFTPD");
+    c = find_config(s->conf, CONF_PARAM, "ServerAlias", FALSE);
+    if (c != NULL) {
+      s->ServerName = pstrdup(s->pool, c->argv[0]);
+
+    } else {
+      s->ServerName = pstrdup(s->pool, "ProFTPD");
+    }
   }
 
   for (; s; s = next_s) {
@@ -2626,8 +2633,16 @@ int fixup_servers(xaset_t *list) {
     }
 
     if (s->ServerName == NULL) {
-      server_rec *m = (server_rec *) list->xas_list;
-      s->ServerName = pstrdup(s->pool, m->ServerName);
+      c = find_config(s->conf, CONF_PARAM, "ServerAlias", FALSE);
+      if (c != NULL) {
+        s->ServerName = pstrdup(s->pool, c->argv[0]);
+
+      } else {
+        server_rec *m;
+
+        m = (server_rec *) list->xas_list;
+        s->ServerName = pstrdup(s->pool, m->ServerName);
+      }
     }
 
     if (s->tcp_rcvbuf_len == 0) {


### PR DESCRIPTION
…as` directive, but does not have an explicit `ServerName`, then use the first `ServerAlias` as the `ServerName`.