### PR TITLE
Add detailed error message for pr_display_file()

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -447,12 +447,16 @@ int pr_display_file(const char *path, const char *fs, const char *resp_code,
 
   fh = pr_fsio_open_canon(path, O_RDONLY);
   if (fh == NULL) {
+    pr_log_debug(DEBUG6, "unable to open file '%s': %s",
+      path, strerror(errno));
     return -1;
   }
 
   res = pr_fsio_fstat(fh, &st);
   if (res < 0) {
     xerrno = errno;
+    pr_log_debug(DEBUG6, "unable to stat file '%s': %s",
+      path, strerror(errno));
 
     pr_fsio_close(fh);
 
@@ -463,6 +467,8 @@ int pr_display_file(const char *path, const char *fs, const char *resp_code,
   if (S_ISDIR(st.st_mode)) {
     pr_fsio_close(fh);
     errno = EISDIR;
+    pr_log_debug(DEBUG6, "display file can not be a directory '%s': %s",
+      path, strerror(errno));
     return -1;
   }
 

--- a/src/display.c
+++ b/src/display.c
@@ -447,16 +447,19 @@ int pr_display_file(const char *path, const char *fs, const char *resp_code,
 
   fh = pr_fsio_open_canon(path, O_RDONLY);
   if (fh == NULL) {
-    pr_log_debug(DEBUG6, "unable to open file '%s': %s",
-      path, strerror(errno));
+    xerrno = errno;
+    pr_trace_msg("display", 4, "unable to open file '%s': %s",
+      path, strerror(xerrno));
+
+    errno = xerrno;
     return -1;
   }
 
   res = pr_fsio_fstat(fh, &st);
   if (res < 0) {
     xerrno = errno;
-    pr_log_debug(DEBUG6, "unable to stat file '%s': %s",
-      path, strerror(errno));
+    pr_trace_msg("display", 4, "unable to stat file '%s': %s",
+      path, strerror(xerrno));
 
     pr_fsio_close(fh);
 
@@ -466,9 +469,11 @@ int pr_display_file(const char *path, const char *fs, const char *resp_code,
 
   if (S_ISDIR(st.st_mode)) {
     pr_fsio_close(fh);
-    errno = EISDIR;
-    pr_log_debug(DEBUG6, "display file can not be a directory '%s': %s",
-      path, strerror(errno));
+    xerrno = EISDIR;
+
+    pr_trace_msg("display", 4, "display file can not be a directory '%s': %s",
+      path, strerror(xerrno));
+    errno = xerrno;
     return -1;
   }
 


### PR DESCRIPTION
pr_display_file() could fail for multiple reasons; adding detailed log messages would help admins debugging the error.