### PR TITLE
Update PR_SCORE_XFER_DONE in pr_throttle_pause

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,7 @@
   to `EVP_MD_CTX_reset'.
 - Issue 1476 - Reload after omitting explicit ModulePath value causes fatal
   module load failures.
+- Issue 1433 - Update PR_SCORE_XFER_DONE in pr_throttle_pause
 
 1.3.8rc3 - Released 23-Apr-2022
 --------------------------------

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -10257,7 +10257,7 @@ static int fxp_handle_read(struct fxp_packet *fxp) {
 
     } else {
       /* Assume EOF */
-      pr_throttle_pause(offset, TRUE);
+      pr_throttle_pause(offset, TRUE, 0);
       xerrno = EOF;
     }
 
@@ -10284,7 +10284,7 @@ static int fxp_handle_read(struct fxp_packet *fxp) {
     return fxp_packet_write(resp);
   }
 
-  pr_throttle_pause(offset, FALSE);
+  pr_throttle_pause(offset, FALSE, 0);
 
   pr_trace_msg(trace_channel, 8, "sending response: DATA (%lu bytes)",
     (unsigned long) res);
@@ -13205,7 +13205,7 @@ static int fxp_handle_write(struct fxp_packet *fxp) {
     pr_timer_reset(PR_TIMER_STALLED, ANY_MODULE);
   }
 
-  pr_throttle_pause(offset, FALSE);
+  pr_throttle_pause(offset, FALSE, 0);
 
   if (res < 0) {
     const char *reason;

--- a/contrib/mod_sftp/scp.c
+++ b/contrib/mod_sftp/scp.c
@@ -1188,13 +1188,13 @@ static int recv_data(pool *p, uint32_t channel_id, struct scp_path *sp,
           "receiving file data, received '%c'", data[writelen]);
       }
 
-      pr_throttle_pause(sp->recvlen, TRUE);
+      pr_throttle_pause(sp->recvlen, TRUE, 0);
 
       sp->recvd_data = TRUE;
       return 1;
     }
 
-    pr_throttle_pause(sp->recvlen, FALSE);
+    pr_throttle_pause(sp->recvlen, FALSE, 0);
 
   } else {
     /* We should have just one extra end-of-stream byte. */
@@ -1203,7 +1203,7 @@ static int recv_data(pool *p, uint32_t channel_id, struct scp_path *sp,
         "receiving file data, received '%c'", data[writelen]);
     }
 
-    pr_throttle_pause(sp->recvlen, TRUE);
+    pr_throttle_pause(sp->recvlen, TRUE, 0);
 
     sp->recvd_data = TRUE;
     return 1;
@@ -1845,10 +1845,10 @@ static int send_data(pool *p, uint32_t channel_id, struct scp_path *sp,
       chunk[chunklen++] = '\0';
       need_confirm = TRUE;
 
-      pr_throttle_pause(sp->sentlen, TRUE);
+      pr_throttle_pause(sp->sentlen, TRUE, 0);
 
     } else {
-      pr_throttle_pause(sp->sentlen, FALSE);
+      pr_throttle_pause(sp->sentlen, FALSE, 0);
     }
 
     pr_trace_msg(trace_channel, 3, "sending '%s' data (%lu bytes)", sp->path,

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -29,6 +29,6 @@
 
 int pr_throttle_have_rate(void);
 void pr_throttle_init(cmd_rec *);
-void pr_throttle_pause(off_t, int);
+void pr_throttle_pause(off_t, int, off_t);
 
 #endif /* PR_THROTTLE_H */

--- a/src/throttle.c
+++ b/src/throttle.c
@@ -209,7 +209,7 @@ void pr_throttle_init(cmd_rec *cmd) {
   }
 }
 
-void pr_throttle_pause(off_t xferlen, int xfer_ending) {
+void pr_throttle_pause(off_t xferlen, int force_scoreboard_update, off_t xfer_done) {
   long ideal = 0, elapsed = 0;
   off_t orig_xferlen = xferlen;
 
@@ -224,11 +224,12 @@ void pr_throttle_pause(off_t xferlen, int xfer_ending) {
   if (!have_xfer_rate) {
     xfer_rate_scoreboard_updates++;
 
-    if (xfer_ending ||
+    if (force_scoreboard_update ||
         xfer_rate_scoreboard_updates % PR_TUNABLE_XFER_SCOREBOARD_UPDATES == 0) {
       /* Update the scoreboard. */
       pr_scoreboard_entry_update(session.pid,
         PR_SCORE_XFER_LEN, orig_xferlen,
+        PR_SCORE_XFER_DONE, xfer_done,
         PR_SCORE_XFER_ELAPSED, (unsigned long) elapsed,
         NULL);
 
@@ -255,10 +256,11 @@ void pr_throttle_pause(off_t xferlen, int xfer_ending) {
        * update the scoreboard -- no throttling needed.
        */
 
-      if (xfer_ending ||
+      if (force_scoreboard_update ||
           xfer_rate_scoreboard_updates % PR_TUNABLE_XFER_SCOREBOARD_UPDATES == 0) {
         pr_scoreboard_entry_update(session.pid,
           PR_SCORE_XFER_LEN, orig_xferlen,
+          PR_SCORE_XFER_DONE, xfer_done,
           PR_SCORE_XFER_ELAPSED, (unsigned long) elapsed,
           NULL);
 
@@ -314,6 +316,7 @@ void pr_throttle_pause(off_t xferlen, int xfer_ending) {
     /* Update the scoreboard. */
     pr_scoreboard_entry_update(session.pid,
       PR_SCORE_XFER_LEN, orig_xferlen,
+      PR_SCORE_XFER_DONE, xfer_done,
       PR_SCORE_XFER_ELAPSED, (unsigned long) ideal,
       NULL);
 
@@ -321,6 +324,7 @@ void pr_throttle_pause(off_t xferlen, int xfer_ending) {
     /* Update the scoreboard. */
     pr_scoreboard_entry_update(session.pid,
       PR_SCORE_XFER_LEN, orig_xferlen,
+      PR_SCORE_XFER_DONE, xfer_done,
       PR_SCORE_XFER_ELAPSED, (unsigned long) elapsed,
       NULL);
   }


### PR DESCRIPTION
This has numerous advantages:

- Update the scoreboard in a single call making xfer_done and elasped_time come
  from the same moment and reducing scoreboard update overhead
- Eliminates excessive XFER_DONE updates in scoreboard, old code updated it
  after every block
- During FTP uploads the number of received bytes also get updated in XFER_DONE
  making ftpwho -o json display "transfer_bytes" for uploads as well

Signed-off-by: Marton Balint <cus@passwd.hu>