### PR TITLE
Issue #1434: Add a conformance check to mod_sftp such that, on startu…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,11 @@
   where `N' is the issue number.
 -----------------------------------------------------------------------------
 
+1.3.8rc4
+--------------------------------
+- Issue 1434 - mod_sftp should fail on startup when SFTP and TLS are both
+  enabled for a vhost.
+
 1.3.8rc3 - Released 23-Apr-2022
 --------------------------------
 - Issue 1323 - Support SSH hostkey rotation via OpenSSH extensions.


### PR DESCRIPTION
…p, if we detect both `SFTPEngine on` _and_ `TLSEngine on` in effect for the same vhost, we fail the startup.