### PR TITLE
Treat the loopback/host address range 127.0.0.0/8 as private addresses,

### DIFF
--- a/include/netaddr.h
+++ b/include/netaddr.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2003-2021 The ProFTPD Project team
+ * Copyright (c) 2003-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -417,6 +417,9 @@ int pr_netaddr_is_loopback(const pr_netaddr_t *);
 /* Returns TRUE if the given pr_netaddr_t contains an RFC1918 address,
  * FALSE otherwise.  Note that -1 will be returned if there was an error,
  * with errno set appropriately.
+ *
+ * Note that host/loopback addresses (127.0.0.0/8) will also be treated
+ * as "private", just like RFC1918 addresses, as well.
  */
 int pr_netaddr_is_rfc1918(const pr_netaddr_t *);
 

--- a/tests/api/netaddr.c
+++ b/tests/api/netaddr.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2008-2021 The ProFTPD Project team
+ * Copyright (c) 2008-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1261,13 +1261,12 @@ START_TEST (netaddr_is_rfc1918_test) {
   fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);
-  fail_unless(res == FALSE, "Failed to handle non-RFC1918 IPv4 address");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
-    strerror(errno), errno);
+  fail_unless(res == TRUE, "Expected 'true' for private/loopback address '%s'",
+    name);
 
   name = "::1";
   addr = pr_netaddr_get_addr(p, name, NULL);
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   fail_unless(addr != NULL, "Failed to get addr for '%s': %s", name,
     strerror(errno));
   res = pr_netaddr_is_rfc1918(addr);


### PR DESCRIPTION
just like RFC1918 addresses.