### PR TITLE
Issue #1451: Build the `auth-otp` utility, for `mod_auth_otp`, at bui…

### DIFF
--- a/contrib/mod_auth_otp/Makefile.in
+++ b/contrib/mod_auth_otp/Makefile.in
@@ -33,7 +33,7 @@ LDFLAGS=-L../../lib @LDFLAGS@
 .c.lo:
 	$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CPPFLAGS) $(CFLAGS) $(SHARED_CFLAGS) -c $<
 
-shared: $(SHARED_MODULE_OBJS)
+shared: $(SHARED_MODULE_OBJS) auth-otp$(EXEEXT)
 	$(LIBTOOL) --mode=link --tag=CC $(CC) -o $(MODULE_NAME).la $(SHARED_MODULE_OBJS) -rpath $(LIBEXECDIR) $(LDFLAGS) $(SHARED_LDFLAGS) $(SHARED_MODULE_LIBS) `cat $(top_srcdir)/$(MODULE_NAME).c | grep '$$Libraries:' | sed -e 's/^.*\$$Libraries: \(.*\)\\$$/\1/'`
 
 static: $(MODULE_OBJS) auth-otp$(EXEEXT)
@@ -62,7 +62,7 @@ install-headers: $(DESTDIR)$(includedir)/proftpd
 install-man: $(DESTDIR)$(mandir) $(DESTDIR)$(mandir)/man8
 	$(INSTALL_MAN) $(top_srcdir)/auth-otp.8 $(DESTDIR)$(mandir)/man8
 
-install-utils: $(DESTDIR)$(sbindir) auth-otp$(EXEEXT)
+install-utils: $(DESTDIR)$(sbindir)
 	$(INSTALL_BIN) auth-otp$(EXEEXT) $(DESTDIR)$(sbindir)/auth-otp$(EXEEXT)
 
 clean:


### PR DESCRIPTION
…ld time rather than install time, when building the module as a shared module.

We already build `auth-otp` at build time when building as a static module;
I'm not sure why we didn't do this at build time for the shared module case,
too.