### PR TITLE
When tracing/handling SSH sessions that use "implicit" MACs, make sur…

### DIFF
--- a/contrib/mod_sftp/mac.c
+++ b/contrib/mod_sftp/mac.c
@@ -690,7 +690,8 @@ void sftp_mac_set_block_size(size_t blocksz) {
 
 const char *sftp_mac_get_read_algo(void) {
   if (read_macs[read_mac_idx].key != NULL ||
-      strcmp(read_macs[read_mac_idx].algo, "none") == 0) {
+      (read_macs[read_mac_idx].algo != NULL &&
+       strcmp(read_macs[read_mac_idx].algo, "none") == 0)) {
     return read_macs[read_mac_idx].algo;
   }
 
@@ -868,7 +869,9 @@ int sftp_mac_read_data(struct ssh2_packet *pkt) {
 }
 
 const char *sftp_mac_get_write_algo(void) {
-  if (write_macs[write_mac_idx].key) {
+  if (write_macs[write_mac_idx].key != NULL ||
+      (write_macs[write_mac_idx].algo != NULL &&
+       strcmp(write_macs[write_mac_idx].algo, "none") == 0)) {
     return write_macs[write_mac_idx].algo;
   }
 


### PR DESCRIPTION
…e we check for cases where the MAC algorithm is not set (as expected), and avoid null pointer dereferences in such cases.