### PR TITLE
Since we are now skipping setting a string for the MAC algorithm, for…

### DIFF
--- a/contrib/mod_sftp/crypto.c
+++ b/contrib/mod_sftp/crypto.c
@@ -1063,6 +1063,11 @@ const EVP_CIPHER *sftp_crypto_get_cipher(const char *name, size_t *key_len,
     size_t *auth_len, size_t *discard_len) {
   register unsigned int i;
 
+  if (name == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
   for (i = 0; ciphers[i].name; i++) {
     if (strcmp(ciphers[i].name, name) == 0) {
       const EVP_CIPHER *cipher;
@@ -1149,6 +1154,11 @@ const EVP_CIPHER *sftp_crypto_get_cipher(const char *name, size_t *key_len,
 
 const EVP_MD *sftp_crypto_get_digest(const char *name, uint32_t *mac_len) {
   register unsigned int i;
+
+  if (name == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
 
   for (i = 0; digests[i].name; i++) {
     if (strcmp(digests[i].name, name) == 0) {

--- a/contrib/mod_sftp/mac.c
+++ b/contrib/mod_sftp/mac.c
@@ -697,9 +697,9 @@ const char *sftp_mac_get_read_algo(void) {
 
   /* It is possible for there to be no MAC, as for some ciphers such as
    * AES-GCM.  Rather than returning NULL here, we indicate this by returning
-   * the empty string (see Issue #1411).
+   * a string (see Issue #1411).
    */
-  return "";
+  return "implicit";
 }
 
 int sftp_mac_is_read_etm(void) {
@@ -877,9 +877,9 @@ const char *sftp_mac_get_write_algo(void) {
 
   /* It is possible for there to be no MAC, as for some ciphers such as
    * AES-GCM.  Rather than returning NULL here, we indicate this by returning
-   * the empty string (see Issue #1411).
+   * a string (see Issue #1411).
    */
-  return "";
+  return "implicit";
 }
 
 int sftp_mac_is_write_etm(void) {


### PR DESCRIPTION
… ciphers

where the MAC is implicit, we are uncovering null pointer dereferences causing
crashes, such as this one.