### PR TITLE
Bug 4485: Fix build-time regression by ensuring that `mod_sftp` can b…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,8 @@
 - Issue 1437 - Implement the "curve448-sha512" SSH key exchange algorithm.
 - Issue 1472 - Include directive broken when using wildcards for directory
   components.
+- Bug 4485 - mod_sftp fails to build using OpenSSL 1.0.x: undefined reference
+  to `EVP_MD_CTX_reset'.
 
 1.3.8rc3 - Released 23-Apr-2022
 --------------------------------

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -4418,7 +4418,13 @@ static int fxp_handle_ext_check_file(struct fxp_packet *fxp, char *digest_list,
     unsigned int digest_len = 0;
 
     pr_signals_handle();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(HAVE_LIBRESSL)
+    EVP_MD_CTX_cleanup(pctx);
+    EVP_MD_CTX_init(pctx);
+#else
     EVP_MD_CTX_reset(pctx);
+#endif /* prior to OpenSSL-1.1.0 */
     EVP_DigestInit(pctx, md);
 
     pr_trace_msg(trace_channel, 19,


### PR DESCRIPTION
…e built against older OpenSSL versions.