### PR TITLE
Fixes typo in mod_tls.html

### DIFF
--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -566,7 +566,7 @@ Example:
 
 <p>
 <hr>
-<h3><a name="TLSECCertficateFile">TLSECCertficateFile</a></h3>
+<h3><a name="TLSECCertificateFile">TLSECCertificateFile</a></h3>
 <strong>Syntax:</strong> TLSECCertificateFile <em>file</em><br>
 <strong>Default:</strong> None<br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>


### PR DESCRIPTION
Fixes a typo in mod_tls.html. 

proftpd[43617]: fatal: unknown configuration directive 'TLSECCertficateFile' on line 9 of 'conf.d/proftpdTLS.conf'
proftpd[43617]: fatal: Did you mean:
  TLSECCertificateFile
  TLSECCertificateKeyFile