### PR TITLE
While trying to build 1.3.8rc4 on Solaris I've found out we are

### DIFF
--- a/include/openbsd-blowfish.h
+++ b/include/openbsd-blowfish.h
@@ -41,6 +41,22 @@
 #define BLF_MAXKEYLEN ((BLF_N-2)*4)	/* 448 bits */
 #define BLF_MAXUTILIZED ((BLF_N+2)*4)	/* 576 bits */
 
+#ifdef	SOLARIS2
+
+#ifndef	u_int32_t
+#define	u_int32_t	uint32_t
+#endif
+
+#ifndef	u_int16_t
+#define	u_int16_t	uint16_t
+#endif
+
+#ifndef	u_int8_t
+#define	u_int8_t	uint8_t
+#endif
+
+#endif
+
 /* Blowfish context */
 typedef struct BlowfishContext {
 	u_int32_t S[4][256];	/* S-Boxes */


### PR DESCRIPTION
missing OpenBSD style of u_int*_t. The easiest way for me
to get forward was to apply small fix to include/openbsd-blowfish.h
to provide those aliases if they are undefined.