### PR TITLE
While working on integration tests for the `mod_enospc` module, which…

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -460,13 +460,13 @@ void pr_data_clear_xfer_pool(void) {
 }
 
 void pr_data_reset(void) {
-  if (session.d &&
-      session.d->pool) {
-    destroy_pool(session.d->pool);
-  }
-
   /* Clear any leftover state from previous transfers. */
   pr_ascii_ftp_reset();
+
+  if (session.d != NULL &&
+      session.d->pool != NULL) {
+    destroy_pool(session.d->pool);
+  }
 
   session.d = NULL;
   session.sf_flags &= (SF_ALL^(SF_ABORT|SF_POST_ABORT|SF_XFER|SF_PASSIVE|SF_ASCII_OVERRIDE|SF_EPSV_ALL));

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -5131,6 +5131,7 @@ int pr_fsio_close(pr_fh_t *fh) {
   if (fh->fh_pool != NULL) {
     destroy_pool(fh->fh_pool);
     fh->fh_pool = NULL;
+    fh->fh_path = NULL;
   }
 
   errno = xerrno;


### PR DESCRIPTION
… injects `ENOSPC` errors on _e.g._ uploads, I discovered some NULL pointer dereferences in the error handling code in `mod_xfer`; fix them.