### PR TITLE
the issue has been reported to upstream:

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
@@ -649,11 +649,12 @@ sub list_file_rel_paths_bug4259 {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       if ($ENV{TEST_VERBOSE}) {
         print STDERR "# response: $buf\n";
@@ -686,11 +687,12 @@ sub list_file_rel_paths_bug4259 {
 
       $buf = '';
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       if ($ENV{TEST_VERBOSE}) {
         print STDERR "# response: $buf\n";
@@ -832,11 +834,12 @@ sub list_file_after_upload {
       my $start = [gettimeofday()];
       my $buf = "ABCD" x 10240;
       $conn->write($buf, length($buf), 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       my $elapsed = tv_interval($start);
       if ($ENV{TEST_VERBOSE}) {
@@ -855,11 +858,12 @@ sub list_file_after_upload {
 
       $buf = '';
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -3542,11 +3546,12 @@ sub list_symlink_issue940 {
 
       $buf = '';
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       if ($ENV{TEST_VERBOSE}) {
         print STDERR "# RESPONSE:\n$buf\n";

--- a/tests/t/lib/ProFTPD/Tests/Commands/RANG.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RANG.pm
@@ -1102,11 +1102,11 @@ sub rang_retr_ok_with_sendfile {
 
       my $buf;
       my $len = $conn->read($buf, 1024);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       $self->assert($len == 3, "Expected len 3, got $len");
@@ -1200,11 +1200,11 @@ sub rang_retr_ok_no_sendfile {
 
       my $buf;
       my $len = $conn->read($buf, 1024);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       $self->assert($len == 3, "Expected len 3, got $len");
@@ -1297,11 +1297,11 @@ sub rang_retr_ok_end_exceeds_file_size {
 
       my $buf;
       my $len = $conn->read($buf, 1024);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       $self->assert($len == 14, "Expected len 14, got $len");

--- a/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
@@ -286,11 +286,12 @@ sub retr_ok_raw_active_multiple_downloads {
 
         my $buf;
         $conn->read($buf, 8192, 30);
-        eval { $conn->close() };
 
         my $resp_code = $client->response_code();
         my $resp_msg = $client->response_msg();
         $self->assert_transfer_ok($resp_code, $resp_msg);
+
+        eval { $conn->close() };
       }
 
       $client->quit();
@@ -374,13 +375,13 @@ sub retr_ok_raw_passive {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
     };
 
     if ($@) {
@@ -962,11 +963,13 @@ sub retr_abs_symlink {
       my $buf;
       $conn->read($buf, 8192, 30);
       my $size = $conn->bytes_read();
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
+
       $client->quit();
 
       my $expected = 5;
@@ -1200,11 +1203,11 @@ sub retr_rel_symlink {
       my $buf;
       $conn->read($buf, 8192, 30);
       my $size = $conn->bytes_read();
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       my $expected = 5;
@@ -2368,11 +2371,12 @@ sub retr_ok_dir_with_spaces {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
+
+      eval { $conn->close() };
 
       $self->assert_transfer_ok($resp_code, $resp_msg);
     };
@@ -2464,11 +2468,12 @@ sub retr_leading_whitespace {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
+
+      eval { $conn->close() };
 
       $self->assert_transfer_ok($resp_code, $resp_msg);
 

--- a/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
@@ -318,11 +318,12 @@ sub hiddenstores_bug3156 {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -1242,11 +1243,11 @@ sub hiddenstores_timeout_stalled_bug4035 {
         die("File $hidden_file exists unexpectedly");
       }
 
-      eval { $conn->close() };
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       eval { $client->quit() };
       unless ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
@@ -129,11 +129,12 @@ sub hidenoaccess_ok {
 
       my $buf;
       $conn->read($buf, 8192, 25);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
 
@@ -305,11 +306,12 @@ sub hidenoaccess_with_directory_glob {
 
       my $buf;
       $conn->read($buf, 8192, 25);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
 

--- a/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
@@ -826,13 +826,15 @@ sub listoptions_opt_1_nlst_complex_glob {
 
       my $buf;
       $conn->read($buf, 16384, 25);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
-      $client->quit();
 
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
+      $client->quit();
+
 
       # We have to be careful of the fact that readdir returns directory
       # entries in an unordered fashion.
@@ -1218,12 +1220,12 @@ sub listoptions_nlstonly {
 
       my $buf;
       $conn->read($buf, 16384, 25);
-      eval { $conn->close() };
       sleep(2);
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       # We have to be careful of the fact that readdir returns directory
@@ -1259,12 +1261,12 @@ sub listoptions_nlstonly {
 
       $buf = '';
       $conn->read($buf, 16384, 25);
-      eval { $conn->close() };
       sleep(2);
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
       $client->quit();
 
       # We have to be careful of the fact that readdir returns directory
@@ -1414,12 +1416,12 @@ sub listoptions_sortednlst_bug4267 {
         $tmp = '';
         $res = $conn->read($tmp, 8192, 5);
       }
-      eval { $conn->close() };
       sleep(2);
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+      eval { $conn->close() };
 
       if ($ENV{TEST_VERBOSE}) {
         print STDERR "buf:\n$buf\n";
@@ -1586,12 +1588,13 @@ sub listoptions_maxfiles {
         $buf .= $tmp;
       }
 
-      eval { $conn->close() };
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
 
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
+
       $client->quit();
 
       # We have to be careful of the fact that readdir returns directory
@@ -1723,11 +1726,11 @@ sub listoptions_nlstnamesonly_issue251 {
 
       my $buf;
       $conn->read($buf, 16384, 25);
-      eval { $conn->close() };
-
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
 

--- a/tests/t/lib/ProFTPD/Tests/Logging/TransferLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/TransferLog.pm
@@ -130,11 +130,12 @@ sub xferlog_retr_ascii_ok {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
     };
@@ -268,11 +269,12 @@ sub xferlog_retr_binary_ok {
 
       my $buf;
       $conn->read($buf, 8192, 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      eval { $conn->close() };
 
       $client->quit();
     };


### PR DESCRIPTION
https://github.com/proftpd/proftpd/issues/1499

it's not clear to me what's going on here.
the thing is we fail with error:
	not ok ERROR list_file_after_upload
	/usr/perl5/site_perl/5.32/Error.pm:461 - list_file_after_upload(ProFTPD::Tests::Commands::LIST)
	Expected response message 'Transfer complete', got 'Abort successful'

the session looks as follows:
	Net::FTP=GLOB(0x75a0cadb0)<<< 220 ProFTPD Server (ProFTPD) [127.0.0.1]
	Net::FTP=GLOB(0x75a0cadb0)>>> USER proftpd
	Net::FTP=GLOB(0x75a0cadb0)<<< 331 Password required for proftpd
	Net::FTP=GLOB(0x75a0cadb0)>>> PASS ....
	Net::FTP=GLOB(0x75a0cadb0)<<< 230 User proftpd logged in
	Net::FTP=GLOB(0x75a0cadb0)>>> TYPE I
	Net::FTP=GLOB(0x75a0cadb0)<<< 200 Type set to I
	# Logged in, sending STOR
	Net::FTP=GLOB(0x75a0cadb0)>>> PASV
	Net::FTP=GLOB(0x75a0cadb0)<<< 227 Entering Passive Mode (127,0,0,1,150,215).
	Net::FTP=GLOB(0x75a0cadb0)>>> STOR test.dat
	Net::FTP=GLOB(0x75a0cadb0)<<< 150 Opening BINARY mode data connection for test.dat
	# Data connection opened, writing data
	Net::FTP=GLOB(0x75a0cadb0)<<< 226 Transfer complete
	# elapsed upload duration: 0.002922
	# File uploaded, sending LIST
	Net::FTP=GLOB(0x75a0cadb0)>>> PASV
	Net::FTP=GLOB(0x75a0cadb0)<<< 227 Entering Passive Mode (127,0,0,1,163,192).
	Net::FTP=GLOB(0x75a0cadb0)>>> LIST /tmp/proftpd-test-15073-test5-7LQxGI14H1/test.dat
	Net::FTP=GLOB(0x75a0cadb0)<<< 150 Opening BINARY mode data connection for file list
	Net::FTP=GLOB(0x75a0cadb0)>>> ABOR
	Net::FTP=GLOB(0x75a0cadb0)<<< 226 Transfer complete
	Net::FTP=GLOB(0x75a0cadb0)<<< 226 Abort successful

the 'ABOR' command seems to be sent on behalf of
	eval { $conn->close() };
I don't know how to tell test to grab a 'Transfer complete'
in session record. not sure if moving conn->close() after
we read ret_code/ret_message is correct fix.

the measures range from slight code reshuffle (like to read response code before we call conn->close()/conn->abort(), adjusting expected value to take response to ABRT into account.

may be there is option to tune FTP client library, however I could not find it.

I have not checked other OS may be this ABRT is specific to Solaris.