### PR TITLE
we need to add a delay at least 5 second (we add 6 secs to

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
@@ -2575,6 +2575,7 @@ sub retr_bug3496 {
 
       # Close the _control_ connection immediately
       $client->{ftp}->close();
+      sleep(6);
 
       my $client2 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 1, 1);
       $client2->login($setup->{user}, $setup->{passwd});


### PR DESCRIPTION
get margin). I believe it may take up to 5 second for server
to detect command connection got closed while data were
in fly. In this period number of running instances is not dropped,
therefore new client can not connect (when MaxInstances is set to 1).