### PR TITLE
this workarounds broken Net::FTP libraray or whatever.

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
@@ -397,14 +397,22 @@ sub stou_ok_file {
 
       my $buf = "Foo!\n";
       $conn->write($buf, length($buf));
-      $conn->close();
 
       my ($resp_code, $resp_msg);
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-
       my $expected;
+      $expected = 150;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected $expected, got $resp_code"));
+      my $uniq_file;
+      if ($resp_msg =~ /^FILE:\s+(\S+)$/) {
+          $uniq_file = $1;
+      }
+      eval { $conn->close() };
 
+      $resp_code = $client->response_code();
+      $resp_msg = $client->response_msg();
       $expected = 226;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -413,7 +421,6 @@ sub stou_ok_file {
       $self->assert($expected eq $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
 
-      my $uniq_file = $client->response_uniq();
       $self->assert($uniq_file, test_msg("Expected non-null unique file"));
 
       my $test_file = "$home_dir/$uniq_file";
@@ -507,13 +514,23 @@ sub stou_file_umask_bug4223 {
 
       my $buf = "Foo!\n";
       $conn->write($buf, length($buf), 30);
-      eval { $conn->close() };
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
+      my $expected;
+      $expected = 150;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected $expected, got $resp_code"));
+      my $uniq_file;
+      if ($resp_msg =~ /^FILE:\s+(\S+)$/) {
+          $uniq_file = $1;
+      }
+      eval { $conn->close() };
+
+      $resp_code = $client->response_code();
+      $resp_msg = $client->response_msg();
       $self->assert_transfer_ok($resp_code, $resp_msg);
 
-      my $uniq_file = $client->response_uniq();
       $self->assert($uniq_file, test_msg("Expected non-null unique file"));
 
       my $test_file = File::Spec->rel2abs("$setup->{home_dir}/$uniq_file");

--- a/tests/t/lib/ProFTPD/Tests/Config/StoreUniquePrefix.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/StoreUniquePrefix.pm
@@ -113,13 +113,22 @@ sub storeuniqueprefix_ok {
 
       my $buf = "Hello, World!\n";
       $conn->write($buf, length($buf));
-      $conn->close();
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
 
       my $expected;
+      $expected = 150;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected $expected, got $resp_code"));
+      my $uniq_file;
+      if ($resp_msg =~ /^FILE:\s+(\S+)$/) {
+          $uniq_file = $1;
+      }
+      eval { $conn->close() };
 
+      $resp_code = $client->response_code();
+      $resp_msg = $client->response_msg();
       $expected = 226;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -127,8 +136,6 @@ sub storeuniqueprefix_ok {
       $expected = "Transfer complete";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
-
-      my $uniq_file = $client->response_uniq();
 
       $client->quit();
 


### PR DESCRIPTION
it looks like unit test relies on unique_name() method
which should return name generated by STOU command.
For reason unknown to me it does not work.
patch workarounds that using ret_code/ret_message

[1] https://perldoc.perl.org/Net::FTP#unique_name()