### PR TITLE
need to fix regular expression. Test fails on Solaris with

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Commands/STAT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STAT.pm
@@ -595,7 +595,12 @@ sub stat_symlink_showsymlinks_on {
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 
-      $expected = '.*?test\.d\/test\.lnk \-> test\.d\/test\.txt$';
+      $expected = '.*test\.d\/test\.lnk \-> \./test\.txt$';
+      if ($^O eq 'solaris') {
+        $expected = '.*test\.d\/test\.lnk \-> \./test\.txt$';
+      } else {
+        $expected = '.*?test\.d\/test\.lnk \-> test\.d\/test\.txt$';
+      }
       $self->assert(qr/$expected/, $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
     };


### PR DESCRIPTION
error:
	Expected: '.*?test\.d\/test\.lnk \-> test\.d\/test\.txt$',
	got:	  ' lrwxrwxrwx   1 anedvedi staff          10 Aug  9 23:42 test.d/test.lnk -> ./test.txt'

the thing we have './test.txt' instead of 'test.d/test.txt'