### PR TITLE
commit fixes 'include_directory_wildcard_issue1472' test case.

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -997,7 +997,7 @@ static int parse_wildcard_config_path(pool *p, const char *path,
    */
 
   parent_path = pstrdup(tmp_pool, "/");
-  component = path + 1;
+  component = path;
 
   while (TRUE) {
     int last_component = FALSE;


### PR DESCRIPTION
it fails with error as follows:

	not ok ERROR include_directory_wildcard_issue1472
	t/lib/ProFTPD/Tests/Config/Include.pm:865 - include_directory_wildcard_issue1472(ProFTPD::Tests::Config::Include)
	RETR test.txt succeeded unexpectedly at t/lib/ProFTPD/Tests/Config/Include.pm line 828.

the error which causes the failure is caused by configuration parser:

	2022-08-16 10:14:16,580 ST-ul-cbe proftpd[26930]: warning:
	unable to include '/tmp/proftpd-test-26903-test5-YaFmyrhTnM/*/test.conf': No such file or directory

I think we don't want to start chopping of path components out side of loop. If I understand things right we should let the loop below to process entire absolute path here.