### PR TITLE
variable $target_dir is part of global scope

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
@@ -198,7 +198,7 @@ sub dir_wide_layout {
     my $namelen = 3;
 
     for (my $i = 0; $i < $width; $i++) {
-      my $target_dir = get_name($namelen, 1);
+      $target_dir = get_name($namelen, 1);
       my $dir = File::Spec->rel2abs("$tmpdir/$target_dir");
       mkpath($dir);
 


### PR DESCRIPTION
I think we want to refer to target_dir from global scope, because we use the target_dir variable later at line 245.