### PR TITLE
Fixes failure reported by t/config/socketoptions.t testsuite

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -989,7 +989,7 @@ int pr_inet_set_proto_keepalive(pool *p, conn_t *c,
   if (val != -1) {
     int option_name;
 
-# if defined(TCP_KEEPALIVE)
+#ifndef TCP_KEEPIDLE
     option_name = TCP_KEEPALIVE;
 # else
     option_name = TCP_KEEPIDLE;


### PR DESCRIPTION
there are both (`SO_KEEPALIVE` and `TCP_KEEPIDLE`) TCP socket options defined on Solaris. In order to make test suite happy I've decided to let `TCP_KEEPIDLE` precedence over `SO_KEEPALIVE` when building proftpd on OS which supports both those options.

this pull request just highlights the issue. perhaps there is better way to fix it.