### PR TITLE
Issue #1533: Ensure that FTPS clients cannot request a TLS session if…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@
 - Issue 1494 - 1.3.8rc4 failing to build on Solaris due to missing type
   declarations.
 - Issue 1500 - mod_ifsession doesn't change the effect of SFTPMaxChannels.
+- Issue 1533 - mod_tls module unexpectedly allows TLS handshake after
+  authentication in some configurations.
 
 1.3.8rc4 - Released 23-Jul-2022
 --------------------------------

--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -836,8 +836,9 @@ The currently implemented options are:
     <code>TLSRequired on</code> or <code>TLSRequired ctrl</code> are in
     effect, it will be possible for the connecting client to send
     usernames and password <i>unprotected</i> before <code>mod_tls</code>
-    rejects the connection.  This results in a slightly weaker security
-    policy enforcement; please consider carefully if this tradeoff is
+    rejects the connection; those credentials could be intercepted and/or
+    manipulated before they reach the server.  This results in a weaker
+    security policy enforcement; please consider carefully if this tradeoff is
     acceptable for your site.
 
     <p>


### PR DESCRIPTION
… they have already authenticated, unless the `AllowPerUser` TLSOption is in effect.