### PR TITLE
We're seeing `mod_sql_mysql` build errors on the FreeBSD Cirrus CI, w…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ task:
     - pkg install -y libmemcached
     - pkg install -y mysql57-client
     - pkg install -y ncurses
-    - pkg install -y openldap24-client
+    - pkg install -y openldap26-client
     - pkg install -y openssl
     - pkg install -y pcre
     - pkg install -y postgresql10-client


### PR DESCRIPTION
…hich look to be related to inability to find the `<mysql.h>` header file.

Try specifying the expected path to the directory where it might be.