### PR TITLE
Issue #376: When running our regression tests in GitHub Actions, they…

### DIFF
--- a/tests/t/lib/ProFTPD/TestSuite/Utils.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/Utils.pm
@@ -1248,6 +1248,13 @@ sub test_setup {
   if ($< != 0) {
     $uid = $<;
     $gid = $(;
+
+    # If `$(` returns a space-separated list of numbers, we want to only
+    # use the first one.
+    if ($gid =~ / /) {
+      my $gids = [split(/\s+/, $gid)];
+      $gid = $gids->[0];
+    }
   }
 
   my $setup = {

--- a/tests/t/lib/ProFTPD/Tests/Commands.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands.pm
@@ -221,6 +221,7 @@ sub cmds_pwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -338,6 +339,7 @@ sub cmds_xpwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -458,6 +460,7 @@ sub cmds_cwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -577,6 +580,7 @@ sub cmds_cwd_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -700,6 +704,7 @@ sub cmds_cwd_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -830,6 +835,7 @@ sub cmds_xcwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -947,6 +953,7 @@ sub cmds_cdup_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1064,6 +1071,7 @@ sub cmds_xcup_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1571,6 +1579,7 @@ sub cmds_mkd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1690,6 +1699,7 @@ sub cmds_mkd_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1812,6 +1822,7 @@ sub cmds_mkd_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1945,6 +1956,7 @@ sub cmds_xmkd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2065,6 +2077,7 @@ sub cmds_rmd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2184,6 +2197,7 @@ sub cmds_rmd_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2306,6 +2320,7 @@ sub cmds_rmd_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2440,6 +2455,7 @@ sub cmds_xrmd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2565,6 +2581,7 @@ sub cmds_dele_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2684,6 +2701,7 @@ sub cmds_dele_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2812,6 +2830,7 @@ sub cmds_dele_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2950,6 +2969,7 @@ sub cmds_mdtm_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3067,6 +3087,7 @@ sub cmds_mdtm_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3195,6 +3216,7 @@ sub cmds_mdtm_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3334,6 +3356,7 @@ sub cmds_size_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3460,6 +3483,7 @@ sub cmds_size_fails_ascii {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3589,6 +3613,7 @@ sub cmds_size_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3724,6 +3749,7 @@ sub cmds_size_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/ABOR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/ABOR.pm
@@ -231,6 +231,7 @@ sub abor_retr_binary_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -330,6 +331,7 @@ sub abor_retr_ascii_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -439,6 +441,7 @@ sub abor_retr_ascii_largefile_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -564,6 +567,7 @@ sub abor_retr_ascii_largefile_followed_by_list_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -724,6 +728,7 @@ sub abor_retr_binary_largefile_followed_by_retr_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 1,
     TimeoutIdle => 15,
@@ -861,6 +866,7 @@ sub abor_retr_binary_largefile_with_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -990,6 +996,7 @@ sub abor_retr_binary_largefile_without_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
     UseSendfile => 'off',
@@ -1106,6 +1113,7 @@ sub abor_stor_binary_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1221,6 +1229,7 @@ sub abor_stor_ascii_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1336,6 +1345,7 @@ sub abor_with_cyrillic_encoding_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 15,
 
@@ -1455,6 +1465,7 @@ sub abor_no_xfer_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1540,6 +1551,7 @@ sub abor_list_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1668,6 +1680,7 @@ sub abor_mlsd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1791,6 +1804,7 @@ sub abor_only_retr_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -1916,6 +1930,7 @@ sub abor_only_retr_binary_with_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2048,6 +2063,7 @@ sub abor_only_retr_binary_without_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
     UseSendfile => 'off',
@@ -2166,6 +2182,7 @@ sub abor_only_stor_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2281,6 +2298,7 @@ sub abor_only_stor_binary {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2394,6 +2412,7 @@ sub abor_only_list {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2522,6 +2541,7 @@ sub abor_only_mlsd {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2635,6 +2655,7 @@ sub abor_only_no_xfer {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2733,6 +2754,7 @@ sub data_eof_retr_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2853,6 +2875,7 @@ sub data_eof_retr_binary_with_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -2967,6 +2990,7 @@ sub data_eof_retr_binary_without_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
     UseSendfile => 'off',
@@ -3078,6 +3102,7 @@ sub data_eof_stor_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3185,6 +3210,7 @@ sub data_eof_stor_binary {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3290,6 +3316,7 @@ sub data_eof_list {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3413,6 +3440,7 @@ sub data_eof_mlsd {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3531,6 +3559,7 @@ sub data_eof_before_abor_retr_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3665,6 +3694,7 @@ sub data_eof_before_abor_retr_binary_with_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -3805,6 +3835,7 @@ sub data_eof_before_abor_retr_binary_without_sendfile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
     UseSendfile => 'off',
@@ -3930,6 +3961,7 @@ sub data_eof_before_abor_stor_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -4051,6 +4083,7 @@ sub data_eof_before_abor_stor_binary {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -4170,6 +4203,7 @@ sub data_eof_before_abor_list {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 
@@ -4307,6 +4341,7 @@ sub data_eof_before_abor_mlsd {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLinger => 5,
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/ALLO.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/ALLO.pm
@@ -52,6 +52,7 @@ sub allo_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -138,6 +139,8 @@ sub allo_chrooted_bug3996 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -255,6 +258,7 @@ sub allo_anon_bug3996 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
@@ -149,6 +149,7 @@ sub appe_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -230,6 +231,7 @@ sub appe_ok_raw_passive {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -313,6 +315,7 @@ sub appe_ok_file_new {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -423,6 +426,7 @@ sub appe_ok_file_existing {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -513,6 +517,7 @@ sub appe_ok_files_new_and_existing_bug3612 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -684,6 +689,7 @@ sub appe_fails_abs_symlink_new {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -796,6 +802,7 @@ sub appe_fails_abs_symlink_new_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -918,6 +925,7 @@ sub appe_fails_rel_symlink_new {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1039,6 +1047,7 @@ sub appe_fails_rel_symlink_new_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1159,6 +1168,7 @@ sub appe_ok_abs_symlink_existing {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1283,6 +1293,7 @@ sub appe_ok_abs_symlink_existing_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1410,6 +1421,7 @@ sub appe_ok_rel_symlink_existing {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1538,6 +1550,7 @@ sub appe_ok_rel_symlink_existing_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1626,6 +1639,7 @@ sub appe_fails_not_reg {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -1738,6 +1752,7 @@ sub appe_fails_abs_symlink_not_reg {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -1844,6 +1859,7 @@ sub appe_fails_abs_symlink_not_reg_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     DefaultRoot => '~',
@@ -1961,6 +1977,7 @@ sub appe_fails_rel_symlink_not_reg {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -2077,6 +2094,7 @@ sub appe_fails_rel_symlink_not_reg_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     DefaultRoot => '~',
@@ -2244,6 +2262,7 @@ sub appe_fails_no_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2354,6 +2373,7 @@ sub appe_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2444,6 +2464,7 @@ sub appe_hiddenstores_bug4144 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     HiddenStores => 'on',
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/CDUP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/CDUP.pm
@@ -77,6 +77,7 @@ sub cdup_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -194,6 +195,7 @@ sub xcup_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/CWD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/CWD.pm
@@ -152,6 +152,7 @@ sub cwd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -247,6 +248,7 @@ sub cwd_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -351,6 +353,7 @@ sub cwd_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -462,6 +465,7 @@ sub cwd_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -571,6 +575,7 @@ sub cwd_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -652,6 +657,7 @@ sub cwd_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -747,6 +753,7 @@ sub cwd_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -842,6 +849,7 @@ sub cwd_fails_enotdir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -942,6 +950,7 @@ sub cwd_fails_abs_symlink_enotdir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1048,6 +1057,7 @@ sub cwd_fails_abs_symlink_enotdir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1160,6 +1170,7 @@ sub cwd_fails_rel_symlink_enotdir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1270,6 +1281,7 @@ sub cwd_fails_rel_symlink_enotdir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1368,6 +1380,7 @@ sub xcwd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1507,6 +1520,7 @@ sub cwd_symlinks_traversing_bug3297 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'on',
     DefaultRoot => '~',
@@ -1691,6 +1705,7 @@ sub cwd_symlinks_oneshot_bug3297 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'on',
     DefaultRoot => '~',
@@ -1793,6 +1808,7 @@ sub cwd_long_path_bug3730 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     CommandBufferSize => $cmd_bufsz,
     DefaultRoot => '~',
@@ -1880,6 +1896,7 @@ sub cwd_tilde_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1988,6 +2005,7 @@ sub cwd_tilde_user_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2085,6 +2103,8 @@ sub cwd_tilde_chrooted_bug3785 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -2205,6 +2225,8 @@ sub cwd_tilde_user_chrooted_bug3785 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
@@ -108,6 +108,7 @@ sub dele_file_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -227,6 +228,7 @@ sub dele_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -359,6 +361,7 @@ sub dele_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -494,6 +497,7 @@ sub dele_fails_eisdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -610,6 +614,7 @@ sub dele_symlink_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -739,6 +744,7 @@ sub dele_symlink_bug3754 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
@@ -112,6 +112,7 @@ sub eprt_ipv4_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -228,6 +229,7 @@ sub eprt_ipv6_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseIPv6 => 'on',
 
@@ -440,6 +442,7 @@ sub eprt_fails_bad_format {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -564,6 +567,7 @@ sub eprt_fails_bad_values {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -687,6 +691,7 @@ sub eprt_fails_bad_proto {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -822,6 +827,7 @@ sub eprt_fails_bad_addr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -947,6 +953,7 @@ sub eprt_fails_bad_port {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1090,6 +1097,7 @@ sub eprt_during_xfer_bug3487 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
@@ -102,6 +102,7 @@ sub epsv_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -218,6 +219,7 @@ sub epsv_ipv4_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -334,6 +336,7 @@ sub epsv_ipv6_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseIPv6 => 'on',
 
@@ -452,6 +455,7 @@ sub epsv_all_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -662,6 +666,7 @@ sub epsv_fails_bad_proto {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -813,6 +818,7 @@ sub epsv_during_xfer_bug3487 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/FEAT.pm
@@ -63,6 +63,7 @@ sub feat_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -207,6 +208,7 @@ sub feat_crlf {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -363,6 +365,7 @@ sub feat_eprt_limit_issue1383 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -520,6 +523,7 @@ sub feat_epsv_limit_issue1383 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -677,6 +681,7 @@ sub feat_eprt_epsv_limit_issue1383 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/HOST.pm
@@ -229,6 +229,7 @@ sub host_after_login_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -314,6 +315,8 @@ sub host_literal_ipv6_fails_useipv6_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'off',
 
     IfModules => {
@@ -400,6 +403,8 @@ sub host_literal_ipv6_with_port_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'on',
 
     IfModules => {
@@ -486,6 +491,7 @@ sub host_invalid_ipv4_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -571,6 +577,7 @@ sub host_ipv4_with_port_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -656,6 +663,7 @@ sub host_unknown_host_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -741,6 +749,7 @@ sub host_known_ipv4_same_host_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -822,6 +831,8 @@ sub host_known_ipv6_same_host_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'on',
     DefaultAddress => '::1',
 
@@ -912,6 +923,7 @@ sub host_known_ipv4_different_host_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1018,6 +1030,8 @@ sub host_known_ipv6_different_host_fails {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'on',
     DefaultAddress => '::1',
 
@@ -1122,6 +1136,7 @@ sub host_known_dns_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1221,6 +1236,7 @@ sub host_config_limit_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1326,6 +1342,7 @@ sub host_before_feat_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1453,6 +1470,7 @@ sub host_after_feat_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
@@ -271,6 +271,7 @@ sub list_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -385,6 +386,7 @@ sub list_ok_raw_passive {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -501,6 +503,7 @@ sub list_ok_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -611,6 +614,7 @@ sub list_file_rel_paths_bug4259 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -786,6 +790,7 @@ sub list_file_after_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -956,6 +961,7 @@ sub list_ok_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1089,6 +1095,7 @@ sub list_dir_twice {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1249,6 +1256,7 @@ sub list_ok_no_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1376,6 +1384,7 @@ sub list_ok_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1602,6 +1611,7 @@ sub list_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1730,6 +1740,7 @@ sub list_fails_enoent_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1856,6 +1867,7 @@ sub list_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2009,6 +2021,7 @@ sub list_bug2821 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout + 15,
     TimeoutNoTransfer => $timeout + 15,
@@ -2185,6 +2198,7 @@ sub list_unsorted_buffering_bug4060 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout + 15,
     TimeoutNoTransfer => $timeout + 15,
@@ -2348,6 +2362,7 @@ sub list_opt_C {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2506,6 +2521,7 @@ sub list_nonascii_chars_bug3032 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2654,6 +2670,7 @@ sub list_leading_whitespace_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2807,6 +2824,7 @@ sub list_leading_whitespace_with_opts_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2960,6 +2978,7 @@ sub list_leading_whitespace_with_strict_opts_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-a +R" strict',
 
@@ -3193,6 +3212,7 @@ EOL
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverride => 'on',
     DefaultRoot => '~',
@@ -3347,6 +3367,7 @@ sub list_symlink_issue697 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverride => 'on',
     DefaultRoot => '~',
@@ -3467,6 +3488,8 @@ sub list_symlink_issue940 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ListOptions => '-la',
 
     IfModules => {
@@ -3656,6 +3679,7 @@ sub list_symlink_rel_with_double_slash_bug3719 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -3810,6 +3834,7 @@ sub list_showsymlinks_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'off',
 
@@ -3944,6 +3969,7 @@ sub list_showsymlinks_off_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ShowSymlinks => 'off',
@@ -4079,6 +4105,7 @@ sub list_showsymlinks_on {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'on',
 
@@ -4213,6 +4240,7 @@ sub list_showsymlinks_on_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ShowSymlinks => 'on',
@@ -4348,6 +4376,7 @@ sub list_glob_bug2367 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4479,6 +4508,7 @@ sub list_glob_legit_dir_name {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4610,6 +4640,7 @@ sub list_glob_legit_dir_name_bug3407 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4761,6 +4792,7 @@ sub list_opt_c {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4921,6 +4953,7 @@ sub list_opt_u {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5068,6 +5101,7 @@ sub list_dash_filename_bug3476 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5202,6 +5236,7 @@ sub list_opt_noerrorifabsent_bug3506 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"" NoErrorIfAbsent',
 
@@ -5362,6 +5397,7 @@ sub list_slashstar_bug3529 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -5545,6 +5581,7 @@ sub list_star_bug3529 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5727,6 +5764,7 @@ sub list_opt_R {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5922,6 +5960,7 @@ sub list_opt_R_self_symlinked_dir_bug3719 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6118,6 +6157,7 @@ sub list_opt_R_self_complex_symlinked_dir_bug3719 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6319,6 +6359,7 @@ sub list_opt_R_rel_symlinked_file_bug3719 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6462,6 +6503,7 @@ sub list_option_parsing {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6593,6 +6635,8 @@ sub list_symlink_rel_path_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -6733,6 +6777,8 @@ sub list_symlink_rel_path_subdir_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -6873,6 +6919,8 @@ sub list_symlink_rel_path_subdir_cwd_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -6986,6 +7034,7 @@ sub list_style_windows {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ListStyle => 'Windows',
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/MDTM.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MDTM.pm
@@ -102,6 +102,7 @@ sub mdtm_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -200,6 +201,7 @@ sub mdtm_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -300,6 +302,8 @@ sub mdtm_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -403,6 +407,7 @@ sub mdtm_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -505,6 +510,7 @@ sub mdtm_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -584,6 +590,7 @@ sub mdtm_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -682,6 +689,7 @@ sub mdtm_fails_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -780,6 +788,7 @@ sub mdtm_fails_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -885,6 +894,7 @@ sub mdtm_fails_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -989,6 +999,7 @@ sub mdtm_fails_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1082,6 +1093,7 @@ sub mdtm_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/MFF.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MFF.pm
@@ -96,6 +96,7 @@ sub mff_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -222,6 +223,7 @@ sub mff_chrooted_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -350,6 +352,7 @@ sub mff_bug3142 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -476,6 +479,7 @@ sub mff_bug3830 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/MFMT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MFMT.pm
@@ -100,6 +100,7 @@ sub mfmt_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -225,6 +226,7 @@ sub mfmt_chrooted_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -352,6 +354,7 @@ sub mfmt_unsupported_precision_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -478,6 +481,7 @@ sub mfmt_bug3142 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -612,6 +616,7 @@ sub mfmt_group_owner_only_bug3577 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_cap.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
@@ -143,6 +143,7 @@ sub mkd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -242,6 +243,7 @@ sub mkd_fails_abs_symlink_new {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -347,6 +349,7 @@ sub mkd_fails_abs_symlink_new_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -460,6 +463,7 @@ sub mkd_fails_rel_symlink_new {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -563,6 +567,7 @@ sub mkd_fails_rel_symlink_new_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -649,6 +654,7 @@ sub mkd_umask_one_param_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '077',
 
@@ -737,6 +743,7 @@ sub mkd_umask_two_params_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '022 077',
 
@@ -825,6 +832,7 @@ sub mkd_with_spaces_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -912,6 +920,7 @@ sub mkd_utf8_with_spaces_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -997,6 +1006,8 @@ sub mkd_chrooted_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1097,6 +1108,8 @@ sub mkd_chrooted_with_cwd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1204,6 +1217,7 @@ sub mkd_sgid_umask_one_param_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '077',
 
@@ -1316,6 +1330,7 @@ sub mkd_sgid_umask_two_params_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '022 077',
 
@@ -1409,6 +1424,7 @@ sub mkd_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1496,6 +1512,7 @@ sub mkd_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1593,6 +1610,7 @@ sub mkd_fails_eexists {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1677,6 +1695,7 @@ sub xmkd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1758,6 +1777,7 @@ sub mkd_digits_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1846,6 +1866,7 @@ sub mkd_embedded_cr_bug4167 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1936,6 +1957,7 @@ sub mkd_embedded_lf_bug4167 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLSD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLSD.pm
@@ -165,6 +165,7 @@ sub mlsd_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -313,6 +314,7 @@ sub mlsd_ok_raw_passive {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -463,6 +465,7 @@ sub mlsd_fails_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -584,6 +587,7 @@ sub mlsd_ok_cwd_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -723,6 +727,7 @@ sub mlsd_ok_other_dir_bug4198 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -838,6 +843,7 @@ sub mlsd_ok_chrooted_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -966,6 +972,7 @@ sub mlsd_ok_empty_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1106,6 +1113,7 @@ sub mlsd_ok_no_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1236,6 +1244,7 @@ sub mlsd_ok_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1451,6 +1460,7 @@ sub mlsd_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1588,6 +1598,7 @@ sub mlsd_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1722,6 +1733,7 @@ sub mlsd_ok_hidden_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/' => {
@@ -1862,6 +1874,7 @@ sub mlsd_ok_path_with_spaces {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1992,6 +2005,7 @@ sub mlsd_nonascii_chars_bug3032 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2131,6 +2145,7 @@ sub mlsd_symlink_showsymlinks_off_bug3318 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'off',
 
@@ -2277,6 +2292,8 @@ sub mlsd_symlink_showsymlinks_on_bug3318 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ShowSymlinks => 'on',
 
     IfModules => {
@@ -2431,6 +2448,7 @@ sub mlsd_symlink_showsymlinks_on_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ShowSymlinks => 'on',
@@ -2587,6 +2605,7 @@ sub mlsd_symlink_showsymlinks_on_use_slink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     FactsOptions => 'UseSlink',
@@ -2755,6 +2774,7 @@ sub mlsd_symlinked_dir_bug3859 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # Note: use the default ShowSymlinks setting
 
@@ -2923,6 +2943,7 @@ sub mlsd_symlinked_dir_showsymlinks_off_bug3859 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'off',
 
@@ -3065,6 +3086,7 @@ sub mlsd_wide_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3208,6 +3230,8 @@ sub mlsd_symlink_rel_path_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ShowSymlinks => 'on',
     DefaultRoot => '~',
 
@@ -3350,6 +3374,8 @@ sub mlsd_symlink_rel_path_subdir_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ShowSymlinks => 'on',
     DefaultRoot => '~',
 
@@ -3492,6 +3518,8 @@ sub mlsd_symlink_rel_path_subdir_cwd_chrooted_bug4322 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ShowSymlinks => 'on',
     DefaultRoot => '~',
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/MODE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MODE.pm
@@ -88,6 +88,7 @@ sub mode_stream_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -205,6 +206,7 @@ sub mode_block_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -328,6 +330,7 @@ sub mode_compressed_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -451,6 +454,7 @@ sub mode_other_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
@@ -189,6 +189,7 @@ sub nlst_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -302,6 +303,7 @@ sub nlst_ok_raw_passive {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -420,6 +422,7 @@ sub nlst_ok_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -516,6 +519,7 @@ sub nlst_ok_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -648,6 +652,7 @@ sub nlst_ok_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -788,6 +793,8 @@ sub nlst_ok_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -921,6 +928,7 @@ sub nlst_ok_no_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1016,6 +1024,7 @@ sub nlst_ok_glob_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1119,6 +1128,7 @@ sub nlst_ok_glob_dir_bug4084 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1238,6 +1248,7 @@ sub nlst_ok_glob_dir_with_recursion_bug4084 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1471,6 +1482,7 @@ sub nlst_fails_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1600,6 +1612,7 @@ sub nlst_fails_enoent_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1739,6 +1752,7 @@ sub nlst_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1893,6 +1907,7 @@ sub nlst_bug2821 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout + 15,
     TimeoutNoTransfer => $timeout + 15,
@@ -2056,6 +2071,7 @@ sub nlst_nonascii_chars_bug3032 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2207,6 +2223,7 @@ sub nlst_leading_whitespace_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2368,6 +2385,7 @@ sub nlst_leading_whitespace_with_opts_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2529,6 +2547,7 @@ sub nlst_leading_whitespace_with_strict_opts_bug3268 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-a +R" strict',
 
@@ -2770,6 +2789,7 @@ EOL
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverride => 'on',
     DefaultRoot => '~',
@@ -2915,6 +2935,7 @@ sub nlst_dash_filename_bug3476 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3048,6 +3069,7 @@ sub nlst_opt_noerrorifabsent_bug3506 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"" NoErrorIfAbsent',
 
@@ -3203,6 +3225,7 @@ sub nlst_trailing_slashes_bug2457 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3361,6 +3384,7 @@ sub nlst_rel_path_bug2496 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3520,6 +3544,8 @@ sub nlst_rel_path_chrooted_bug2496 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -3673,6 +3699,7 @@ sub nlst_parent_dir_bug4011 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3839,6 +3866,7 @@ sub nlst_opt_a_root_dir_bug4069 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3983,6 +4011,8 @@ sub nlst_opt_1_with_chroot {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -4097,6 +4127,7 @@ sub nlst_glob_with_rel_path_issue1325 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4286,6 +4317,7 @@ sub nlst_glob_with_rel_path_dotdir_issue1325 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/OPTS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/OPTS.pm
@@ -75,6 +75,7 @@ sub opts_bug3870 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/PASS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PASS.pm
@@ -93,6 +93,7 @@ sub pass_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -212,6 +213,7 @@ sub pass_fails_no_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -335,6 +337,7 @@ sub pass_fails_no_passwd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -464,6 +467,7 @@ sub pass_nonascii_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -586,6 +590,7 @@ sub pass_spaces_bugXXXX {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -704,6 +709,7 @@ sub pass_spaces_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/PASV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PASV.pm
@@ -82,6 +82,7 @@ sub pasv_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -308,6 +309,7 @@ sub pasv_during_xfer_bug3487 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
@@ -113,6 +113,7 @@ sub port_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -324,6 +325,7 @@ sub port_fails_bad_format {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -449,6 +451,7 @@ sub port_fails_bad_values {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -573,6 +576,7 @@ sub port_fails_bad_addr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -699,6 +703,7 @@ sub port_fails_bad_port {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -825,6 +830,7 @@ sub port_eaddrnotavail {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1010,6 +1016,7 @@ sub port_during_xfer_bug3487 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1163,6 +1170,7 @@ sub port_eaddrinuse_bug3944 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootRevoke => 'off',
     TimeoutIdle => '30',

--- a/tests/t/lib/ProFTPD/Tests/Commands/PWD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PWD.pm
@@ -83,6 +83,7 @@ sub pwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -206,6 +207,7 @@ sub xpwd_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -330,6 +332,7 @@ sub pwd_upload_only {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/QUIT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/QUIT.pm
@@ -72,6 +72,7 @@ sub quit_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
@@ -102,6 +102,7 @@ sub rest_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -313,6 +314,7 @@ sub rest_fails_negative_offset {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -437,6 +439,7 @@ sub rest_fails_bad_offset {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -561,6 +564,7 @@ sub rest_fails_offset_and_ascii {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -717,6 +721,7 @@ sub rest_2gb_last_byte {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -895,6 +900,7 @@ sub rest_4gb_last_byte {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
@@ -161,6 +161,7 @@ sub retr_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -248,6 +249,7 @@ sub retr_ok_raw_active_multiple_downloads {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -333,6 +335,7 @@ sub retr_ok_raw_passive {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -432,6 +435,7 @@ sub retr_ok_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -550,6 +554,7 @@ sub retr_ok_ascii_file_bug4237 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -745,6 +750,7 @@ sub retr_ok_ascii_file_bug4277 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -922,6 +928,7 @@ sub retr_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1038,6 +1045,7 @@ sub retr_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1160,6 +1168,7 @@ sub retr_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1280,6 +1289,7 @@ sub retr_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1371,6 +1381,7 @@ sub retr_fails_not_reg {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1538,6 +1549,7 @@ sub retr_fails_no_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1623,6 +1635,7 @@ sub retr_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1713,6 +1726,7 @@ sub retr_fails_enoent_glob {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1812,6 +1826,7 @@ sub retr_fails_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1913,6 +1928,7 @@ sub retr_fails_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2019,6 +2035,7 @@ sub retr_fails_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2123,6 +2140,7 @@ sub retr_fails_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2221,6 +2239,7 @@ sub retr_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2331,6 +2350,7 @@ sub retr_ok_dir_with_spaces {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2427,6 +2447,7 @@ sub retr_leading_whitespace {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2533,6 +2554,8 @@ sub retr_bug3496 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxInstances => 1,
 
     IfModules => {
@@ -2619,6 +2642,7 @@ sub retr_2nd_transfer_terminates_1st_transfer_bug4010 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/RMD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RMD.pm
@@ -122,6 +122,7 @@ sub rmd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -226,6 +227,7 @@ sub rmd_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -334,6 +336,7 @@ sub rmd_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -448,6 +451,7 @@ sub rmd_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -560,6 +564,7 @@ sub rmd_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -644,6 +649,7 @@ sub rmd_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -729,6 +735,7 @@ sub rmd_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -828,6 +835,7 @@ sub rmd_fails_enotdir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -921,6 +929,7 @@ sub rmd_fails_enotempty {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1016,6 +1025,7 @@ sub rmd_fails_eloop {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1124,6 +1134,7 @@ sub rmd_fails_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1233,6 +1244,7 @@ sub rmd_fails_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1349,6 +1361,7 @@ sub rmd_fails_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1463,6 +1476,7 @@ sub rmd_fails_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1551,6 +1565,7 @@ sub xrmd_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1630,6 +1645,7 @@ sub rmd_with_spaces {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RNFR.pm
@@ -117,6 +117,7 @@ sub rnfr_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -216,6 +217,7 @@ sub rnfr_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -316,6 +318,7 @@ sub rnfr_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -411,6 +414,7 @@ sub rnfr_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -504,6 +508,7 @@ sub rnfr_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -620,6 +625,7 @@ sub rnfr_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -734,6 +740,7 @@ sub rnfr_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -844,6 +851,7 @@ sub rnfr_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -952,6 +960,7 @@ sub rnfr_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1070,6 +1079,7 @@ sub rnfr_fails_login_required {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1164,6 +1174,7 @@ sub rnfr_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1315,6 +1326,7 @@ sub rnfr_during_xfer_bug3492 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1466,6 +1478,7 @@ sub rnfr_limit_bug3698 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~/sub.d' => {
@@ -1606,6 +1619,7 @@ sub rnfr_list_bad_cmd_sequence_bug3829 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/RNTO.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RNTO.pm
@@ -127,6 +127,7 @@ sub rnto_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -242,6 +243,7 @@ sub rnto_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -377,6 +379,7 @@ sub rnto_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -505,6 +508,7 @@ sub rnto_fails_login_required {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -630,6 +634,7 @@ sub rnto_fails_no_rnfr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -747,6 +752,7 @@ sub rnto_fails_enoent_no_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -855,6 +861,7 @@ sub rnto_fails_enoent_no_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -979,6 +986,7 @@ sub rnto_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1123,6 +1131,7 @@ sub rnto_fails_allow_overwrite {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1269,6 +1278,8 @@ sub rnto_fails_device_full_bug3354 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1410,6 +1421,7 @@ sub rnto_symlink_bug3754 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1544,6 +1556,7 @@ sub rnto_lowercase_issue1023 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/SIZE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/SIZE.pm
@@ -108,6 +108,7 @@ sub size_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -209,6 +210,7 @@ sub size_abs_symlink_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -310,6 +312,7 @@ sub size_abs_symlink_file_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -414,6 +417,7 @@ sub size_rel_symlink_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -516,6 +520,7 @@ sub size_rel_symlink_file_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -612,6 +617,7 @@ sub size_abs_symlink_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -714,6 +720,7 @@ sub size_abs_symlink_dir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -819,6 +826,7 @@ sub size_rel_symlink_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -922,6 +930,7 @@ sub size_rel_symlink_dir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1016,6 +1025,7 @@ sub size_fails_ascii {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1101,6 +1111,7 @@ sub size_fails_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1192,6 +1203,7 @@ sub size_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/STAT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STAT.pm
@@ -91,6 +91,7 @@ sub stat_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -183,6 +184,7 @@ sub stat_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -297,6 +299,7 @@ sub stat_dir_with_files_bug3990 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -420,6 +423,7 @@ sub stat_symlink_showsymlinks_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'off',
 
@@ -545,6 +549,7 @@ sub stat_symlink_showsymlinks_on {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ShowSymlinks => 'on',
 
@@ -674,6 +679,7 @@ sub stat_symlink_showsymlinks_off_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ShowSymlinks => 'off',
@@ -800,6 +806,7 @@ sub stat_symlink_showsymlinks_on_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ShowSymlinks => 'on',
@@ -891,6 +898,7 @@ sub stat_system {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -965,6 +973,7 @@ sub stat_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1049,6 +1058,7 @@ sub stat_listoptions_bug3295 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '-1',
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/STOR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STOR.pm
@@ -141,6 +141,7 @@ sub stor_ok_raw_active {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -227,6 +228,7 @@ sub stor_ok_raw_passive {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -313,6 +315,7 @@ sub stor_ok_binary_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -405,6 +408,7 @@ sub stor_ok_ascii_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -499,6 +503,7 @@ sub stor_ok_ascii_file_bug4237 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -620,6 +625,7 @@ sub stor_ok_ascii_file_bug4277 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -912,6 +918,7 @@ sub stor_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1162,6 +1169,7 @@ sub stor_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1255,6 +1263,7 @@ sub stor_fails_not_reg {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -1417,6 +1426,7 @@ sub stor_fails_no_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1511,6 +1521,7 @@ sub stor_fails_eperm {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1736,6 +1747,7 @@ sub stor_fails_abs_symlink_dir_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1992,6 +2004,7 @@ sub stor_fails_rel_symlink_dir_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2080,6 +2093,7 @@ sub stor_leading_whitespace {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2166,6 +2180,7 @@ sub stor_multiple_periods {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STOU.pm
@@ -103,6 +103,7 @@ sub stou_ok_raw_active {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -231,6 +232,7 @@ sub stou_ok_raw_passive {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -360,6 +362,7 @@ sub stou_ok_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -468,6 +471,7 @@ sub stou_file_umask_bug4223 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -564,6 +568,7 @@ sub stou_file_umask_chrooted_bug4223 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     DefaultRoot => '~',
@@ -791,6 +796,7 @@ sub stou_fails_eperm {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/STRU.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/STRU.pm
@@ -87,6 +87,7 @@ sub stru_file_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -203,6 +204,7 @@ sub stru_record_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -326,6 +328,7 @@ sub stru_page_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -449,6 +452,7 @@ sub stru_other_fails {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Commands/USER.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/USER.pm
@@ -77,6 +77,7 @@ sub user_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -194,6 +195,7 @@ sub user_fails_no_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AccessDenyMsg.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AccessDenyMsg.pm
@@ -84,6 +84,7 @@ sub accessdenymsg_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AccessDenyMsg => $access_deny_msg,
 
@@ -204,6 +205,7 @@ sub accessdenymsg_var_u_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AccessDenyMsg => $access_deny_msg,
 
@@ -324,6 +326,7 @@ sub accessdenymsg_limit_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AccessDenyMsg => $access_deny_msg,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AccessGrantMsg.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AccessGrantMsg.pm
@@ -79,6 +79,7 @@ sub accessgrantmsg_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AccessGrantMsg => $access_grant_msg,
 
@@ -193,6 +194,7 @@ sub accessgrantmsg_var_u_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AccessGrantMsg => $access_grant_msg,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AllowFilter.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AllowFilter.pm
@@ -147,8 +147,9 @@ sub allowfilter_dele_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -285,6 +286,8 @@ sub allowfilter_dele_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {
@@ -422,8 +425,9 @@ sub allowfilter_mkd_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -555,8 +559,9 @@ sub allowfilter_mkd_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -694,8 +699,9 @@ sub allowfilter_rmd_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -822,8 +828,9 @@ sub allowfilter_rmd_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -961,8 +968,9 @@ sub allowfilter_rnfr_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1089,8 +1097,9 @@ sub allowfilter_rnfr_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1229,8 +1238,9 @@ sub allowfilter_rnto_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1360,8 +1370,9 @@ sub allowfilter_rnto_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1498,8 +1509,9 @@ sub allowfilter_stor_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1637,8 +1649,9 @@ sub allowfilter_stor_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1774,8 +1787,9 @@ sub allowfilter_stor_denied_nocase_bug3592 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -1917,8 +1931,9 @@ sub allowfilter_stor_denied_nocase_bug3609 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AllowForeignAddress.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AllowForeignAddress.pm
@@ -98,6 +98,7 @@ sub fxp_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'off',
 
@@ -244,6 +245,7 @@ sub fxp_denied_eprt {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'off',
 
@@ -391,6 +393,7 @@ sub fxp_port_denied_by_class {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => $class_name,
 
@@ -543,6 +546,7 @@ sub fxp_pasv_denied_by_class_issue1346 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => $class_name,
 
@@ -691,6 +695,7 @@ sub fxp_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 
@@ -821,6 +826,7 @@ sub fxp_allowed_eprt {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 
@@ -955,6 +961,7 @@ sub fxp_port_allowed_by_class {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => $class_name,
 
@@ -1088,6 +1095,7 @@ sub fxp_pasv_allowed_by_class_issue1346 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => $class_name,
 
@@ -1210,6 +1218,7 @@ sub fxp_allowed_2gb {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AllowOverwrite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AllowOverwrite.pm
@@ -90,6 +90,7 @@ sub allowoverwrite_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -218,6 +219,7 @@ sub allowoverwrite_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -350,6 +352,7 @@ sub allowoverwrite_as_root {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     RootLogin => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Config/AnonAllowRobots.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AnonAllowRobots.pm
@@ -64,6 +64,7 @@ sub anon_allow_robots_on_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -171,6 +172,7 @@ sub anon_allow_robots_on {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -273,6 +275,7 @@ sub anon_allow_robots_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -398,6 +401,7 @@ sub anon_allow_robots_off_existing_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -496,6 +500,7 @@ sub anon_allow_robots_off_non_anon_login {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AnonRejectPasswords.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AnonRejectPasswords.pm
@@ -85,6 +85,7 @@ sub anon_reject_passwords_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -218,6 +219,7 @@ sub anon_reject_passwords_flags_nocase {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -351,6 +353,7 @@ sub anon_reject_passwords_not_and_flags_nocase {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AnonRequirePassword.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AnonRequirePassword.pm
@@ -80,6 +80,7 @@ sub anon_require_password_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -206,6 +207,7 @@ sub anon_require_password_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
@@ -69,6 +69,7 @@ sub authaliasonly_on {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     UserAlias => "$alias $setup->{user}",
     AuthAliasOnly => 'on',
@@ -181,6 +182,7 @@ sub authaliasonly_off_anon_bug2070 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -321,6 +323,7 @@ sub authaliasonly_on_anon_bug3501 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $home_dir => {
@@ -461,6 +464,7 @@ sub authaliasonly_on_system_bug3501 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $home_dir => {
@@ -564,6 +568,8 @@ sub authaliasonly_on_anon_bug4255 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AuthAliasOnly => 'on',
 
     Anonymous => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthGroupFile.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthGroupFile.pm
@@ -83,6 +83,7 @@ sub authgroupfile_bug3347 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthUserFile.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthUserFile.pm
@@ -82,6 +82,7 @@ sub authuserfile_empty_passwd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthUsingAlias.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthUsingAlias.pm
@@ -81,6 +81,7 @@ sub authusingalias_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -205,6 +206,7 @@ sub authusingalias_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Classes.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Classes.pm
@@ -171,6 +171,7 @@ sub class_from_all_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -298,6 +299,7 @@ sub class_from_none_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -429,6 +431,7 @@ sub class_from_ipaddr_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -556,6 +559,7 @@ sub class_from_ipaddr_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -687,6 +691,7 @@ sub class_from_negated_ipaddr_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -814,6 +819,7 @@ sub class_from_negated_ipaddr_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -945,6 +951,7 @@ sub class_from_netmask_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -1072,6 +1079,7 @@ sub class_from_netmask_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -1203,6 +1211,7 @@ sub class_from_negated_netmask_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -1330,6 +1339,7 @@ sub class_from_negated_netmask_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -1461,6 +1471,8 @@ sub class_from_dns_name_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -1589,6 +1601,8 @@ sub class_from_dns_name_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -1721,6 +1735,8 @@ sub class_from_negated_dns_name_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -1849,6 +1865,8 @@ sub class_from_negated_dns_name_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -1981,6 +1999,8 @@ sub class_from_dns_glob_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -2109,6 +2129,8 @@ sub class_from_dns_glob_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -2241,6 +2263,8 @@ sub class_from_negated_dns_glob_allow {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -2369,6 +2393,8 @@ sub class_from_negated_dns_glob_deny {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {
@@ -2501,6 +2527,7 @@ sub class_satisfy_any {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -2635,6 +2662,8 @@ sub class_satisfy_all {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     Limit => {

--- a/tests/t/lib/ProFTPD/Tests/Config/CommandBufferSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/CommandBufferSize.pm
@@ -103,6 +103,7 @@ sub cmdbuffersz_small {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CommandBufferSize => $cmdbufsz,
     TimeoutIdle => $idle_timeout,
@@ -234,6 +235,7 @@ sub cmdbuffersz_large {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CommandBufferSize => $cmdbufsz,
 
@@ -383,6 +385,7 @@ sub cmdbuffersz_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/CreateHome.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/CreateHome.pm
@@ -96,6 +96,7 @@ sub createhome_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => 'on',
 
@@ -200,6 +201,7 @@ sub createhome_dirmode_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => 'on 711 dirmode 755',
 
@@ -319,6 +321,7 @@ sub createhome_explicit_parent_owner_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 711 uid $explicit_guid gid $explicit_guid",
 
@@ -423,6 +426,7 @@ sub createhome_user_parent_owner_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 711 uid ~ gid ~",
 
@@ -559,6 +563,7 @@ sub createhome_skel_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on skel $skel",
 
@@ -665,6 +670,7 @@ sub createhome_homegid_bug3503 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 711 homegid $home_gid",
 
@@ -777,6 +783,7 @@ sub createhome_dirmode_uid_gid_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 700 dirmode 700 uid ~ gid ~",
 
@@ -899,6 +906,7 @@ sub createhome_dirmode_uid_gid_norootprivs_bug3813 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 700 dirmode 700 uid ~ gid ~ NoRootPrivs",
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DefaultChdir.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DefaultChdir.pm
@@ -117,6 +117,7 @@ sub defaultchdir_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~/subdir',
 
@@ -240,6 +241,7 @@ sub defaultchdir_var_u {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~/%u',
 
@@ -363,6 +365,7 @@ sub defaultchdir_with_defaultroot {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '/subdir',
     DefaultRoot => '~',
@@ -487,6 +490,7 @@ sub defaultchdir_with_defaultroot2 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
     DefaultRoot => $home_dir,
@@ -613,6 +617,7 @@ sub defaultchdir_one_env_var_bug3502 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~/%{env:PROFTPD_USER}',
 
@@ -739,6 +744,7 @@ sub defaultchdir_multi_env_var_bug3502 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~/%{env:PROFTPD_USER}/%{env:PROFTPD_USER_HOME}',
 
@@ -862,6 +868,7 @@ sub defaultchdir_empty_env_var_bug3502 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~/%{env:PROFTPD_USER}',
 
@@ -988,6 +995,7 @@ sub defaultchdir_user_mux_one_level {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => "$home_root/%u[0]/%u/subdir",
 
@@ -1114,6 +1122,7 @@ sub defaultchdir_user_mux_three_levels {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => "$home_root/%u[0]/%u[0]%u[1]/%u[0]%u[1]%u[2]/%u/subdir",
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DefaultRoot.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DefaultRoot.pm
@@ -120,6 +120,7 @@ sub defaultroot_rel_symlink_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -261,6 +262,7 @@ sub defaultroot_abs_symlink_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -413,6 +415,7 @@ sub defaultroot_rel_symlink_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -542,6 +545,7 @@ sub defaultroot_rel_symlink_dangling {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -659,6 +663,7 @@ sub defaultroot_allowchrootsymlinks_bug3852 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowChrootSymlinks => 'off',
     DefaultRoot => '~',
@@ -773,6 +778,7 @@ sub defaultroot_allowchrootsymlinks_bug4306 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowChrootSymlinks => 'off',
     DefaultRoot => '~',

--- a/tests/t/lib/ProFTPD/Tests/Config/DeleteAbortedStores.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DeleteAbortedStores.pm
@@ -101,8 +101,9 @@ sub deleteabortedstores_conn_aborted_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
 
@@ -243,8 +244,9 @@ sub deleteabortedstores_cmd_abort_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
     TimeoutLinger => 1,
@@ -386,8 +388,9 @@ sub deleteabortedstores_conn_aborted_bug3917 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
 
     IfModules => {
@@ -496,8 +499,9 @@ sub deleteabortedstores_hiddenstores_on_timeout_idle_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
     TimeoutIdle => $timeout_idle,
@@ -605,8 +609,9 @@ sub deleteabortedstores_hiddenstores_on_timeout_stalled_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
     TimeoutStalled => $timeout_stalled,
@@ -754,8 +759,9 @@ sub deleteabortedstores_hiddenstores_on_xfer_aborted_bug4467 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
     AllowOverwrite => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Config/DenyFilter.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DenyFilter.pm
@@ -97,8 +97,9 @@ sub denyfilter_mkd_etc_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -238,6 +239,8 @@ sub denyfilter_stor_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {
@@ -380,6 +383,8 @@ sub denyfilter_stor_denied_nocase {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {
@@ -534,6 +539,8 @@ sub denyfilter_site_chmod_777_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
@@ -163,6 +163,7 @@ sub dir_wide_layout {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayChdir.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayChdir.pm
@@ -99,6 +99,7 @@ sub displaychdir_singleline {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayChdir => 'display.txt',
 
@@ -245,6 +246,7 @@ sub displaychdir_multiline {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayChdir => 'display.txt',
 
@@ -392,6 +394,7 @@ sub displaychdir_first_chdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayChdir => "display.txt true",
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayConnect.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayConnect.pm
@@ -323,6 +323,7 @@ sub displayconnect_client_count {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayConnect => $connect_file,
 
@@ -458,6 +459,7 @@ sub displayconnect_class_client_count {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayConnect => $connect_file,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayFileTransfer.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayFileTransfer.pm
@@ -92,6 +92,7 @@ sub displayfilexfer_abs_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayFileTransfer => $xfer_file,
 
@@ -220,6 +221,7 @@ sub displayfilexfer_rel_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayFileTransfer => $xfer_file,
 
@@ -369,6 +371,7 @@ sub displayfilexfer_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     DisplayFileTransfer => $xfer_file,
@@ -495,6 +498,7 @@ sub displayfilexfer_multiline {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayFileTransfer => $xfer_file,
 
@@ -597,6 +601,7 @@ sub displayfilexfer_non_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayFileTransfer => $xfer_file,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayLogin.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayLogin.pm
@@ -87,6 +87,8 @@ sub displaylogin_abs_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayLogin => $login_file,
 
     IfModules => {
@@ -219,6 +221,8 @@ sub displaylogin_rel_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayLogin => $login_file,
 
     IfModules => {
@@ -335,6 +339,7 @@ sub displaylogin_absent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -449,6 +454,8 @@ sub displaylogin_multiline {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayLogin => $login_file,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayQuit.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayQuit.pm
@@ -87,6 +87,8 @@ sub displayquit_abs_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayQuit => $quit_file,
 
     IfModules => {
@@ -205,6 +207,8 @@ sub displayquit_rel_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayQuit => $quit_file,
 
     IfModules => {
@@ -322,6 +326,8 @@ sub displayquit_multiline {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayQuit => $quit_file,
 
     IfModules => {
@@ -412,6 +418,8 @@ sub displayquit_non_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DisplayQuit => $quit_file,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/EnvVars.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/EnvVars.pm
@@ -65,6 +65,7 @@ sub envvar_bug2048 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ServerIdent => 'on',
     ServerName => '%{env:PR_SERVER_NAME}',
@@ -151,6 +152,7 @@ sub envvar_bug3502 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ServerIdent => 'on',
     ServerName => '"Green %{env:PR_SERVER_NAME}"',
@@ -236,6 +238,7 @@ sub envvar_vhost_addr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -341,6 +344,7 @@ sub envvar_multiple_vars_single_directive_issue507 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ServerIdent => 'on',
     ServerName => '"%{env:PR_SERVER_FIRST_NAME}%{env:PR_SERVER_LAST_NAME}@%{env:PR_SERVER_DOMAIN}"',
@@ -429,6 +433,7 @@ sub envvar_global_context_issue857 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Global => {
       ServerIdent => 'on "ProFTPD Server (%{env:PR_SERVER_NAME}) [127.0.0.1]"',

--- a/tests/t/lib/ProFTPD/Tests/Config/GroupOwner.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/GroupOwner.pm
@@ -88,6 +88,7 @@ sub groupowner_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -210,6 +211,7 @@ sub groupowner_failed_norootprivs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -359,6 +361,7 @@ sub groupowner_ok_suppl_group_norootprivs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootLogin => $root_login,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
@@ -121,8 +121,9 @@ sub hiddenstores_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
 
     IfModules => {
@@ -271,8 +272,9 @@ sub hiddenstores_bug3156 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowRetrieveRestart => 'on',
     HiddenStores => 'on',
 
@@ -415,8 +417,9 @@ sub hiddenstores_prefix_bug3294 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => $hiddenstore_prefix,
 
     IfModules => {
@@ -556,8 +559,9 @@ sub hiddenstores_bool_prefix_bug3294 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => $hiddenstore_prefix,
 
     IfModules => {
@@ -698,8 +702,9 @@ sub hiddenstores_suffix_bug3872 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => "$hiddenstore_prefix $hiddenstore_suffix",
 
     IfModules => {
@@ -851,8 +856,9 @@ sub hiddenstores_pid_var_bug4062 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => '.in. .%P',
 
     IfModules => {
@@ -963,8 +969,9 @@ sub hiddenstores_timeout_idle_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     TimeoutIdle => $timeout_idle,
 
@@ -1079,8 +1086,9 @@ sub hiddenstores_timeout_notransfer_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     TimeoutNoTransfer => $timeout_noxfer,
 
@@ -1193,8 +1201,9 @@ sub hiddenstores_timeout_stalled_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     TimeoutStalled => $timeout_stalled,
 
@@ -1312,8 +1321,9 @@ sub hiddenstores_timeout_session_bug4035 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     HiddenStores => 'on',
     TimeoutSession => $timeout_session,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/HideFiles.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideFiles.pm
@@ -196,6 +196,8 @@ EOF
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
     DefaultChdir => '~',
 
@@ -323,6 +325,8 @@ sub hidefiles_list_issue1279 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
     DefaultChdir => '~',
 
@@ -504,6 +508,8 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     Anonymous => {
@@ -692,6 +698,8 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
     DefaultChdir => '~',
 
@@ -861,6 +869,8 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     Anonymous => {
@@ -1024,6 +1034,7 @@ sub hidefiles_bug3130 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1184,6 +1195,7 @@ sub hidefiles_per_user_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1347,6 +1359,7 @@ sub hidefiles_per_not_user_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1534,6 +1547,7 @@ sub hidefiles_anon_list_rel_path_bug3226 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1733,6 +1747,7 @@ sub hidefiles_anon_nlst_rel_path_bug3226 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1930,6 +1945,7 @@ sub hidefiles_anon_list_abs_path_bug3226 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2130,6 +2146,7 @@ sub hidefiles_anon_nlst_abs_path_bug3226 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2327,6 +2344,7 @@ sub hidefiles_negated_bug3276 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2521,6 +2539,7 @@ sub hidefiles_negated_chroot_bug3276 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2721,6 +2740,7 @@ sub hidefiles_negated_chroot_subdirs_visible_bug3276 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2950,6 +2970,7 @@ sub hidefiles_none_per_user_bug3397 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3133,6 +3154,8 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
     DefaultChdir => '~',
 
@@ -3273,6 +3296,8 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
     DefaultChdir => '~',
 
@@ -3439,6 +3464,8 @@ sub hidefiles_mlsd_dotfiles {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {
@@ -3618,6 +3645,8 @@ sub hidefiles_stat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Directory => {
@@ -3747,6 +3776,8 @@ sub hidefiles_directory_pcre {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     TimeoutIdle => $timeout_idle,
@@ -3877,6 +3908,7 @@ sub hidefiles_list_symlink_bug3924 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => { 
       '/' => {
@@ -4057,6 +4089,7 @@ sub hidefiles_mlsd_symlink_bug3924 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => { 
       '/' => {
@@ -4229,6 +4262,7 @@ sub hidefiles_multi_dirs {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/HideGroup.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideGroup.pm
@@ -111,6 +111,7 @@ sub hidegroup_explicit_group_list {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -288,6 +289,7 @@ sub hidegroup_explicit_group_nlst {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -465,6 +467,7 @@ sub hidegroup_explicit_group_mlsd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -652,6 +655,7 @@ sub hidegroup_session_group {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -827,6 +831,7 @@ sub hidegroup_not_session_group {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -1005,6 +1010,8 @@ sub hidegroup_hidenoaccess_on_bug3530 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     Directory => {
@@ -1198,6 +1205,8 @@ sub hidegroup_hideuser_bug3530 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     Directory => {
@@ -1400,6 +1409,7 @@ sub hidegroup_virtual_group_bug3934 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
@@ -87,6 +87,7 @@ sub hidenoaccess_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -263,6 +264,7 @@ sub hidenoaccess_with_directory_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/*' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/HideUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideUser.pm
@@ -102,6 +102,7 @@ sub hideuser_explicit_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -286,6 +287,7 @@ sub hideuser_session_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -474,6 +476,7 @@ sub hideuser_not_session_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -658,6 +661,7 @@ sub hideuser_virtual_user_bug3934 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/IfDefine.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/IfDefine.pm
@@ -88,6 +88,7 @@ sub ifdefine_exists {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -174,6 +175,7 @@ sub ifdefine_not_exist {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -262,6 +264,7 @@ sub ifdefine_exists_via_define {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -350,6 +353,7 @@ sub ifdefine_exists_via_env {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Include.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Include.pm
@@ -902,9 +902,11 @@ EOC
     ScoreboardFile => $setup->{scoreboard_file},
     SystemLog => $setup->{log_file},
 
-    AllowOverride => 'on',
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    AllowOverride => 'on',
     DefaultChdir => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/Anonymous.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/Anonymous.pm
@@ -114,6 +114,7 @@ sub anon_limit_write {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -274,6 +275,7 @@ sub anon_limit_write_changing_dirs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -465,6 +467,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverride => 'on',
 
@@ -659,6 +662,8 @@ sub anon_limit_login_dns_name {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseReverseDNS => 'on',
 
     IfModules => {
@@ -801,6 +806,7 @@ sub anon_limit_write_allow_stor_using_abs_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -967,6 +973,7 @@ sub anon_limit_write_allow_stor_using_rel_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/Filters.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/Filters.pm
@@ -90,6 +90,7 @@ sub filter_dele_allow_bug2067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -218,6 +219,7 @@ sub filter_dele_deny_bug2067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -346,6 +348,7 @@ sub filter_stor_allow_bug2067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/HELP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/HELP.pm
@@ -50,6 +50,8 @@ sub limit_help_issue1296 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {
@@ -158,6 +160,8 @@ sub limit_site_help_issue1296 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/LOGIN.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/LOGIN.pm
@@ -87,6 +87,8 @@ sub login_limit_ip_glob_range_bug3484 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'off',
 
     IfModules => {
@@ -217,6 +219,8 @@ sub login_limit_allowgroup_backslash {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'off',
 
     IfModules => {
@@ -335,6 +339,8 @@ sub login_limit_multiple_sections {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     UseIPv6 => 'off',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/MFMT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/MFMT.pm
@@ -78,6 +78,8 @@ sub mfmt_limit_bug3399 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/OPTS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/OPTS.pm
@@ -77,6 +77,7 @@ sub opts_limit_utf8_bug3438 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -207,6 +208,7 @@ sub opts_limit_all_bug3438 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/RMD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/RMD.pm
@@ -84,6 +84,8 @@ sub rmd_unremovable_subdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/SubDirectories.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/SubDirectories.pm
@@ -84,6 +84,7 @@ sub subdirs_mkd_denied_pwd_allowed_bug3077 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -241,6 +242,7 @@ sub subdirs_mkd_denied_limit_xmkd_bug3077 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -389,6 +391,7 @@ sub subdirs_xmkd_allowed_limit_mkd_bug3077 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/XMKD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/XMKD.pm
@@ -120,6 +120,7 @@ sub mkd_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -254,6 +255,7 @@ sub mkd_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -401,6 +403,7 @@ sub mkd_denied_group_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -539,6 +542,7 @@ sub mkd_denied_class_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -683,6 +687,7 @@ sub mkd_denied_classes_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -829,6 +834,7 @@ sub xmkd_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -962,6 +968,7 @@ sub xmkd_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1108,6 +1115,7 @@ sub xmkd_denied_group_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1245,6 +1253,7 @@ sub xmkd_denied_class_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1388,6 +1397,7 @@ sub xmkd_denied_classes_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
@@ -154,6 +154,7 @@ sub listoptions_opt_t {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '-t',
 
@@ -308,6 +309,7 @@ sub listoptions_opt_1_list {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-A -1" strict',
 
@@ -443,6 +445,7 @@ sub listoptions_opt_1_nlst {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-A -1" strict',
 
@@ -613,6 +616,7 @@ sub listoptions_opt_1_nlst_simple_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-A -1" strict',
 
@@ -787,6 +791,7 @@ sub listoptions_opt_1_nlst_complex_glob {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     ListOptions => '"-A -1" strict',
@@ -962,8 +967,9 @@ sub listoptions_listonly {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    TimeoutLinger => 1,
+    AuthOrder => 'mod_auth_file.c',
 
+    TimeoutLinger => 1,
     ListOptions => '"-A -1" LISTOnly',
 
     IfModules => {
@@ -1177,8 +1183,9 @@ sub listoptions_nlstonly {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    TimeoutLinger => 1,
+    AuthOrder => 'mod_auth_file.c',
 
+    TimeoutLinger => 1,
     ListOptions => '"-A -1" NLSTOnly',
 
     IfModules => {
@@ -1366,8 +1373,9 @@ sub listoptions_sortednlst_bug4267 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    TimeoutLinger => 1,
+    AuthOrder => 'mod_auth_file.c',
 
+    TimeoutLinger => 1,
     ListOptions => '"" SortedNLST',
 
     IfModules => {
@@ -1540,6 +1548,7 @@ sub listoptions_maxfiles {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout + 15,
     TimeoutNoTransfer => $timeout + 15,
@@ -1684,6 +1693,7 @@ sub listoptions_nlstnamesonly_issue251 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ListOptions => '"-A -1 NLSTOnly"',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/LogOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/LogOptions.pm
@@ -56,6 +56,7 @@ sub logoptions_no_timestamp {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogOptions => '-Timestamp',
 
@@ -155,6 +156,7 @@ sub logoptions_no_hostname {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogOptions => '-Hostname',
 
@@ -255,6 +257,7 @@ sub logoptions_no_virtualhost {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogOptions => '-VirtualHost',
 
@@ -354,6 +357,7 @@ sub logoptions_use_rolebasedprocesslabels {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogOptions => '+RoleBasedProcessLabels',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MasqueradeAddress.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MasqueradeAddress.pm
@@ -88,6 +88,7 @@ sub masqaddr_pasv {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MasqueradeAddress => $masq_addr,
 
@@ -218,6 +219,7 @@ sub masqaddr_pasv_delayed_resolving_bug4104 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MasqueradeAddress => $masq_addr,
 
@@ -317,6 +319,7 @@ sub masqaddr_empty_addr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MasqueradeAddress => $masq_addr,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClients.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClients.pm
@@ -75,6 +75,7 @@ sub maxclients_one {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClients => $max_clients,
 
@@ -176,6 +177,7 @@ sub maxclients_one_ifsess_per_user_regex {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -454,6 +456,7 @@ sub maxclients_one_anon_bug4068 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $anon_dir => {

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerClass.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerClass.pm
@@ -69,6 +69,8 @@ sub maxclientsperclass_one {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxClientsPerClass => "$class_name $max_clients",
 
     IfModules => {
@@ -191,6 +193,7 @@ sub maxclientsperclass_one_multi_conns {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerClass => "$class_name $max_clients",
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerHost.pm
@@ -73,6 +73,8 @@ sub maxclientsperhost_one {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxClientsPerHost => $max_clients_per_host,
 
     IfModules => {
@@ -176,6 +178,7 @@ sub maxclientsperhost_one_multi_conns {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerHost => $max_clients_per_host,
 
@@ -270,6 +273,7 @@ sub maxclientsperhost_anon_one_bug4326 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerUser.pm
@@ -68,6 +68,8 @@ sub maxclientsperuser_one {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxClientsPerUser => $max_clients,
 
     IfModules => {
@@ -173,6 +175,7 @@ sub maxclientsperuser_one_multi_conns {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerUser => $max_clients,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxCommandRate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxCommandRate.pm
@@ -69,6 +69,7 @@ sub maxcmdrate_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxCommandRate => $max_cmd_rate,
 
@@ -164,6 +165,7 @@ sub maxcmdrate_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxCommandRate => $max_cmd_rate,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxConnectionsPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxConnectionsPerHost.pm
@@ -63,6 +63,8 @@ sub maxconnsperhost_one_multi_conns {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxConnectionsPerHost => $max_conns_per_host,
     TimeoutIdle => 30,
 
@@ -169,6 +171,7 @@ sub maxclientsperhost_one_multi_conns {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerHost => $max_clients_per_host,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxInstances.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxInstances.pm
@@ -60,6 +60,7 @@ sub maxinstances_one {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxInstances => $max_instances,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxLoginAttempts.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxLoginAttempts.pm
@@ -49,6 +49,7 @@ sub maxloginattempts_one {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => $max_logins,
 
@@ -189,6 +190,7 @@ sub maxloginattempts_absent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxPasswordSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxPasswordSize.pm
@@ -49,6 +49,7 @@ sub maxpasswordsize_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxPasswordSize => $max_passwd_size,
 
@@ -120,6 +121,7 @@ sub maxpasswordsize_failed_too_long {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxPasswordSize => $max_passwd_size,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxRetrieveFileSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxRetrieveFileSize.pm
@@ -89,6 +89,7 @@ sub maxretrievefilesize_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxRetrieveFileSize => '100 B',
 
@@ -221,6 +222,7 @@ sub maxretrievefilesize_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxRetrieveFileSize => '4 B',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxStoreFileSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxStoreFileSize.pm
@@ -84,6 +84,7 @@ sub maxstorefilesize_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxStoreFileSize => '100 B',
 
@@ -206,6 +207,7 @@ sub maxstorefilesize_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxStoreFileSize => '4 B',
 
@@ -348,6 +350,7 @@ sub maxstorefilesize_appe_bug3649 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerHost.pm
@@ -50,6 +50,8 @@ sub maxtransfersperhost_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file}, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxTransfersPerHost => "RETR $max_transfers",
 
     IfModules => {
@@ -149,6 +151,8 @@ sub maxtransfersperhost_retr_custom_message {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file}, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxTransfersPerHost => "RETR $max_transfers \"Too many transfers from your host\"",
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerUser.pm
@@ -50,6 +50,8 @@ sub maxtransfersperuser_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file}, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxTransfersPerUser => "RETR $max_transfers",
 
     IfModules => {
@@ -149,6 +151,8 @@ sub maxtransfersperuser_retr_custom_message {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file}, 
+    AuthOrder => 'mod_auth_file.c',
+
     MaxTransfersPerUser => "RETR $max_transfers \"Too many transfers from your user\"",
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/Order.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Order.pm
@@ -93,6 +93,8 @@ sub order_allowdeny_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Limit => {
@@ -227,6 +229,8 @@ sub order_allow_deny_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Limit => {
@@ -361,6 +365,8 @@ sub order_denyallow_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Limit => {
@@ -490,6 +496,8 @@ sub order_deny_allow_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Limit => {

--- a/tests/t/lib/ProFTPD/Tests/Config/PassivePorts.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/PassivePorts.pm
@@ -103,6 +103,8 @@ sub pasv_ports_server_config {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     PassivePorts => "$min_port $max_port",
 
     IfModules => {
@@ -246,6 +248,7 @@ sub pasv_ports_global {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Global => {
       PassivePorts => "$min_port $max_port",

--- a/tests/t/lib/ProFTPD/Tests/Config/PathAllowFilter.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/PathAllowFilter.pm
@@ -116,8 +116,9 @@ sub pathallowfilter_dele_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$',
 
@@ -197,8 +198,9 @@ sub pathallowfilter_dele_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathAllowFilter => '\.txt$',
 
     IfModules => {
@@ -287,8 +289,9 @@ sub pathallowfilter_mkd_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.d$',
 
@@ -373,8 +376,9 @@ sub pathallowfilter_mkd_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$',
 
@@ -464,8 +468,9 @@ sub pathallowfilter_rmd_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.d$',
 
@@ -545,8 +550,9 @@ sub pathallowfilter_rmd_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$',
 
@@ -636,8 +642,9 @@ sub pathallowfilter_rnfr_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.d$',
 
@@ -717,8 +724,9 @@ sub pathallowfilter_rnfr_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.dir$',
 
@@ -815,8 +823,9 @@ sub pathallowfilter_rnto_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.d$',
 
@@ -899,8 +908,9 @@ sub pathallowfilter_rnto_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.d$',
 
@@ -989,8 +999,9 @@ sub pathallowfilter_stor_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$',
 
@@ -1081,8 +1092,9 @@ sub pathallowfilter_stor_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$',
 
@@ -1170,8 +1182,9 @@ sub pathallowfilter_stor_denied_nocase_bug3592 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '\.txt$ [NC]',
 
@@ -1266,8 +1279,9 @@ sub pathallowfilter_stor_denied_nocase_bug3609 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathAllowFilter => '(?i)\.txt$',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/PathDenyFilter.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/PathDenyFilter.pm
@@ -136,8 +136,9 @@ sub pathdenyfilter_dele_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.tmp$',
 
@@ -217,8 +218,9 @@ sub pathdenyfilter_dele_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathDenyFilter => '\.txt$',
 
     IfModules => {
@@ -307,8 +309,9 @@ sub pathdenyfilter_mkd_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.dir$',
 
@@ -393,8 +396,9 @@ sub pathdenyfilter_mkd_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathDenyFilter => '\.dir$',
 
     IfModules => {
@@ -483,8 +487,9 @@ sub pathdenyfilter_rmd_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.dir$',
 
@@ -564,8 +569,9 @@ sub pathdenyfilter_rmd_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathDenyFilter => '\.dir$',
 
     IfModules => {
@@ -654,8 +660,9 @@ sub pathdenyfilter_rnfr_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.dir$',
 
@@ -735,8 +742,9 @@ sub pathdenyfilter_rnfr_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathDenyFilter => '\.d$',
 
     IfModules => {
@@ -832,8 +840,9 @@ sub pathdenyfilter_rnto_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.dir$',
 
@@ -916,8 +925,9 @@ sub pathdenyfilter_rnto_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     PathDenyFilter => '\.dir$',
 
     IfModules => {
@@ -1005,8 +1015,9 @@ sub pathdenyfilter_stor_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.jpg$',
 
@@ -1097,8 +1108,9 @@ sub pathdenyfilter_stor_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.jpg$',
 
@@ -1186,8 +1198,9 @@ sub pathdenyfilter_stor_denied_bug3032 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '[^[:print:]]',
 
@@ -1275,8 +1288,9 @@ sub pathdenyfilter_stor_trailing_space {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '"\.* $"',
 
@@ -1364,8 +1378,9 @@ sub pathdenyfilter_stor_leading_space {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '"(\.*/)? [^/]*$"',
 
@@ -1453,8 +1468,9 @@ sub pathdenyfilter_stor_leading_trailing_space {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '"(\.*/)?( [^/]*$|\.* $)"',
 
@@ -1542,8 +1558,9 @@ sub pathdenyfilter_stor_denied_nocase_bug3592 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.jpg$ [nocase]',
 
@@ -1633,8 +1650,9 @@ sub pathdenyfilter_stor_dotfiles_denied {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     PathDenyFilter => '\.[^/]*$',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/PidFile.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/PidFile.pm
@@ -42,6 +42,7 @@ sub pidfile_world_writable_issue1018 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '0000',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/Protocols.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Protocols.pm
@@ -93,6 +93,7 @@ sub protocols_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -208,6 +209,7 @@ sub protocols_with_ftp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Protocols => 'ftp',
 
@@ -325,6 +327,7 @@ sub protocols_without_ftp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Protocols => 'foo bar',
 
@@ -445,6 +448,7 @@ sub protocols_ifsess_with_ftp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -580,6 +584,7 @@ sub protocols_ifsess_without_ftp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/RLimitCPU.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RLimitCPU.pm
@@ -93,6 +93,7 @@ sub rlimitcpu_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitCPU => 'max',
 
@@ -200,6 +201,7 @@ sub rlimitcpu_session_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitCPU => 'session max',
 
@@ -307,6 +309,7 @@ sub rlimitcpu_session_min {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitCPU => 'session 0',
 
@@ -410,6 +413,7 @@ sub rlimitcpu_daemon_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitCPU => 'daemon max',
 
@@ -517,6 +521,7 @@ sub rlimitcpu_daemon_min {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitCPU => 'daemon 0',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/RLimitChroot.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RLimitChroot.pm
@@ -87,6 +87,7 @@ sub rlimitchroot_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     RLimitChroot => 'on',
@@ -355,6 +356,7 @@ sub rlimitchroot_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     RLimitChroot => 'off',
@@ -490,6 +492,7 @@ sub rlimitchroot_ifuser_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
     RLimitChroot => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Config/RLimitMemory.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RLimitMemory.pm
@@ -83,6 +83,7 @@ sub rlimitmemory_max_bug3571 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitMemory => 'max',
 
@@ -190,6 +191,7 @@ sub rlimitmemory_session_max_bug3571 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitMemory => 'session max',
 
@@ -297,6 +299,7 @@ sub rlimitmemory_daemon_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitMemory => 'daemon max',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/RLimitOpenFiles.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RLimitOpenFiles.pm
@@ -93,6 +93,7 @@ sub rlimitopenfiles_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitOpenFiles => 'max',
 
@@ -200,6 +201,7 @@ sub rlimitopenfiles_session_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitOpenFiles => 'session max',
 
@@ -307,6 +309,7 @@ sub rlimitopenfiles_session_min {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitOpenFiles => 'session 6',
 
@@ -419,6 +422,7 @@ sub rlimitopenfiles_daemon_max {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitOpenFiles => 'daemon max',
 
@@ -526,6 +530,7 @@ sub rlimitopenfiles_daemon_min {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RLimitOpenFiles => 'daemon 3',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/RegexOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RegexOptions.pm
@@ -45,8 +45,9 @@ sub regexoptions_posix_engine_issue1300 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     DenyFilter => '\*.*/',
     RegexOptions => 'Engine POSIX',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/RequireValidShell.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RequireValidShell.pm
@@ -125,6 +125,7 @@ sub requirevalidshell_off_valid_shell {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RequireValidShell => 'off',
 
@@ -230,6 +231,7 @@ sub requirevalidshell_off_invalid_shell {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RequireValidShell => 'off',
 
@@ -335,6 +337,7 @@ sub requirevalidshell_on_valid_shell {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RequireValidShell => 'on',
 
@@ -440,6 +443,7 @@ sub requirevalidshell_on_invalid_shell {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RequireValidShell => 'on',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/RewriteHome.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RewriteHome.pm
@@ -83,6 +83,7 @@ sub rewritehome_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -204,6 +205,7 @@ sub rewritehome_bad_home {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -319,6 +321,8 @@ sub rewritehome_chroot_bug3348 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~/',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/RootRevoke.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RootRevoke.pm
@@ -85,6 +85,7 @@ sub rootrevoke_on_active_transfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootRevoke => 'on',
 
@@ -211,6 +212,7 @@ sub rootrevoke_on_active_transfer_nonpriv_port {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootRevoke => 'on',
 
@@ -350,6 +352,7 @@ sub rootrevoke_usenoncompliantactivetransfer_active_transfer_bug3731 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootRevoke => 'UseNonCompliantActiveTransfer',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/SetEnv.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/SetEnv.pm
@@ -84,6 +84,8 @@ sub setenv_serverroot {
     'AllowStoreRestart on',
     "AuthUserFile $auth_user_file",
     "AuthGroupFile $auth_group_file",
+    "AuthOrder mod_auth_file.c",
+
     'DefaultChdir ~',
 
     '<IfModule mod_delay.c>',

--- a/tests/t/lib/ProFTPD/Tests/Config/SocketOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/SocketOptions.pm
@@ -81,6 +81,7 @@ sub socketoptions_none {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -207,6 +208,7 @@ sub socketoptions_rcvbuf_bug3607 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     SocketOptions => "rcvbuf $rcvbufsz",
 
@@ -354,6 +356,7 @@ sub socketoptions_sndbuf_bug3607 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     SocketOptions => "sndbuf $sndbufsz",
 
@@ -503,6 +506,7 @@ sub socketoptions_keepalive_on {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     PassivePorts => "41200 43400",
     SocketOptions => "keepalive on",
@@ -603,6 +607,7 @@ sub socketoptions_keepalive_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     PassivePorts => "41200 43400",
     SocketOptions => "keepalive off",

--- a/tests/t/lib/ProFTPD/Tests/Config/StoreUniquePrefix.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/StoreUniquePrefix.pm
@@ -73,8 +73,9 @@ sub storeuniqueprefix_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     AllowOverwrite => 'on',
     StoreUniquePrefix => $prefix,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/SyslogLevel.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/SyslogLevel.pm
@@ -64,6 +64,7 @@ sub sysloglevel_debug {
     "DebugLevel 10",
     "AuthUserFile $setup->{auth_user_file}",
     "AuthGroupFile $setup->{auth_group_file}",
+    "AuthOrder mod_auth_file.c",
   ];
 
   my ($port, $config_user, $config_group) = config_write($setup->{config_file},
@@ -156,8 +157,10 @@ sub sysloglevel_debug_sftp {
     SystemLog => $setup->{log_file},
     SyslogLevel => 'debug',
     DebugLevel => '10',
+
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutIdle.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutIdle.pm
@@ -80,6 +80,7 @@ sub timeoutidle_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 
@@ -219,6 +220,7 @@ sub timeoutidle_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutLogin.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutLogin.pm
@@ -79,6 +79,7 @@ sub timeoutlogin_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLogin => $timeout_login,
 
@@ -188,6 +189,7 @@ sub timeoutlogin_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLogin => $timeout_login,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutNoTransfer.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutNoTransfer.pm
@@ -79,6 +79,7 @@ sub timeoutnoxfer_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutNoTransfer => $timeout_noxfer,
 
@@ -197,6 +198,7 @@ sub timeoutnoxfer_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutNoTransfer => $timeout_noxfer,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutSession.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutSession.pm
@@ -79,6 +79,7 @@ sub timeoutsession_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutSession => $timeout_session,
 
@@ -201,6 +202,7 @@ sub timeoutsession_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutSession => $timeout_session,
 

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutStalled.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutStalled.pm
@@ -105,6 +105,7 @@ sub timeoutstalled_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -237,6 +238,7 @@ sub timeoutstalled_exceeded_list {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -376,6 +378,7 @@ sub timeoutstalled_exceeded_nlst {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -515,6 +518,7 @@ sub timeoutstalled_exceeded_mlsd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -654,6 +658,7 @@ sub timeoutstalled_exceeded_retr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -793,6 +798,7 @@ sub timeoutstalled_exceeded_stor {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
 
@@ -932,6 +938,7 @@ sub timeoutstalled_exceeded_retr_usesendfile_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutStalled => $timeout_stalled,
     UseSendfile => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Config/Trace.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Trace.pm
@@ -76,6 +76,7 @@ sub trace_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -222,6 +223,7 @@ sub trace_ifclass_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Class => {
       $class => {
@@ -391,6 +393,7 @@ sub trace_ifuser_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -554,6 +557,7 @@ sub trace_ifgroup_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -684,6 +688,7 @@ sub trace_level_range_bug3617 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -830,6 +835,7 @@ sub trace_session_level_range_bug3617 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -951,6 +957,7 @@ sub trace_level_per_vhost {
     Global => {
       AuthUserFile => $setup->{auth_user_file},
       AuthGroupFile => $setup->{auth_group_file},
+      AuthOrder => 'mod_auth_file.c',
       Trace => 'DEFAULT:10',
     },
   };

--- a/tests/t/lib/ProFTPD/Tests/Config/TraceOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TraceOptions.pm
@@ -56,6 +56,7 @@ sub traceoptions_conn_ips {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -173,6 +174,7 @@ sub traceoptions_timestamp_millis {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -289,6 +291,7 @@ sub traceoptions_no_timestamp {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/TransferOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TransferOptions.pm
@@ -60,6 +60,7 @@ sub transferoptions_ignore_ascii_download_bug4159 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultTransferMode => 'binary',
     TransferOptions => 'IgnoreASCII',
@@ -167,6 +168,7 @@ sub transferoptions_ignore_ascii_upload_bug4159 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultTransferMode => 'binary',
     TransferOptions => 'IgnoreASCII',

--- a/tests/t/lib/ProFTPD/Tests/Config/TransferRate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TransferRate.pm
@@ -96,6 +96,8 @@ sub transferrate_retr_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     # 1 KB/sec
@@ -249,6 +251,8 @@ sub transferrate_stor_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     # 1 KB/sec

--- a/tests/t/lib/ProFTPD/Tests/Config/Umask.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Umask.pm
@@ -89,6 +89,7 @@ sub umask_new_dir_mode {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '022 000',
 
@@ -229,6 +230,7 @@ sub umask_new_dir_mode_subdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '022',
 
@@ -383,6 +385,7 @@ sub umask_new_dir_mode_subdir_userowner_groupowner {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Umask => '022',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/UseFtpUsers.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseFtpUsers.pm
@@ -133,6 +133,7 @@ sub useftpusers_off_unlisted_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseFtpUsers => 'off',
 
@@ -237,6 +238,7 @@ sub useftpusers_off_listed_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseFtpUsers => 'off',
 
@@ -341,6 +343,7 @@ sub useftpusers_on_unlisted_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseFtpUsers => 'on',
 
@@ -445,6 +448,7 @@ sub useftpusers_on_listed_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseFtpUsers => 'on',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/UseGlobbing.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseGlobbing.pm
@@ -72,6 +72,7 @@ sub useglobbing_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseGlobbing => 'off',
 

--- a/tests/t/lib/ProFTPD/Tests/Config/UseSendfile.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseSendfile.pm
@@ -140,6 +140,7 @@ sub usesendfile_on_ascii {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseSendfile => 'on',
 
@@ -288,6 +289,7 @@ sub usesendfile_off_ascii {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseSendfile => 'off',
 
@@ -436,6 +438,7 @@ sub usesendfile_on_binary {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseSendfile => 'on',
 
@@ -585,6 +588,7 @@ sub usesendfile_off_binary {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UseSendfile => 'off',
 
@@ -735,6 +739,7 @@ sub usesendfile_on_binary_dir_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -938,6 +943,7 @@ sub usesendfile_off_binary_dir_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1153,6 +1159,8 @@ sub usesendfile_on_binary_ftpaccess_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {
@@ -1364,6 +1372,8 @@ sub usesendfile_off_binary_ftpaccess_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {
@@ -1564,6 +1574,7 @@ sub usesendfile_len_binary_dir_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1788,6 +1799,8 @@ sub usesendfile_len_binary_ftpaccess_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {
@@ -2009,6 +2022,8 @@ sub usesendfile_len_ascii_ftpaccess_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {
@@ -2209,6 +2224,7 @@ sub usesendfile_pct_binary_dir_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2433,6 +2449,8 @@ sub usesendfile_pct_binary_ftpaccess_bug3310 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Config/UserAlias.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserAlias.pm
@@ -85,6 +85,7 @@ sub useralias_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UserAlias => "$alias $user",
 
@@ -182,6 +183,7 @@ sub useralias_anon_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $home_dir => {
@@ -297,6 +299,7 @@ sub useralias_with_at_symbol_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UserAlias => "$alias $user",
 

--- a/tests/t/lib/ProFTPD/Tests/Config/UserOwner.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserOwner.pm
@@ -95,6 +95,7 @@ sub userowner_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -238,6 +239,7 @@ sub userowner_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -355,6 +357,7 @@ sub userowner_failed_norootprivs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -502,6 +505,7 @@ sub userowner_anon_mkd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_cap.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Config/UserPassword.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserPassword.pm
@@ -81,6 +81,7 @@ sub userpassword_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     UserPassword => "$user $user_pass_ciphertext",
 
@@ -188,6 +189,7 @@ sub userpassword_anon_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $anon_dir => {

--- a/tests/t/lib/ProFTPD/Tests/Config/VirtualHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/VirtualHost.pm
@@ -48,6 +48,7 @@ sub vhost_namebased_different_ports {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     ServerName => 'Real Server',
     SocketBindTight => 'off',
@@ -77,6 +78,7 @@ sub vhost_namebased_different_ports {
 
   AuthUserFile $setup->{auth_user_file}
   AuthGroupFile $setup->{auth_group_file}
+  AuthOrder mod_auth_file.c
 </VirtualHost>
 EOC
     unless (close($fh)) {

--- a/tests/t/lib/ProFTPD/Tests/Contrib/ftpasswd.pm
+++ b/tests/t/lib/ProFTPD/Tests/Contrib/ftpasswd.pm
@@ -218,6 +218,7 @@ sub ftpasswd_lock_unlock_bug3994 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -350,6 +351,7 @@ sub ftpasswd_change_home_issue566 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -473,6 +475,7 @@ sub ftpasswd_delete_member_from_group_issue620 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {
@@ -593,6 +596,7 @@ sub ftpasswd_add_member_to_group_issue625 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Limit => {
       LOGIN => {

--- a/tests/t/lib/ProFTPD/Tests/HTTP.pm
+++ b/tests/t/lib/ProFTPD/Tests/HTTP.pm
@@ -132,6 +132,7 @@ sub test_http_req {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
@@ -530,6 +530,8 @@ sub extlog_retr_default {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     ExtendedLog => "$ext_log ALL",
 
     IfModules => {
@@ -725,6 +727,7 @@ sub extlog_retr_bug3137 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f"',
     ExtendedLog => "$ext_log READ custom",
@@ -879,6 +882,7 @@ sub extlog_stor_bug3137 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -1029,6 +1033,7 @@ sub extlog_site_cmds_bug3171 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log ALL custom",
@@ -1184,6 +1189,7 @@ sub extlog_mlsd_var_d_D_f_F_bug3950 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%d %D %f %F"',
     ExtendedLog => "$ext_log DIRS custom",
@@ -1361,6 +1367,7 @@ sub extlog_sftp_mlsd_var_d_D_f_F_bug3950 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %d %D %f %F"',
     ExtendedLog => "$ext_log DIRS custom",
@@ -1581,6 +1588,7 @@ sub extlog_mfmt_var_d_D_f_F {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %d %D %f %F"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -1767,6 +1775,7 @@ sub extlog_protocol {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol}"',
     ExtendedLog => "$ext_log ALL custom",
@@ -1902,6 +1911,7 @@ sub extlog_protocol_version_quoted_bug3383 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "\"%{protocol}\" \"%{version}\""',
     ExtendedLog => "$ext_log ALL custom",
@@ -2016,6 +2026,7 @@ sub extlog_remote_port {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %{remote-port}"',
     ExtendedLog => "$ext_log ALL custom",
@@ -2161,6 +2172,7 @@ sub extlog_rename_from {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %w %f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -2337,6 +2349,7 @@ sub extlog_sftp_rename_from {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%w %f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -2568,6 +2581,7 @@ sub extlog_ext_sftp_posix_rename_bug3949 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%w %f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -2799,6 +2813,7 @@ sub extlog_orig_user {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%U"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -2946,6 +2961,7 @@ sub extlog_bug1908 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ExtendedLog => "$ext_log READ",
 
@@ -3120,6 +3136,7 @@ sub extlog_file_modified_bug3457 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     LogFormat => 'custom "%{file-modified}"',
@@ -3266,6 +3283,7 @@ sub extlog_dele_bug3469 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %f"',
     ExtendedLog => "$ext_log ALL custom",
@@ -3416,6 +3434,7 @@ sub extlog_client_dir_bug3395 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %d"',
     ExtendedLog => "$ext_log ALL custom",
@@ -3561,8 +3580,9 @@ sub extlog_client_dir_chroot_bug3395 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultRoot => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultRoot => '~',
     LogFormat => 'custom "%m %d"',
     ExtendedLog => "$ext_log ALL custom",
 
@@ -3703,6 +3723,7 @@ sub extlog_device_full {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %d"',
     ExtendedLog => "$ext_log ALL custom",
@@ -3816,6 +3837,7 @@ sub extlog_uid_bug3390 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{uid}"',
     ExtendedLog => "$ext_log READ custom",
@@ -3952,6 +3974,7 @@ sub extlog_gid_bug3390 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{gid}"',
     ExtendedLog => "$ext_log READ custom",
@@ -4090,6 +4113,7 @@ sub extlog_pass_ok_var_s_bug3528 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s %S"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -4202,6 +4226,7 @@ sub extlog_pass_failed_var_s_bug3528 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s %S"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -4356,6 +4381,7 @@ sub extlog_ftp_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
@@ -4533,6 +4559,7 @@ sub extlog_ftp_sendfile_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
@@ -4703,11 +4730,12 @@ sub extlog_ftp_deflate_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    TimeoutLinger => 1,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
     ServerIdent => 'on "FTP Server"',
+    TimeoutLinger => 1,
 
     IfModules => {
       'mod_deflate.c' => {
@@ -4892,6 +4920,7 @@ sub extlog_ftps_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
@@ -5082,6 +5111,7 @@ sub extlog_sftp_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
@@ -5292,6 +5322,7 @@ sub extlog_scp_raw_bytes_bug3554 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log ALL custom",
@@ -5444,6 +5475,7 @@ sub extlog_exit_bug3559 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %L %m \"%S\" %I %O"',
     ExtendedLog => "$ext_log EXIT custom",
@@ -5621,6 +5653,7 @@ sub extlog_eos_reason_quit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -5765,6 +5798,7 @@ sub extlog_eos_reason_eof {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -5911,6 +5945,7 @@ sub extlog_eos_reason_timeoutidle {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -6061,6 +6096,7 @@ sub extlog_eos_reason_timeoutlogin {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -6212,6 +6248,7 @@ sub extlog_eos_reason_timeoutnotransfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -6379,6 +6416,7 @@ sub extlog_eos_reason_timeoutsession {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -6531,6 +6569,7 @@ sub extlog_eos_reason_timeoutstalled {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{protocol} %m eos_reason=\"%E\""',
     ExtendedLog => "$ext_log EXIT custom",
@@ -6705,6 +6744,7 @@ sub extlog_vars_H_L_matching_server_bug3620 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%L %H"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -6814,6 +6854,7 @@ sub extlog_vars_H_L_default_server_bug3620 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultServer => 'off',
     SocketBindTight => 'off',
@@ -6845,6 +6886,8 @@ sub extlog_vars_H_L_default_server_bug3620 {
 
   AuthUserFile $setup->{auth_user_file}
   AuthGroupFile $setup->{auth_group_file}
+  AuthOrder mod_auth_file.c
+
   RequireValidShell off
   WtmpLog off
 
@@ -6983,6 +7026,7 @@ sub extlog_user_pass {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %U %A"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -7127,6 +7171,7 @@ sub extlog_anon_user_pass {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %U %A"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -7295,6 +7340,7 @@ sub extlog_cmd_resp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %J [%r] = %s %S"',
     ExtendedLog => "$ext_log ALL custom",
@@ -7449,6 +7495,7 @@ sub extlog_xfer_timeout_bug3696 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -7607,6 +7654,7 @@ sub extlog_sftp_xfer_timeout_bug3696 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -7793,6 +7841,7 @@ sub extlog_var_r {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r"',
     ExtendedLog => "$ext_log ALL custom",
@@ -7956,6 +8005,7 @@ sub extlog_pass_var_r {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -8097,6 +8147,7 @@ sub extlog_sftp_pass_var_r {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -8292,6 +8343,7 @@ sub extlog_sftp_retr_var_s_bug3948 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s"',
     ExtendedLog => "$ext_log READ custom",
@@ -8495,6 +8547,7 @@ sub extlog_sftp_stor_var_s_bug3948 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     LogFormat => 'custom "%m %s"',
@@ -8699,6 +8752,7 @@ sub extlog_abor {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log ALL custom",
@@ -8874,6 +8928,7 @@ sub extlog_xfer_status_nonxfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9041,6 +9096,7 @@ sub extlog_xfer_status_success {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9225,6 +9281,7 @@ sub extlog_xfer_status_cancelled {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9408,6 +9465,7 @@ sub extlog_xfer_status_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to trigger a download failure
     MaxRetrieveFileSize => '12 B',
@@ -9601,6 +9659,7 @@ sub extlog_xfer_status_timeout {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to tickle the "timeout" transfer status
     TimeoutStalled => $timeout_stalled,
@@ -9805,6 +9864,7 @@ sub extlog_xfer_failure_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9987,6 +10047,7 @@ sub extlog_xfer_failure_reason {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to trigger a download failure
     MaxRetrieveFileSize => '12 B',
@@ -10212,6 +10273,8 @@ sub extlog_ftps_xfer_status_cancelled {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -10458,6 +10521,8 @@ sub extlog_ftps_xfer_status_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -10652,6 +10717,7 @@ sub extlog_login_maxclients_bug3811 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -10822,6 +10888,7 @@ sub extlog_login_maxclientsperclass_bug3811 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -11006,6 +11073,7 @@ sub extlog_login_maxclientsperhost_bug3811 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -11175,6 +11243,7 @@ sub extlog_login_maxclientsperuser_bug3811 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s"',
     ExtendedLog => "$ext_log AUTH custom",
@@ -11342,6 +11411,7 @@ sub extlog_preauth_var_U_bug3822 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %U"',
     ExtendedLog => "$ext_log ALL custom",
@@ -11488,6 +11558,7 @@ sub extlog_preauth_var_u_bug3822 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %u"',
     ExtendedLog => "$ext_log ALL custom",
@@ -11606,6 +11677,7 @@ sub extlog_micros_ts_bug3889 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{%Y-%m-%d %H:%M:%S}t,%{microsecs} %f"',
     ExtendedLog => "$ext_log READ custom",
@@ -11759,6 +11831,7 @@ sub extlog_millis_ts_bug3889 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{%Y-%m-%d %H:%M:%S}t,%{millisecs} %f"',
     ExtendedLog => "$ext_log READ custom",
@@ -11880,6 +11953,7 @@ sub extlog_iso8601_ts_bug3889 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{ISO8601} %f"',
     ExtendedLog => "$ext_log READ custom",
@@ -12042,6 +12116,7 @@ sub extlog_dirs_class_var_f_bug3966 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %f"',
     ExtendedLog => "$ext_log DIRS custom",
@@ -12235,6 +12310,7 @@ sub extlog_var_basename_bug3987 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%{basename}"',
     ExtendedLog => "$ext_log READ custom",
@@ -12380,6 +12456,7 @@ sub extlog_exclusion_bug4067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log ALL,!AUTH custom",
@@ -12535,6 +12612,7 @@ sub extlog_sftp_ssh_sftp_bug4067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log SFTP custom",
@@ -12733,6 +12811,7 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log DIRS,!SSH,!SFTP custom",
@@ -12930,6 +13009,7 @@ sub extlog_sftp_read_write_bug4067 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
     ExtendedLog => "$ext_log READ,WRITE custom",
@@ -13150,6 +13230,7 @@ sub extlog_sftp_xfer_status_filtered {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     PathDenyFilter => '^.*\.csv$',
     LogFormat => 'custom "%m %{transfer-status}"',
@@ -13334,6 +13415,7 @@ sub extlog_var_file_offset {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f: %{file-offset}"',
     ExtendedLog => "$ext_log READ custom",
@@ -13476,6 +13558,7 @@ sub extlog_var_file_size_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f: %{file-size}"',
     ExtendedLog => "$ext_log READ custom",
@@ -13611,6 +13694,7 @@ sub extlog_sftp_var_file_size_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %f: %{file-size}"',
     ExtendedLog => "$ext_log READ custom",
@@ -13783,6 +13867,7 @@ sub extlog_var_file_size_stor {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f: %{file-size}"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -13916,6 +14001,7 @@ sub extlog_sftp_var_file_size_stor {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m: %f: %{file-size}"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -14083,6 +14169,7 @@ sub extlog_var_transfer_type_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f: %{transfer-type}"',
     ExtendedLog => "$ext_log READ custom",
@@ -14237,6 +14324,7 @@ sub extlog_var_transfer_type_stor {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%f: %{transfer-type}"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -14401,6 +14489,7 @@ sub extlog_file_transfer_secs {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Throttle the transfer, to aid in the timing
     TransferRate => 'RETR 1',
@@ -14548,6 +14637,7 @@ sub extlog_file_transfer_millisecs_bug4218 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Throttle the transfer, to aid in the timing
     TransferRate => 'RETR 1',
@@ -14695,6 +14785,7 @@ sub extlog_response_millisecs_bug4218 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Throttle the transfer, to aid in the timing
     TransferRate => 'RETR 1',
@@ -14826,6 +14917,7 @@ sub extlog_stor_var_f_xfer_timed_out {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %s: %f"',
     ExtendedLog => "$ext_log ALL custom",
@@ -14963,6 +15055,7 @@ sub extlog_write_invalid_cmd_bug4313 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r"',
     ExtendedLog => "$ext_log WRITE custom",
@@ -15071,6 +15164,7 @@ sub extlog_xfer_port_nonxfer_issue912 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15202,6 +15296,7 @@ sub extlog_xfer_port_success_issue912 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15367,6 +15462,7 @@ sub extlog_sftp_xfer_port_issue912 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %{transfer-port}"',
     ExtendedLog => "$ext_log ALL custom",

--- a/tests/t/lib/ProFTPD/Tests/Logging/ServerLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/ServerLog.pm
@@ -80,6 +80,7 @@ sub serverlog_ifclass_matching_class_bug3832 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -220,6 +221,7 @@ sub serverlog_ifclass_not_matching_class_bug3832 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Logging/SystemLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/SystemLog.pm
@@ -95,6 +95,7 @@ sub systemlog_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => 'none',
 
@@ -256,6 +257,7 @@ sub systemlog_with_sysloglevel_crit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     SyslogLevel => 'crit',
     TransferLog => 'none',
@@ -416,6 +418,7 @@ sub systemlog_with_debuglevel {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DebugLevel => 4,
 
@@ -559,6 +562,7 @@ sub systemlog_ifclass_matching_class_bug3832 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -715,6 +719,7 @@ sub systemlog_ifclass_not_matching_class_bug3832 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Logging/TransferLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/TransferLog.pm
@@ -90,6 +90,7 @@ sub xferlog_retr_ascii_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -228,6 +229,7 @@ sub xferlog_retr_binary_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -377,6 +379,7 @@ sub xferlog_retr_aborted {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Have the file being downloaded be sent in 1KB chunks, to slow the
     # download down
@@ -513,6 +516,7 @@ sub xferlog_stor_ascii_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -651,6 +655,7 @@ sub xferlog_stor_binary_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -789,6 +794,7 @@ sub xferlog_stor_aborted {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -949,6 +955,7 @@ sub xferlog_stor_enospc_bug3895 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -1111,6 +1118,7 @@ sub xferlog_dele_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -1274,6 +1282,7 @@ sub xferlog_device_full_for_log {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xfer_log,
 
@@ -1386,6 +1395,7 @@ sub xferlog_device_full_for_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     TransferLog => $xfer_log,

--- a/tests/t/lib/ProFTPD/Tests/Logins.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logins.pm
@@ -221,6 +221,7 @@ sub login_plaintext_fails_empty_password_bug4139 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowEmptyPasswords => 'off',
 
@@ -346,6 +347,7 @@ sub login_anonymous_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -477,6 +479,7 @@ sub login_anonymous_with_delay_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -606,6 +609,7 @@ sub login_anonymous_user_alias_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -832,6 +836,7 @@ sub login_anonymous_fails_empty_password_bug4139 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -985,6 +990,7 @@ sub login_anonymous_symlink_dir_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1134,6 +1140,7 @@ sub login_anonymous_allowchrootsymlinks_bug3852 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowChrootSymlinks => 'off',
 
@@ -1269,6 +1276,7 @@ sub login_multiple_attempts_per_conn {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1381,6 +1389,7 @@ sub login_regular_with_anon_defined_bug3307 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $home_dir => {
@@ -1508,6 +1517,7 @@ sub login_fails_bad_sequence {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1597,6 +1607,7 @@ sub login_reauthenticate_fails_bug3736 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1680,6 +1691,7 @@ sub login_reauthenticate_ok_same_user_bug4217 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1755,6 +1767,7 @@ sub login_reauthenticate_fails_different_user_bug4217 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1838,6 +1851,7 @@ sub login_reauthenticate_fails_extra_pass_bug4217 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_file.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_file.pm
@@ -189,6 +189,7 @@ sub auth_user_file_id_range_ok {
 
     AuthUserFile => "$auth_user_file id 100-500",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -294,6 +295,7 @@ sub auth_user_file_id_range_failed {
 
     AuthUserFile => "$auth_user_file id 100-500",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -404,6 +406,7 @@ sub auth_user_file_home_filter_ok {
 
     AuthUserFile => "$auth_user_file home $user\$",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -509,6 +512,7 @@ sub auth_user_file_home_filter_failed {
 
     AuthUserFile => "$auth_user_file home ^3133tH\@x0R\$",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -618,6 +622,7 @@ sub auth_user_file_name_filter_ok {
 
     AuthUserFile => "$auth_user_file name ^$user\$",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -723,6 +728,7 @@ sub auth_user_file_name_filter_failed {
 
     AuthUserFile => "$auth_user_file name ^3133tH\@x0R\$",
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -832,6 +838,7 @@ sub auth_group_file_id_range_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => "$auth_group_file id 100-500",
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -953,6 +960,7 @@ sub auth_group_file_id_range_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => "$auth_group_file id 100-500",
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1078,6 +1086,7 @@ sub auth_group_file_name_filter_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => "$auth_group_file name ^$group\$",
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1199,6 +1208,7 @@ sub auth_group_file_name_filter_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => "$auth_group_file name ^3133tH\@x0R\$",
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1324,6 +1334,7 @@ sub auth_user_file_at_symbol_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1435,6 +1446,7 @@ sub auth_user_file_world_readable_bug3892 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1508,6 +1520,7 @@ sub auth_user_file_world_writable_bug3892 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1565,6 +1578,7 @@ sub auth_user_file_world_readable_insecure_perms_opt {
 AuthFileOptions InsecurePerms
 AuthUserFile $setup->{auth_user_file}
 AuthGroupFile $setup->{auth_group_file}
+AuthOrder mod_auth_file.c
 EOC
     unless (close($fh)) {
       die("Can't write $setup->{config_file}: $!");
@@ -1636,6 +1650,7 @@ sub auth_group_file_world_readable_bug3892 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1708,6 +1723,7 @@ sub auth_group_file_world_writable_bug3892 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1781,6 +1797,7 @@ sub auth_user_file_world_writable_parent_dir_bug3892 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1885,6 +1902,7 @@ sub auth_user_file_symlink_world_writable_parent_dir_bug3892 {
 
     AuthUserFile => $auth_user_symlink,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1927,6 +1945,7 @@ sub auth_user_file_bad_syntax_bug3985 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2001,6 +2020,7 @@ sub auth_group_file_bad_syntax_bug3985 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2107,6 +2127,7 @@ sub auth_user_file_bad_syntax_check_issue490 {
 AuthFileOptions SyntaxCheck
 AuthUserFile $setup->{auth_user_file}
 AuthGroupFile $setup->{auth_group_file}
+AuthOrder mod_auth_file.c
 EOC
     unless (close($fh)) {
       die("Can't write $setup->{log_file}: $!");
@@ -2160,6 +2181,7 @@ AuthUserFile $setup->{auth_user_file}
 
 AuthFileOptions SyntaxCheck
 AuthGroupFile $setup->{auth_group_file}
+AuthOrder mod_auth_file.c
 EOC
     unless (close($fh)) {
       die("Can't write $setup->{log_file}: $!");
@@ -2239,6 +2261,7 @@ sub auth_file_symlink_segfault_bug4145 {
 
     AuthUserFile => $auth_user_symlink,
     AuthGroupFile => $auth_group_symlink,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2315,6 +2338,7 @@ sub auth_file_line_too_long_issue1321 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
@@ -160,6 +160,7 @@ sub ban_on_event_max_login_attempts {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -290,6 +291,7 @@ sub ban_on_event_max_login_attempts_from_user {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -484,6 +486,7 @@ sub ban_message {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -651,6 +654,7 @@ sub ban_ifclass_engine_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -841,6 +845,7 @@ sub ban_ifclass_engine_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 1,
 
@@ -1011,6 +1016,7 @@ sub ban_max_logins_exceeded_bug3281 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -1163,6 +1169,7 @@ sub ban_timeout_login_exceeded_bug3281 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutLogin => $timeout_login,
 
@@ -1306,6 +1313,7 @@ sub ban_engine_vhost_bug3355 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => $max_login_attempts,
 
@@ -1335,6 +1343,8 @@ sub ban_engine_vhost_bug3355 {
   Port $vhost_port
   AuthUserFile $auth_user_file
   AuthGroupFile $auth_group_file
+  AuthOrder mod_auth_file.c
+
   MaxLoginAttempts $max_login_attempts
   <IfModule mod_ban.c>
     BanEngine off
@@ -1492,6 +1502,7 @@ sub ban_unhandled_cmd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 1,
 
@@ -1673,6 +1684,7 @@ sub ban_on_event_client_connect_rate {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_ban.c' => {
@@ -1840,6 +1852,7 @@ sub ban_sighup_bug3751 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -1955,6 +1968,7 @@ sub ban_on_event_tlshandshake {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_ban.c' => {
@@ -2129,6 +2143,8 @@ sub ban_on_event_rootlogin {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootLogin => 'off',
 
     IfModules => {
@@ -2310,6 +2326,8 @@ sub ban_on_event_rootlogin_userdefined {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootLogin => 'off',
 
     IfModules => {
@@ -2451,6 +2469,7 @@ sub ban_opt_any_server_issue1010 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ban/memcache.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ban/memcache.pm
@@ -75,6 +75,7 @@ sub ban_memcache_max_login_attempts {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 1,
 
@@ -254,6 +255,7 @@ sub ban_memcache_json_max_login_attempts_bug4056 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 1,
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_cap.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_cap.pm
@@ -122,6 +122,7 @@ sub cap_dac_override {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     RootLogin => 'on',
@@ -259,6 +260,7 @@ sub cap_dac_override_ifuser_bug3576 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     RootLogin => 'on',
@@ -409,6 +411,7 @@ sub cap_rootrevoke_off_bug3839 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     RootLogin => 'on',
@@ -549,6 +552,7 @@ sub cap_rootrevoke_default_bug3839 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     RootLogin => 'on',
@@ -682,6 +686,7 @@ sub cap_sftp_setreuid_eagain_bug3923 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
@@ -217,6 +217,7 @@ sub copy_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -349,6 +350,7 @@ sub copy_file_no_login_bug4169 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -485,6 +487,7 @@ sub copy_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -609,6 +612,7 @@ sub copy_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -734,6 +738,7 @@ sub copy_before_auth {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -858,6 +863,7 @@ sub copy_help {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -997,6 +1003,7 @@ sub copy_config_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1156,6 +1163,7 @@ sub copy_config_allowoverwrite {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1277,6 +1285,7 @@ sub copy_config_pathdenyfilter {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     PathDenyFilter => '\.txt$',
 
@@ -2681,6 +2690,7 @@ sub copy_cpfr_cpto {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2823,6 +2833,7 @@ sub copy_cpfr_cpto_no_login_bug4169 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2969,6 +2980,7 @@ sub copy_cpto_no_cpfr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3102,6 +3114,7 @@ sub copy_cpfr_cpto_paths_with_spaces {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3246,6 +3259,8 @@ sub copy_config_limit_bug3399 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -3588,6 +3603,8 @@ sub copy_cpto_timeout_bug4263 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => 3,
 
     IfModules => {
@@ -3691,6 +3708,8 @@ sub copy_cpfr_config_limit_read_bug4372 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => 3,
 
     IfModules => {
@@ -3805,6 +3824,8 @@ sub copy_cpto_config_limit_write_bug4372 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => 3,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
@@ -137,6 +137,7 @@ sub deflate_opts_modez_level {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_deflate.c' => {
@@ -259,6 +260,7 @@ sub deflate_feat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_deflate.c' => {
@@ -399,6 +401,8 @@ sub deflate_list {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {
@@ -567,6 +571,8 @@ sub deflate_list_alternating_modes {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {
@@ -754,6 +760,8 @@ sub deflate_rest {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {
@@ -906,6 +914,8 @@ sub deflate_retr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {
@@ -1084,8 +1094,9 @@ sub deflate_rest_retr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    TimeoutLinger => 1,
+    AuthOrder => 'mod_auth_file.c',
 
+    TimeoutLinger => 1,
     AllowRetrieveRestart => 'on',
 
     IfModules => {
@@ -1258,6 +1269,8 @@ sub deflate_stor {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {
@@ -1439,6 +1452,8 @@ sub deflate_rest_stor {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     AllowOverwrite => 'on',
@@ -1610,6 +1625,7 @@ sub deflate_stor_64kb_binary {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_deflate.c' => {
@@ -1866,6 +1882,7 @@ sub deflate_stor_64kb_binary_chunks {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_deflate.c' => {
@@ -2128,6 +2145,7 @@ sub deflate_tls_mode_z {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_deflate.c' => {
@@ -2273,6 +2291,8 @@ sub deflate_netio_close_bad_cmd_sequence_bug3828 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLinger => 1,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
@@ -124,6 +124,7 @@ sub delay_cold_table {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -239,6 +240,7 @@ sub delay_warm_table {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -339,6 +341,7 @@ sub delay_extra_user_cmd_bug3622 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -501,6 +504,7 @@ sub delay_extra_pass_cmd_bug3622 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -663,6 +667,7 @@ sub delay_table_none_bug4020 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -782,6 +787,7 @@ sub delay_delayonevent_user_bug4020 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -866,6 +872,7 @@ sub delay_delayonevent_pass_bug4020 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -965,6 +972,7 @@ sub delay_delayonevent_failedlogin_bug4020 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1060,6 +1068,7 @@ sub delay_delayonevent_user_pass_bug4020 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => [

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_digest.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_digest.pm
@@ -396,6 +396,7 @@ sub digest_hash_feat {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -493,6 +494,7 @@ sub digest_hash_opts {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -669,6 +671,7 @@ sub digest_hash_crc32 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -820,6 +823,7 @@ sub digest_hash_crc32_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -971,6 +975,7 @@ sub digest_hash_crc32_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1128,6 +1133,7 @@ sub digest_hash_crc32_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1283,6 +1289,7 @@ sub digest_hash_crc32_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1411,6 +1418,7 @@ sub digest_hash_md5 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1537,6 +1545,7 @@ sub digest_hash_sha1 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1664,6 +1673,7 @@ sub digest_hash_sha256 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1791,6 +1801,7 @@ sub digest_hash_sha512 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1894,6 +1905,7 @@ sub digest_hash_failed_not_logged_in {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2001,6 +2013,7 @@ sub digest_hash_failed_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2110,6 +2123,7 @@ sub digest_hash_failed_not_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2227,6 +2241,7 @@ sub digest_hash_failed_config_limit {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2348,6 +2363,7 @@ sub digest_hash_failed_blacklisted_files {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2484,6 +2500,7 @@ sub digest_xcrc {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2621,6 +2638,7 @@ sub digest_xcrc_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2757,6 +2775,7 @@ sub digest_xcrc_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -2899,6 +2918,7 @@ sub digest_xcrc_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3039,6 +3059,7 @@ sub digest_xcrc_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -3178,6 +3199,7 @@ sub digest_xcrc_2gb {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3295,6 +3317,7 @@ sub digest_md5 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3387,6 +3410,7 @@ sub digest_md5_failed_not_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3508,6 +3532,7 @@ sub digest_xmd5 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3620,6 +3645,7 @@ sub digest_xsha {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3732,6 +3758,7 @@ sub digest_xsha1 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3845,6 +3872,7 @@ sub digest_xsha256 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3958,6 +3986,7 @@ sub digest_xsha512 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4070,6 +4099,8 @@ sub digest_host {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultServer => 'on',
     ServerName => '"Default Server"',
 
@@ -4267,6 +4298,7 @@ sub digest_path_offset_length {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4379,6 +4411,7 @@ sub digest_path_with_spaces {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4497,6 +4530,7 @@ sub digest_path_with_spaces_offset_length {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4610,6 +4644,7 @@ sub digest_caching {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4728,6 +4763,7 @@ sub digest_caching_max_size {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4900,6 +4936,7 @@ sub digest_caching_max_age_same_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5070,6 +5107,7 @@ sub digest_caching_max_age_different_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5230,6 +5268,8 @@ sub digest_caching_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseSendfile => 'off',
 
     IfModules => {
@@ -5376,6 +5416,8 @@ sub digest_caching_rest_retr {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     UseSendfile => 'off',
 
     IfModules => {
@@ -5516,6 +5558,7 @@ sub digest_caching_stor {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5644,6 +5687,7 @@ sub digest_caching_rest_stor {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5782,6 +5826,7 @@ sub digest_caching_appe {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5901,6 +5946,7 @@ sub digest_failed_not_logged_in {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5993,6 +6039,7 @@ sub digest_failed_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6089,6 +6136,7 @@ sub digest_failed_not_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6190,6 +6238,7 @@ sub digest_failed_blacklisted_files {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6299,6 +6348,7 @@ sub digest_failed_start_pos_invalid_number {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6404,6 +6454,7 @@ sub digest_failed_end_pos_invalid_number {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6509,6 +6560,7 @@ sub digest_failed_end_pos_too_large {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6614,6 +6666,7 @@ sub digest_failed_start_pos_after_end_pos {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6754,6 +6807,7 @@ sub digest_config_algorithms {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6900,6 +6954,7 @@ sub digest_config_default_algo {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7008,6 +7063,7 @@ sub digest_config_engine {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7156,6 +7212,7 @@ sub digest_config_engine_per_user {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7323,6 +7380,7 @@ sub digest_config_enable {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7464,6 +7522,8 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverride => 'on',
 
     IfModules => {
@@ -7589,6 +7649,7 @@ sub digest_config_max_size {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7725,6 +7786,7 @@ sub digest_config_max_size_per_user {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7961,6 +8023,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     UseSendfile => 'off',
 
@@ -8131,6 +8194,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8320,6 +8384,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8519,6 +8584,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_exec.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_exec.pm
@@ -162,6 +162,7 @@ sub exec_on_connect {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -301,6 +302,7 @@ sub exec_on_cmd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -430,6 +432,7 @@ sub exec_on_cmd_var_total_bytes_xfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -571,6 +574,7 @@ sub exec_on_cmd_var_bytes_xfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -712,6 +716,7 @@ sub exec_on_exit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -841,6 +846,7 @@ sub exec_on_error {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1010,6 +1016,7 @@ sub exec_on_restart {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1120,6 +1127,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1275,6 +1283,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1430,6 +1439,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1582,6 +1592,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1698,6 +1709,7 @@ sub exec_before_cmd_var_f_bug3432 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1834,6 +1846,7 @@ sub exec_before_cmd_var_F_bug3432 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1969,6 +1982,7 @@ sub exec_on_cmd_var_A_bug3479 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Anonymous => {
       $home_dir => {
@@ -2142,6 +2156,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -2310,6 +2325,8 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -2452,6 +2469,7 @@ sub exec_enable_per_dir_bug4076 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -2588,6 +2606,7 @@ sub exec_ifuser_on_cmd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_facl.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_facl.pm
@@ -74,6 +74,7 @@ sub facl_bug4303 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_facts.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_facts.pm
@@ -75,6 +75,7 @@ sub facts_advertise_off {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -207,6 +208,7 @@ sub facts_default_issue1367 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -348,6 +350,7 @@ sub facts_ownername_with_space_issue1367 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -487,6 +490,7 @@ sub facts_groupname_with_space_issue1367 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -617,6 +621,7 @@ sub opts_mlst_invalid {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -704,6 +709,7 @@ sub opts_mlst_clear {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -835,6 +841,7 @@ sub opts_mlst_set {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_geoip.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_geoip.pm
@@ -56,6 +56,7 @@ sub geoip_explicitly_allowed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -143,6 +144,7 @@ sub geoip_multi_allow_bug4188 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_geoip/sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_geoip/sql.pm
@@ -118,6 +118,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
@@ -184,9 +184,11 @@ sub ifuser_allowoverwrite {
     ScoreboardFile => $scoreboard_file,
     SystemLog => $log_file,
 
-    AllowOverride => 'on',
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
+    AllowOverride => 'on',
 
     IfModules => {
       'mod_delay.c' => {
@@ -341,10 +343,11 @@ sub ifgroup_dir_allow_mkd_bug3467 {
     ScoreboardFile => $scoreboard_file,
     SystemLog => $log_file,
 
-    AllowOverride => 'on',
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
+    AllowOverride => 'on',
     DefaultRoot => "~ $group",
 
     IfModules => {
@@ -483,6 +486,7 @@ sub ifuser_dir_allow_mkd_bug3467 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -625,6 +629,7 @@ sub ifclass_dir_allow_mkd_bug3467 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
     
     IfModules => {
       'mod_delay.c' => {
@@ -735,6 +740,7 @@ sub ifuser_login_deny_by_ip  {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -826,6 +832,7 @@ sub ifuser_login_deny_by_user  {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -949,6 +956,7 @@ sub ifgroup_ifclass_login_allowclass_bug3547 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1091,6 +1099,7 @@ sub ifuser_regex_login_deny_by_ip_bug3625  {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1226,6 +1235,7 @@ sub ifauthenticated_bug3629 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -1393,6 +1403,8 @@ sub ifgroup_displaylogin_bug3882 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1542,6 +1554,8 @@ sub ifgroup_dir_allow_stor_bug3881 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1719,6 +1733,8 @@ sub ifgroup_dir_allow_stor_bug3881_sftp {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1917,6 +1933,7 @@ sub ifclass_global_no_logging {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
     
     IfModules => {
       'mod_delay.c' => {
@@ -2097,6 +2114,7 @@ sub ifuser_no_pass_bug4199 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2247,6 +2265,7 @@ sub ifclass_and_not_classes {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2352,6 +2371,7 @@ sub ifuser_directory_bug4315 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_lang.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_lang.pm
@@ -185,6 +185,7 @@ sub lang_feat_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -325,6 +326,7 @@ sub lang_feat_engine_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -468,6 +470,7 @@ sub lang_lang_none_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -583,6 +586,7 @@ sub lang_lang_env_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -703,6 +707,7 @@ sub lang_lang_default_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -834,6 +839,7 @@ sub lang_lang_unknown_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -958,6 +964,7 @@ sub lang_opts_utf8_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1082,6 +1089,7 @@ sub lang_opts_utf8_nonbool_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1214,6 +1222,7 @@ sub lang_lang_default_en_US {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1341,6 +1350,7 @@ sub lang_lang_default_en_US_UTF8 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1460,6 +1470,7 @@ sub lang_opts_utf8_useencoding_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1595,6 +1606,7 @@ sub lang_opts_utf8_useencoding_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1738,6 +1750,7 @@ sub lang_opts_utf8_useencoding_charsets {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1868,6 +1881,7 @@ sub lang_opts_utf8_useencoding_charsets_strict {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2022,6 +2036,7 @@ sub lang_opts_utf8_useencoding_charsets_strict_with_utf8 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2190,6 +2205,7 @@ sub lang_opts_utf8_useencoding_charsets_with_env {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2329,6 +2345,7 @@ sub lang_useencoding_latin1_utf8 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2466,6 +2483,7 @@ sub lang_useencoding_utf8_latin1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2597,6 +2615,7 @@ sub lang_opts_utf8_prefer_server_encoding_bug4125 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2752,6 +2771,7 @@ sub lang_opts_utf8_useencoding_charsets_prefer_server_encoding_bug4125 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2915,6 +2935,7 @@ sub lang_useencoding_ascii_utf8_require_valid_encoding_bug4125 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3017,6 +3038,7 @@ sub lang_useencoding_latin1_utf8_per_user_bug4214 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3127,6 +3149,7 @@ sub lang_useencoding_utf8_latin1_per_user_bug4214 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_log_forensic.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_log_forensic.pm
@@ -81,6 +81,7 @@ sub forensic_failed_login {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -224,6 +225,7 @@ sub forensic_good_login {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_file.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_file.pm
@@ -204,6 +204,7 @@ sub quotatab_file_single_suppl_group {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
 
@@ -382,6 +383,7 @@ sub quotatab_file_all_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
 
@@ -618,6 +620,7 @@ sub quotatab_file_bytes_download_zero {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultChdir => '~',
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
@@ -10502,6 +10502,7 @@ EOS
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ratio.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ratio.pm
@@ -95,6 +95,7 @@ sub ratio_bug3600 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -242,6 +243,7 @@ sub ratio_after_disconnect {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -438,6 +440,7 @@ sub ratio_userratio_with_credit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_readme.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_readme.pm
@@ -82,6 +82,7 @@ sub readme_login_path {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -184,6 +185,7 @@ sub readme_login_path_nonexistent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -288,6 +290,7 @@ sub readme_login_pattern {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -415,6 +418,7 @@ sub readme_cwd_pattern {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -579,6 +583,7 @@ sub readme_cwd_pattern_multiple_matches {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -743,6 +748,7 @@ sub readme_login_path_displaylogin_bug3605 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DisplayLogin => $login_file,
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_redis.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_redis.pm
@@ -155,6 +155,7 @@ sub redis_log_on_command {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -268,6 +269,7 @@ sub redis_log_on_command_custom_key {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -388,6 +390,7 @@ sub redis_log_on_command_per_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -517,6 +520,7 @@ sub redis_log_on_command_per_dir_none {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -639,6 +643,7 @@ sub redis_log_on_command_per_dir_none2 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -758,6 +763,7 @@ sub redis_log_on_event {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -878,6 +884,7 @@ sub redis_log_on_event_custom_key {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1000,6 +1007,7 @@ sub redis_log_on_event_per_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1129,6 +1137,7 @@ sub redis_log_on_event_per_dir_none {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1251,6 +1260,7 @@ sub redis_log_on_event_per_dir_none2 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1370,6 +1380,7 @@ sub redis_log_fmt_extra_with_log_on_commmand {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1489,6 +1500,7 @@ sub redis_log_fmt_extra_with_log_on_event {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_rewrite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_rewrite.pm
@@ -324,6 +324,7 @@ sub rewrite_map_lowercase {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -474,6 +475,7 @@ sub rewrite_map_spaces_underscores {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -602,6 +604,7 @@ sub rewrite_map_whitespace_underscores {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -711,6 +714,7 @@ sub rewrite_map_whitespace_trim {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -854,6 +858,7 @@ sub rewrite_rule_append_pid {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1002,6 +1007,7 @@ sub rewrite_bug2915 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1136,6 +1142,7 @@ sub rewrite_bug3027 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1281,6 +1288,7 @@ sub rewrite_bug3034 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 
@@ -1427,6 +1435,7 @@ sub rewrite_bug3169 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 
@@ -1575,6 +1584,7 @@ sub rewrite_map_unescape_bug3170 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowForeignAddress => 'on',
 
@@ -1738,6 +1748,7 @@ sub rewrite_cond_env_var_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1895,6 +1906,7 @@ sub rewrite_cond_env_var_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     SetEnv => 'PR_TEST_FOO foo',
 
@@ -2043,6 +2055,7 @@ sub rewrite_rule_env_var_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2194,6 +2207,7 @@ sub rewrite_rule_env_var_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     SetEnv => 'PR_TEST_FOO foo',
 
@@ -2336,6 +2350,7 @@ sub rewrite_escape_rule_backref_bug3028 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2475,6 +2490,7 @@ sub rewrite_escape_cond_backref_bug3028 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2619,6 +2635,7 @@ sub rewrite_cond_rename_var_bug3029 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2739,6 +2756,7 @@ sub rewrite_cond_or_flags_bug3269 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2875,6 +2893,7 @@ sub rewrite_cond_nc_flags {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3020,6 +3039,7 @@ sub rewrite_map_fifo_bug3611 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3168,6 +3188,7 @@ sub rewrite_rule_replaceall_backslash_with_slash {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3324,6 +3345,7 @@ sub rewrite_map_max_replace_bug3721 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3464,6 +3486,7 @@ sub rewrite_cond_time_var_bug3673 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3611,6 +3634,7 @@ sub rewrite_cond_time_year_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3766,6 +3790,7 @@ sub rewrite_cond_time_mon_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3921,6 +3946,7 @@ sub rewrite_cond_time_day_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4076,6 +4102,7 @@ sub rewrite_cond_time_wday_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4231,6 +4258,7 @@ sub rewrite_cond_time_hour_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4386,6 +4414,7 @@ sub rewrite_cond_time_min_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4541,6 +4570,7 @@ sub rewrite_cond_time_sec_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4695,6 +4725,7 @@ sub rewrite_rule_time_year_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4846,6 +4877,7 @@ sub rewrite_rule_time_mon_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4997,6 +5029,7 @@ sub rewrite_rule_time_day_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5148,6 +5181,7 @@ sub rewrite_rule_time_wday_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5299,6 +5333,7 @@ sub rewrite_rule_time_hour_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5450,6 +5485,7 @@ sub rewrite_rule_time_min_var_bug3673 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5592,6 +5628,7 @@ sub rewrite_bug3767 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5725,6 +5762,8 @@ sub rewrite_bug4017 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -5862,6 +5901,8 @@ sub rewrite_using_pcre_bug4017 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -5965,8 +6006,9 @@ sub rewrite_using_pcre_issue1300 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
-    DefaultChdir => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultChdir => '~',
     DenyFilter => '\*.*/',
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_rlimit.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_rlimit.pm
@@ -47,6 +47,7 @@ sub rlimit_memory {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -2062,6 +2062,7 @@ sub ssh2_connect_bad_version_bad_format {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2169,6 +2170,7 @@ sub ssh2_connect_bad_version_unsupported_proto_version {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2276,6 +2278,7 @@ sub ssh2_connect_bad_version_too_long {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2383,6 +2386,7 @@ sub ssh2_connect_bad_version_too_short {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2490,6 +2494,7 @@ sub ssh2_connect_version_with_comments {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2628,6 +2633,7 @@ sub ssh2_connect_version_bug3918 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2795,6 +2801,8 @@ sub ssh2_connect_timeout_login {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLogin => 3,
 
     IfModules => {
@@ -2900,6 +2908,7 @@ sub ssh2_kex_dh_group1_sha1 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3027,6 +3036,7 @@ sub ssh2_kex_dh_group14_sha1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3160,6 +3170,7 @@ sub ssh2_kex_dh_gex_sha1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3345,6 +3356,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3596,6 +3608,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3847,6 +3860,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4046,6 +4060,7 @@ sub ssh2_hostkey_rsa {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4178,6 +4193,7 @@ sub ssh2_hostkey_rsa_only {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4330,6 +4346,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4514,6 +4531,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4690,6 +4708,7 @@ sub ssh2_hostkey_dss {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4822,6 +4841,7 @@ sub ssh2_hostkey_dss_only {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4994,6 +5014,7 @@ sub ssh2_hostkey_dss_bug3634 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5183,6 +5204,7 @@ sub ssh2_hostkey_passphraseprovider_bug3851 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5369,6 +5391,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5619,6 +5642,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5869,6 +5893,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6074,6 +6099,7 @@ sub ssh2_ext_hostkey_openssh_rsa_issue793 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6262,6 +6288,7 @@ sub ssh2_ext_hostkey_openssh_rsa_passphraseprovider_issue793 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6464,6 +6491,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6668,6 +6696,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6870,6 +6899,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7073,6 +7103,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7278,6 +7309,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7465,6 +7497,7 @@ sub ssh2_cipher_c2s_aes256_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7598,6 +7631,7 @@ sub ssh2_cipher_c2s_aes192_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7731,6 +7765,7 @@ sub ssh2_cipher_c2s_aes128_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7864,6 +7899,7 @@ sub ssh2_cipher_c2s_blowfish_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7998,6 +8034,7 @@ sub ssh2_cipher_c2s_arcfour {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8234,6 +8271,7 @@ sub ssh2_cipher_c2s_3des_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8367,6 +8405,7 @@ sub ssh2_cipher_c2s_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8598,6 +8637,7 @@ sub ssh2_cipher_s2c_aes192_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8731,6 +8771,7 @@ sub ssh2_cipher_s2c_aes128_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8864,6 +8905,7 @@ sub ssh2_cipher_s2c_blowfish_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8998,6 +9040,7 @@ sub ssh2_cipher_s2c_arcfour {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9234,6 +9277,7 @@ sub ssh2_cipher_s2c_3des_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9367,6 +9411,7 @@ sub ssh2_cipher_s2c_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9491,6 +9536,7 @@ sub ssh2_ext_cipher_aes128_gcm_bug3759 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9660,6 +9706,7 @@ sub ssh2_ext_cipher_aes256_gcm_bug3759 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9839,6 +9886,7 @@ sub ssh2_mac_c2s_hmac_sha1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9972,6 +10020,7 @@ sub ssh2_mac_c2s_hmac_sha1_96 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10105,6 +10154,7 @@ sub ssh2_mac_c2s_hmac_md5 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10239,6 +10289,7 @@ sub ssh2_mac_c2s_hmac_md5_96 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10373,6 +10424,7 @@ sub ssh2_mac_c2s_hmac_ripemd160 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10507,6 +10559,7 @@ sub ssh2_mac_c2s_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10641,6 +10694,7 @@ sub ssh2_mac_s2c_hmac_sha1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10774,6 +10828,7 @@ sub ssh2_mac_s2c_hmac_sha1_96 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10907,6 +10962,7 @@ sub ssh2_mac_s2c_hmac_md5 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11041,6 +11097,7 @@ sub ssh2_mac_s2c_hmac_md5_96 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11175,6 +11232,7 @@ sub ssh2_mac_s2c_hmac_ripemd160 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11309,6 +11367,7 @@ sub ssh2_mac_s2c_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11494,6 +11553,7 @@ EOC
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11679,6 +11739,7 @@ sub ssh2_ext_mac_hmac_md5_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11846,6 +11907,7 @@ sub ssh2_ext_mac_hmac_sha1_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12012,6 +12074,7 @@ sub ssh2_ext_mac_hmac_sha256_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12178,6 +12241,7 @@ sub ssh2_ext_mac_hmac_sha512_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12344,6 +12408,7 @@ sub ssh2_ext_mac_umac_64_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12510,6 +12575,7 @@ sub ssh2_ext_mac_umac_128_etm_openssh {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12686,6 +12752,7 @@ sub ssh2_compress_c2s_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12819,6 +12886,7 @@ sub ssh2_compress_c2s_zlib {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12954,6 +13022,7 @@ sub ssh2_compress_s2c_none {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13087,6 +13156,7 @@ sub ssh2_compress_s2c_zlib {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13231,6 +13301,7 @@ sub ssh2_auth_hostbased {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13373,6 +13444,7 @@ sub ssh2_auth_publickey_rsa_no_match_bug3493 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13514,6 +13586,7 @@ sub ssh2_auth_publickey_rsa_with_match_bug3493 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13630,6 +13703,7 @@ sub ssh2_auth_publickey_rsa2048_2nd_key {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13766,6 +13840,7 @@ sub ssh2_auth_publickey_rsa2048 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13911,6 +13986,7 @@ sub ssh2_auth_publickey_rsa2048_no_nl {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14021,6 +14097,7 @@ sub ssh2_auth_publickey_rsa2048_min_4096_bug4233 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14164,6 +14241,7 @@ sub ssh2_auth_publickey_rsa4096 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14305,6 +14383,7 @@ sub ssh2_auth_publickey_rsa8192 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14448,6 +14527,8 @@ sub ssh2_auth_publickey_rsa16384 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -14599,6 +14680,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14804,6 +14886,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14999,6 +15082,7 @@ sub ssh2_auth_publickey_dsa1024 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15140,6 +15224,7 @@ sub ssh2_auth_publickey_dsa2048 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15281,6 +15366,7 @@ sub ssh2_auth_publickey_dsa4096 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15422,6 +15508,7 @@ sub ssh2_auth_publickey_dsa8192 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15566,6 +15653,7 @@ sub ssh2_auth_publickey_user_var_bug3315 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15735,6 +15823,7 @@ sub ssh2_ext_auth_publickey_ecdsa256 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15966,6 +16055,7 @@ sub ssh2_ext_auth_publickey_ecdsa384 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -16197,6 +16287,7 @@ sub ssh2_ext_auth_publickey_ecdsa521 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -16401,6 +16492,7 @@ sub ssh2_ext_auth_publickey_openssh_rsa_bug4221 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -16608,6 +16700,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -16871,6 +16964,7 @@ sub ssh2_auth_password_failed {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17000,6 +17094,7 @@ sub ssh2_auth_kbdint_failed_password_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17164,6 +17259,7 @@ sub ssh2_auth_twice {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17328,6 +17424,7 @@ sub ssh2_auth_publickey_password_chain_bug4153 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17489,6 +17586,7 @@ sub ssh2_auth_publickey_publickey_chain_bug4153 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17768,6 +17866,7 @@ sub ssh2_interop_scanner {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -17921,6 +18020,7 @@ sub ssh2_interop_probe {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18072,6 +18172,7 @@ sub ssh2_channel_failed_ptyreq {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18215,6 +18316,7 @@ sub ssh2_channel_failed_shell {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18358,6 +18460,7 @@ sub ssh2_channel_failed_exec_cmd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18503,6 +18606,7 @@ sub ssh2_channel_env_default {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18667,6 +18771,7 @@ sub ssh2_channel_env_accept_glob_char {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -18837,6 +18942,7 @@ sub ssh2_channel_env_accept_single_char {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -19006,6 +19112,7 @@ sub ssh2_channel_max_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -19155,6 +19262,7 @@ sub ssh2_disconnect_client {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 
@@ -19295,6 +19403,7 @@ sub sftp_without_auth {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -19405,6 +19514,7 @@ sub sftp_stat {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -19566,6 +19676,7 @@ sub sftp_stat_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -19725,6 +19836,7 @@ sub sftp_stat_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -19882,6 +19994,7 @@ sub sftp_stat_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -20018,6 +20131,7 @@ sub sftp_stat_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -20172,6 +20286,7 @@ sub sftp_stat_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -20335,6 +20450,7 @@ sub sftp_stat_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -20497,6 +20613,7 @@ sub sftp_stat_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -20638,6 +20755,7 @@ sub sftp_stat_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -20781,6 +20899,7 @@ sub sftp_fstat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -20953,6 +21072,7 @@ sub sftp_lstat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -21103,6 +21223,7 @@ sub sftp_setstat {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -21258,6 +21379,7 @@ sub sftp_setstat_sgid {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -21417,6 +21539,7 @@ sub sftp_setstat_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -21574,6 +21697,7 @@ sub sftp_setstat_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -21726,6 +21850,7 @@ sub sftp_setstat_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -21865,6 +21990,7 @@ sub sftp_setstat_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -22017,6 +22143,7 @@ sub sftp_setstat_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -22178,6 +22305,7 @@ sub sftp_setstat_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -22335,6 +22463,7 @@ sub sftp_setstat_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -22479,6 +22608,7 @@ sub sftp_setstat_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -22625,6 +22755,7 @@ sub sftp_fsetstat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -22798,6 +22929,7 @@ sub sftp_realpath {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -22964,6 +23096,7 @@ sub sftp_realpath_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -23143,6 +23276,7 @@ sub sftp_realpath_symlink_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -23325,6 +23459,8 @@ sub sftp_realpath_symlink_file_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -23479,6 +23615,7 @@ sub sftp_realpath_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -23650,6 +23787,7 @@ sub sftp_realpath_symlink_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -23824,6 +23962,8 @@ sub sftp_realpath_symlink_dir_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -23977,6 +24117,7 @@ sub sftp_open_enoent_bug3345 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -24135,6 +24276,8 @@ sub sftp_open_trunc_bug3449 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -24343,6 +24486,8 @@ sub sftp_open_creat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -24497,6 +24642,8 @@ sub sftp_open_creat_excl {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -24677,6 +24824,8 @@ sub sftp_open_append_bug3450 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -24854,6 +25003,8 @@ sub sftp_open_rdonly {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -25024,6 +25175,8 @@ sub sftp_open_wronly {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -25194,6 +25347,8 @@ sub sftp_open_rdwr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -25371,6 +25526,8 @@ sub sftp_open_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -25536,6 +25693,7 @@ sub sftp_open_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -25691,6 +25849,8 @@ sub sftp_open_abs_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -25829,6 +25989,7 @@ sub sftp_open_abs_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -25985,6 +26146,8 @@ sub sftp_open_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -26154,6 +26317,7 @@ sub sftp_open_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -26314,6 +26478,8 @@ sub sftp_open_rel_symlink_enoent {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
 
@@ -26457,6 +26623,7 @@ sub sftp_open_rel_symlink_enoent_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -26602,6 +26769,7 @@ sub sftp_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -26757,6 +26925,7 @@ sub sftp_upload_with_compression {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -26922,6 +27091,7 @@ sub sftp_upload_zero_len_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -27112,6 +27282,7 @@ sub sftp_upload_largefile {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -27301,6 +27472,8 @@ sub sftp_upload_device_full {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -27476,6 +27649,8 @@ sub sftp_upload_fifo_bug3312 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -27632,6 +27807,8 @@ sub sftp_upload_fifo_bug3313 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -28030,6 +28207,7 @@ sub sftp_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -28212,6 +28390,7 @@ sub sftp_download_with_compression {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -28378,6 +28557,7 @@ sub sftp_download_with_compression_rekeying {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -28567,6 +28747,7 @@ sub sftp_download_zero_len_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -28765,6 +28946,7 @@ sub sftp_download_largefile {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -28958,6 +29140,7 @@ sub sftp_download_fifo_bug3314 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -29167,6 +29350,7 @@ sub sftp_ext_download_bug3550 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -29429,6 +29613,7 @@ sub sftp_ext_download_server_rekey {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 
@@ -29655,6 +29840,7 @@ sub sftp_ext_download_rekey_rsa1024_hostkey_bug4097 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 
@@ -29855,6 +30041,7 @@ sub sftp_download_server_rekey {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     TimeoutIdle => $timeout_idle,
 
@@ -30037,6 +30224,7 @@ sub sftp_download_readonly_bug3787 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -30200,6 +30388,7 @@ sub sftp_readdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -30393,6 +30582,7 @@ sub sftp_readdir_abs_symlink_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -30573,6 +30763,7 @@ sub sftp_readdir_abs_symlink_dir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -30772,6 +30963,7 @@ sub sftp_readdir_abs_symlink_dir_vroot {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -30970,6 +31162,7 @@ sub sftp_readdir_rel_symlink_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -31154,6 +31347,7 @@ sub sftp_readdir_rel_symlink_dir_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -31364,6 +31558,7 @@ sub sftp_readdir_wide_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -31589,6 +31784,7 @@ sub sftp_readdir_with_removes {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -31805,6 +32001,7 @@ sub sftp_mkdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -31956,6 +32153,7 @@ sub sftp_mkdir_eexist {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -32089,6 +32287,7 @@ sub sftp_mkdir_abs_symlink_eexist {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -32214,6 +32413,7 @@ sub sftp_mkdir_abs_symlink_eexist_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -32346,6 +32546,7 @@ sub sftp_mkdir_rel_symlink_eexist {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -32476,6 +32677,7 @@ sub sftp_mkdir_rel_symlink_eexist_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -32623,6 +32825,7 @@ sub sftp_mkdir_readdir_bug3481 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -32803,6 +33006,7 @@ sub sftp_rmdir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -32957,6 +33161,7 @@ sub sftp_rmdir_dir_not_empty {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -33107,6 +33312,7 @@ sub sftp_rmdir_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -33244,6 +33450,7 @@ sub sftp_rmdir_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -33387,6 +33594,7 @@ sub sftp_rmdir_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -33528,6 +33736,7 @@ sub sftp_rmdir_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -33682,6 +33891,7 @@ sub sftp_remove {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -33844,6 +34054,7 @@ sub sftp_rename {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -33979,6 +34190,7 @@ sub sftp_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -34115,6 +34327,7 @@ sub sftp_symlink_dst_already_exists {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -34263,6 +34476,7 @@ sub sftp_symlink_src_does_not_exist {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -34397,6 +34611,7 @@ sub sftp_readlink_abs_dst {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -34530,6 +34745,8 @@ sub sftp_readlink_abs_dst_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -34662,6 +34879,7 @@ sub sftp_readlink_rel_dst {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -34789,6 +35007,8 @@ sub sftp_readlink_rel_dst_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -34947,6 +35167,7 @@ sub sftp_readlink_symlink_dir_bug4140 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -35102,6 +35323,7 @@ sub sftp_config_allowoverwrite {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -35271,6 +35493,7 @@ sub sftp_config_allowstorerestart {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -35434,6 +35657,8 @@ sub sftp_config_client_alive {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -35569,6 +35794,7 @@ sub sftp_config_client_match {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -35681,6 +35907,7 @@ sub sftp_config_client_match_no_matching_protocol_version_issue1200 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -36441,6 +36668,7 @@ sub sftp_config_createhome {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     CreateHome => "on 711 homegid $home_gid",
 
@@ -36613,6 +36841,8 @@ sub sftp_config_defaultchdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~/public_sftp',
 
     IfModules => {
@@ -36811,6 +37041,7 @@ sub sftp_config_deleteabortedstores {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     HiddenStores => 'on',
     DeleteAbortedStores => 'on',
@@ -36982,6 +37213,7 @@ sub sftp_config_dirfakemode {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DirFakeMode => '0310',
 
@@ -37197,6 +37429,7 @@ sub sftp_config_hiddenstores {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     HiddenStores => 'on',
 
@@ -37382,6 +37615,7 @@ sub sftp_config_hidefiles_abs_path {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/' => {
@@ -37596,6 +37830,7 @@ sub sftp_config_hidefiles_deferred_path_bug3470 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -37810,6 +38045,8 @@ sub sftp_config_hidefiles_deferred_path_chroot_bug3470 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     Directory => {
@@ -38030,6 +38267,7 @@ sub sftp_config_hidefiles_symlink_bug3924 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '/' => {
@@ -38248,6 +38486,7 @@ sub sftp_config_hidenoaccess {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -38468,6 +38707,8 @@ sub sftp_config_max_clients_per_host_bug3630 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     MaxClientsPerHost => $max_clients_per_host,
 
     IfModules => {
@@ -38590,6 +38831,7 @@ sub sftp_auth_logging_bad_password_issue693 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Note that this test looks at the generated logging for verifying the
     # behavior, thus we set the DebugLevel appropriately.
@@ -38739,6 +38981,7 @@ sub sftp_auth_logging_bad_password_max_login_attempts_issue693 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Note that we specifically want 2 here, to test the handling of the
     # initial non-fatal attempt, and the second fatal
@@ -38898,6 +39141,7 @@ sub sftp_auth_logging_publickey_then_password_issue693 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Note that this test looks at the generated logging for verifying the
     # behavior, thus we set the DebugLevel appropriately.
@@ -39057,6 +39301,7 @@ sub sftp_auth_logging_publickey_then_password_max_login_attempts_issue693 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     # Note that we specifically want 2 here, to test the handling of the
     # initial non-fatal attempt, and the second fatal
@@ -39220,6 +39465,8 @@ sub sftp_config_max_login_attempts_via_password {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxLoginAttempts => 1,
 
     # Note that this test looks at the generated logging for verifying the
@@ -39377,6 +39624,8 @@ sub sftp_config_max_login_attempts_via_publickey {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxLoginAttempts => 1,
 
     # Note that this test looks at the generated logging for verifying the
@@ -39559,6 +39808,8 @@ sub sftp_config_max_login_attempts_none_bug4087 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     MaxLoginAttempts => 'none',
 
     IfModules => {
@@ -39717,6 +39968,7 @@ sub sftp_config_pathdenyfilter_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     PathDenyFilter => '\.ext$',
 
@@ -39876,6 +40128,7 @@ sub sftp_config_pathdenyfilter_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     PathDenyFilter => '\.dir$',
 
@@ -40049,6 +40302,8 @@ sub sftp_config_rekey_short_timeout_failed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -40241,6 +40496,8 @@ sub sftp_config_rekey_long_timeout_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -40417,6 +40674,7 @@ sub sftp_config_rootlogin {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     RootLogin => 'off',
 
@@ -40550,6 +40808,7 @@ sub sftp_config_protocols {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -40696,6 +40955,8 @@ sub sftp_config_serverident_off {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     ServerIdent => 'off',
 
     IfModules => {
@@ -40859,6 +41120,8 @@ sub sftp_config_serverident_on {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     ServerIdent => 'on',
 
     IfModules => {
@@ -41024,6 +41287,8 @@ sub sftp_config_serverident_on_custom {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     ServerIdent => "on $custom_id",
 
     IfModules => {
@@ -41189,6 +41454,8 @@ sub sftp_config_timeoutidle {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle,
 
     IfModules => {
@@ -41373,6 +41640,8 @@ sub sftp_config_timeoutlogin {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutLogin => $timeout_login,
 
     IfModules => {
@@ -41516,6 +41785,8 @@ sub sftp_config_timeoutnotransfer_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutNoTransfer => $timeout_noxfer,
 
     IfModules => {
@@ -41680,6 +41951,8 @@ sub sftp_config_timeoutnotransfer_readdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutNoTransfer => $timeout_noxfer,
 
     IfModules => {
@@ -41844,6 +42117,8 @@ sub sftp_config_timeoutnotransfer_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutNoTransfer => $timeout_noxfer,
 
     IfModules => {
@@ -42020,6 +42295,8 @@ sub sftp_config_timeoutstalled {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutStalled => $timeout_stalled,
 
     IfModules => {
@@ -42189,6 +42466,7 @@ sub sftp_config_ignore_upload_perms_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -42356,6 +42634,7 @@ sub sftp_config_ignore_upload_perms_mkdir_bug3680 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -42527,6 +42806,7 @@ sub sftp_config_ignore_set_perms_bug3599 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -42704,6 +42984,7 @@ sub sftp_config_ignore_set_times_bug3706 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -42886,6 +43167,7 @@ sub sftp_config_ignore_set_owners_bug3757 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -43061,6 +43343,8 @@ sub sftp_config_userowner {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootRevoke => 'off',
 
     Directory => {
@@ -43239,6 +43523,8 @@ sub sftp_config_groupowner_file_nonmember {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
 #    RootRevoke => 'off',
 
     Directory => {
@@ -43430,6 +43716,8 @@ sub sftp_config_groupowner_file_member_norootprivs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootLogin => $root_login,
 
     Directory => {
@@ -43622,6 +43910,8 @@ sub sftp_config_groupowner_dir_member_norootprivs_bug3765 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~',
 
     Directory => {
@@ -43865,6 +44155,7 @@ EOF
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverride => 'on',
     PathDenyFilter => '"\\\\.ftpaccess$"',
@@ -44066,6 +44357,7 @@ sub sftp_config_limit_appe {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     Directory => {
       '~' => {
@@ -44231,6 +44523,7 @@ sub sftp_config_limit_chmod {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -44395,6 +44688,7 @@ sub sftp_config_limit_chgrp_bug3757 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -44565,6 +44859,7 @@ sub sftp_config_limit_list {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -44757,6 +45052,7 @@ sub sftp_config_limit_nlst {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -44951,6 +45247,8 @@ sub sftp_config_limit_allowfilter_stor_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultChdir => '~/test.d',
 
     IfModules => {
@@ -45117,6 +45415,7 @@ sub sftp_config_limit_allowfilter_stor_denied {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -45276,6 +45575,7 @@ sub sftp_config_limit_dirs_realpath_bug3871 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -45454,6 +45754,7 @@ sub sftp_config_limit_readdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -45638,6 +45939,7 @@ sub sftp_config_limit_fsetstat_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -45831,6 +46133,7 @@ sub sftp_config_limit_mkdir_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -45996,6 +46299,7 @@ sub sftp_config_limit_opendir_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -46162,6 +46466,7 @@ sub sftp_config_limit_readdir_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -46397,6 +46702,7 @@ sub sftp_config_limit_readlink_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -46573,6 +46879,7 @@ sub sftp_config_limit_remove_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -46753,6 +47060,7 @@ sub sftp_config_limit_rename_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -46925,6 +47233,7 @@ sub sftp_config_limit_rmdir_bug3753 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -47059,6 +47368,8 @@ sub sftp_config_maxclientsperuser_issue750 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxClientsPerUser => 1,
 
     IfModules => {
@@ -47216,6 +47527,7 @@ sub sftp_multi_channels {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -47353,6 +47665,7 @@ sub sftp_config_serverlog_issue1227 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -47508,6 +47821,7 @@ sub sftp_config_insecure_hostkey_perms_bug4098 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -47568,6 +47882,7 @@ sub sftp_config_allow_empty_passwords_off_bug4309 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -47768,6 +48083,7 @@ sub sftp_multi_channel_downloads {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -48027,6 +48343,7 @@ sub sftp_log_xferlog_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xferlog_file,
 
@@ -48288,6 +48605,8 @@ sub sftp_log_xferlog_download_incomplete {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TransferLog => $xferlog_file,
 
     IfModules => {
@@ -48537,6 +48856,7 @@ sub sftp_log_xferlog_delete {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xferlog_file,
 
@@ -48775,8 +49095,9 @@ sub sftp_log_xferlog_delete_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultRoot => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultRoot => '~',
     TransferLog => $xferlog_file,
 
     IfModules => {
@@ -49000,6 +49321,7 @@ sub sftp_log_xferlog_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xferlog_file,
 
@@ -49241,6 +49563,8 @@ sub sftp_log_xferlog_upload_incomplete {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TransferLog => $xferlog_file,
 
     IfModules => {
@@ -49481,6 +49805,7 @@ sub sftp_log_extlog_auth_bug3845 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'login "\"%r\" %s"',
     ExtendedLog => "$extlog_file AUTH login",
@@ -49668,6 +49993,7 @@ sub sftp_log_extlog_reads {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%m \"%F\""',
     ExtendedLog => "$extlog_file READ transfer",
@@ -49856,6 +50182,7 @@ sub sftp_log_extlog_read_close {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%m \"%F\""',
     ExtendedLog => "$extlog_file READ transfer",
@@ -50061,6 +50388,7 @@ sub sftp_log_extlog_write_close {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%m \"%F\""',
     ExtendedLog => "$extlog_file WRITE transfer",
@@ -50283,6 +50611,7 @@ sub sftp_log_extlog_var_s_reads {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'response "%r %s"',
     ExtendedLog => "$extlog_file READ response",
@@ -50537,6 +50866,7 @@ sub sftp_log_extlog_var_s_writes {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'response "%r %s"',
     ExtendedLog => "$extlog_file WRITE response",
@@ -50768,6 +51098,7 @@ sub sftp_log_extlog_file_modified_bug3457 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     LogFormat => 'custom "%{file-modified}"',
@@ -50952,6 +51283,7 @@ sub sftp_log_extlog_retr_file_size {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%m %b',
     ExtendedLog => "$extlog_file READ transfer",
@@ -51171,6 +51503,7 @@ sub sftp_log_extlog_putty_mget_retr_file_size_bug3560 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%m %b',
     ExtendedLog => "$extlog_file READ transfer",
@@ -51431,8 +51764,9 @@ sub sftp_log_extlog_var_F_mkdir_rmdir_bug3591 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultRoot => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultRoot => '~',
     LogFormat => 'dirlog "%m %F"',
     ExtendedLog => "$extlog_file WRITE dirlog",
 
@@ -51651,6 +51985,7 @@ sub sftp_log_extlog_var_w_rename_bug3029 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'rename "%m: %w %f"',
     ExtendedLog => "$extlog_file ALL rename",
@@ -51898,6 +52233,7 @@ sub sftp_log_extlog_var_f_remove {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'delete "%m %f"',
     ExtendedLog => "$extlog_file WRITE delete",
@@ -52091,6 +52427,7 @@ sub sftp_log_extlog_var_f_write {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'writes "%f: %r"',
     ExtendedLog => "$extlog_file WRITE writes",
@@ -52289,8 +52626,9 @@ sub sftp_log_extlog_var_f_write_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
-    DefaultRoot => '~',
+    AuthOrder => 'mod_auth_file.c',
 
+    DefaultRoot => '~',
     LogFormat => 'writes "%f: %r"',
     ExtendedLog => "$extlog_file WRITE writes",
 
@@ -52488,6 +52826,7 @@ sub sftp_log_extlog_var_r_write {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'writes "%r"',
     ExtendedLog => "$extlog_file WRITE writes",
@@ -52690,6 +53029,7 @@ sub sftp_log_extlog_var_note_bug3707 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'requestID "%m %f id=%{note:sftp.file-handle}"',
     ExtendedLog => "$extlog_file READ requestID",
@@ -52940,6 +53280,7 @@ sub sftp_log_extlog_var_s_remove_bug3873 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'delete "%m %f %s"',
     ExtendedLog => "$extlog_file WRITE delete",
@@ -53165,6 +53506,7 @@ sub sftp_log_extlog_env_banner_bug4065 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'banner "%m: banner=%{SFTP_CLIENT_BANNER}e"',
     ExtendedLog => "$extlog_file ALL banner",
@@ -53341,6 +53683,7 @@ sub sftp_log_extlog_userauth_full_request {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'userauth "%m: %r"',
     ExtendedLog => "$extlog_file AUTH userauth",
@@ -53518,6 +53861,7 @@ sub sftp_sighup {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DenyFilter => '\*/',
 
@@ -53962,6 +54306,7 @@ sub sftp_wrap_login_allowed_bug3352 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -54132,6 +54477,7 @@ sub sftp_wrap_login_denied_bug3352 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -54239,6 +54585,7 @@ sub scp_upload {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -54384,6 +54731,7 @@ sub scp_upload_zero_len_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -54532,6 +54880,7 @@ sub scp_upload_largefile {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -54698,6 +55047,7 @@ sub scp_upload_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -54841,6 +55191,7 @@ sub scp_upload_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     DefaultRoot => '~',
@@ -54989,6 +55340,7 @@ sub scp_upload_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
 
@@ -55136,6 +55488,7 @@ sub scp_upload_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     DefaultRoot => '~',
@@ -55280,6 +55633,7 @@ sub scp_upload_subdir_enoent {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -55427,6 +55781,7 @@ sub scp_upload_subdir_enoent_with_limits {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -55604,6 +55959,8 @@ sub scp_upload_fifo_bug3312 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -55755,6 +56112,8 @@ sub scp_upload_fifo_bug3313 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -55873,6 +56232,7 @@ sub scp_ext_null_ptr_issue1043 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -56166,6 +56526,7 @@ sub scp_ext_upload_recursive_dir_bug3447 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -56464,6 +56825,7 @@ sub scp_ext_upload_recursive_dir_bug3792 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -56777,6 +57139,8 @@ sub scp_ext_upload_recursive_dir_bug4004 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     Umask => '002',
 
     IfModules => {
@@ -57036,6 +57400,8 @@ sub scp_ext_upload_recursive_dirs_bug4257 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     Umask => '002',
 
     IfModules => {
@@ -57263,6 +57629,7 @@ sub scp_ext_upload_different_name_bug3425 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -57461,6 +57828,7 @@ sub scp_ext_upload_recursive_empty_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -57682,6 +58050,8 @@ sub scp_ext_upload_shorter_file_bug4013 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
 
     IfModules => {
@@ -57896,6 +58266,8 @@ sub scp_ext_upload_file_with_timestamp_bug4026 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     AllowOverwrite => 'on',
     DefaultRoot => '~',
 
@@ -58057,6 +58429,7 @@ sub scp_download {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58195,6 +58568,7 @@ sub scp_download_enoent_bug3798 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58344,6 +58718,7 @@ sub scp_download_zero_len_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58526,6 +58901,7 @@ sub scp_download_largefile {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58691,6 +59067,7 @@ sub scp_download_fifo_bug3314 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58842,6 +59219,7 @@ sub scp_download_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -58985,6 +59363,7 @@ sub scp_download_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -59134,6 +59513,7 @@ sub scp_download_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -59281,6 +59661,7 @@ sub scp_download_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -59432,6 +59813,7 @@ sub scp_ext_download_bug3544 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -59629,6 +60011,7 @@ sub scp_ext_download_bug3798 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -59827,6 +60210,7 @@ sub scp_ext_download_glob_single_match_bug3904 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -60054,6 +60438,7 @@ sub scp_ext_download_glob_multiple_matches_bug3904 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -60342,6 +60727,7 @@ sub scp_ext_download_recursive_dir_bug3456 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -60568,6 +60954,7 @@ sub scp_ext_download_recursive_empty_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -60770,6 +61157,7 @@ sub scp_ext_download_glob_no_matches_bug3935 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -60947,6 +61335,7 @@ sub scp_config_ignore_upload_perms {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -61121,6 +61510,7 @@ sub scp_config_ignore_upload_times {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -61281,6 +61671,7 @@ sub scp_config_hiddenstores {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     HiddenStores => 'on',
 
@@ -61435,6 +61826,7 @@ sub scp_config_subdir_upload_allowed {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # Provide a specific <Directory> configuration which should only allow
     # uploads to a sub directory, not to the parent directory.  Apparently
@@ -61596,6 +61988,7 @@ sub scp_config_protocols {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -61749,6 +62142,8 @@ sub scp_config_userowner {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootRevoke => 'off',
 
     Directory => {
@@ -61910,6 +62305,8 @@ sub scp_config_groupowner_file_nonmember {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootRevoke => 'off',
 
     Directory => {
@@ -62084,6 +62481,8 @@ sub scp_config_groupowner_file_member_norootprivs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     RootLogin => $root_login,
 
     Directory => {
@@ -62255,6 +62654,7 @@ sub scp_log_extlog_var_f_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'transfer "%f %F"',
     ExtendedLog => "$extlog_file WRITE transfer",
@@ -62457,6 +62857,7 @@ sub scp_log_extlog_file_modified_bug3457 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     LogFormat => 'custom "%{file-modified}"',
@@ -62599,6 +63000,7 @@ sub scp_log_extlog_var_file_size_download_issue676 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     LogFormat => 'custom "%{file-size}"',
@@ -62765,6 +63167,7 @@ sub scp_log_xferlog_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xferlog_file,
 
@@ -63011,6 +63414,7 @@ sub scp_log_xferlog_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     TransferLog => $xferlog_file,
 
@@ -63304,10 +63708,12 @@ EOS
     TraceLog => $log_file,
     Trace => 'DEFAULT:10 ssh2:20 sftp:20 scp:20',
 
-    AllowOverwrite => 'on',
-    AllowStoreRestart => 'on',
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
+    AllowOverwrite => 'on',
+    AllowStoreRestart => 'on',
 
     IfModules => {
       'mod_delay.c' => {
@@ -63558,6 +63964,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -63765,6 +64172,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -63991,6 +64399,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -64227,6 +64636,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -64466,6 +64876,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -64697,6 +65108,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -64928,6 +65340,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -65122,6 +65535,7 @@ sub scp_ifsess_protocols {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -65278,6 +65692,7 @@ sub sftp_ext_hostkey_rotation_issue1323 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/FIPS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/FIPS.pm
@@ -169,6 +169,7 @@ sub sftp_fips_cipher_cast128_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -305,6 +306,7 @@ sub sftp_fips_cipher_blowfish_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -441,6 +443,7 @@ sub sftp_fips_cipher_3des_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -580,6 +583,7 @@ sub sftp_fips_cipher_aes128_cbc {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -728,6 +732,7 @@ sub sftp_fips_cipher_aes128_cbc_auth_publickey_rsa {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -882,6 +887,7 @@ sub sftp_fips_cipher_aes128_cbc_auth_publickey_dsa {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1027,6 +1033,7 @@ sub sftp_fips_cipher_aes128_ctr {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1166,6 +1173,7 @@ sub sftp_fips_mac_hmac_md5 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1302,6 +1310,7 @@ sub sftp_fips_mac_hmac_md5_96 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1438,6 +1447,7 @@ sub sftp_fips_mac_ripemd160 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1574,6 +1584,7 @@ sub sftp_fips_mac_hmac_sha1 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/ban.pm
@@ -129,6 +129,8 @@ sub sftp_ban_max_login_attempts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     MaxLoginAttempts => 1,
 
     IfModules => {
@@ -287,6 +289,7 @@ sub sftp_ban_maxcmdrate_exceeded {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxCommandRate => $max_cmd_rate,
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/exec.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/exec.pm
@@ -149,6 +149,7 @@ sub sftp_exec_on_connect {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -299,6 +300,7 @@ sub sftp_exec_on_cmd {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -487,6 +489,7 @@ sub sftp_exec_on_cmd_var_total_bytes_xfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -686,6 +689,7 @@ sub sftp_exec_on_cmd_var_bytes_xfer {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -865,6 +869,7 @@ sub sftp_exec_on_exit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1024,6 +1029,7 @@ sub sftp_exec_on_error {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1223,6 +1229,7 @@ sub exec_on_restart {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1332,6 +1339,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1483,6 +1491,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_exec.c' => {
@@ -1650,6 +1659,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/rewrite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/rewrite.pm
@@ -213,6 +213,7 @@ sub ssh2_rewrite_auth_password {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -323,6 +324,7 @@ sub ssh2_rewrite_auth_publickey {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -435,6 +437,7 @@ sub ssh2_rewrite_auth_homedir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     RewriteHome => 'on',
 
@@ -608,6 +611,7 @@ sub sftp_rewrite_stat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -779,6 +783,7 @@ sub sftp_rewrite_lstat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -966,6 +971,7 @@ sub sftp_rewrite_setstat {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1149,6 +1155,7 @@ sub sftp_rewrite_realpath {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1322,6 +1329,7 @@ sub sftp_rewrite_realpath_backslashes_bug4017 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1498,6 +1506,7 @@ sub sftp_rewrite_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1683,6 +1692,7 @@ sub sftp_rewrite_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1865,6 +1875,7 @@ sub sftp_rewrite_readdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2064,6 +2075,7 @@ sub sftp_rewrite_mkdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2223,6 +2235,7 @@ sub sftp_rewrite_rmdir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2391,6 +2404,7 @@ sub sftp_rewrite_remove {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2561,6 +2575,7 @@ sub sftp_rewrite_rename {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2735,6 +2750,7 @@ sub sftp_rewrite_rename_file_var_w_bug3643 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2901,6 +2917,7 @@ sub sftp_rewrite_rename_dir_var_w_bug3643 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3076,6 +3093,7 @@ sub sftp_rewrite_symlink {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3252,6 +3270,7 @@ sub sftp_rewrite_readlink {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3410,6 +3429,7 @@ sub sftp_rewrite_homedir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3573,6 +3593,7 @@ sub scp_rewrite_upload {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3739,6 +3760,7 @@ sub scp_rewrite_download {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/sql.pm
@@ -220,6 +220,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -453,6 +454,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -688,6 +690,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -929,6 +932,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to tickle the "failed" transfer status
     MaxRetrieveFileSize => '12 B',
@@ -1170,6 +1174,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
     AllowStoreRestart => 'on',
@@ -1441,6 +1446,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1668,6 +1674,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1843,6 +1850,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2043,6 +2051,8 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -2233,6 +2243,8 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -2426,6 +2438,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/wrap2.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/wrap2.pm
@@ -169,6 +169,7 @@ sub sftp_wrap2_file_login {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -365,6 +366,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -564,6 +566,7 @@ sub sftp_wrap2_deny_msg_on_connect_bug3670 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -752,6 +755,7 @@ sub sftp_wrap2_deny_msg_on_auth_bug3670 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -920,6 +924,7 @@ sub sftp_wrap2_deny_msg_var_u {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_pam.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_pam.pm
@@ -133,6 +133,7 @@ sub sftp_pam_failed_login_attempts_bug3921 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
@@ -208,6 +208,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -347,6 +348,7 @@ sub ssh2_auth_publickey_rsa_sql_var_U {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -536,6 +538,7 @@ sub ssh2_auth_publickey_rsa_sql_var_u {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -751,6 +754,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -928,6 +932,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1111,6 +1116,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1296,6 +1302,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1484,6 +1491,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1682,6 +1690,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1885,6 +1894,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2088,6 +2098,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2301,6 +2312,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2475,6 +2487,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2652,6 +2665,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2877,6 +2891,7 @@ EOC
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3071,6 +3086,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_shaper.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_shaper.pm
@@ -131,6 +131,7 @@ sub shaper_sighup {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_shaper.c' => {
@@ -209,6 +210,8 @@ sub shaper_queue_dos {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $test_timeout + 10,
 
     IfModules => {
@@ -349,6 +352,7 @@ sub shaper_resumed_download_bug3928 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowRetrieveRestart => 'on',
     TimeoutIdle => $test_timeout + 10,
@@ -488,6 +492,7 @@ sub shaper_sighup_shaperlog_bug4077 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_shaper.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_site.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_site.pm
@@ -144,6 +144,7 @@ sub site_help_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -289,6 +290,7 @@ sub site_help_chgrp_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -400,6 +402,7 @@ sub site_chgrp_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -512,6 +515,7 @@ sub site_chgrp_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -629,6 +633,7 @@ sub site_chgrp_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -752,6 +757,7 @@ sub site_chgrp_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -873,6 +879,7 @@ sub site_chgrp_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1002,6 +1009,7 @@ sub site_chmod_no_login {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1133,6 +1141,7 @@ sub site_chmod_numeric_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1243,6 +1252,7 @@ sub site_chmod_symbolic_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1361,6 +1371,7 @@ sub site_chmod_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1479,6 +1490,7 @@ sub site_chmod_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1603,6 +1615,7 @@ sub site_chmod_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1725,6 +1738,7 @@ sub site_chmod_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
@@ -201,6 +201,7 @@ sub site_misc_mkdir_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -298,6 +299,8 @@ sub site_misc_mkdir_dir_umask_bug4311 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     Umask => '022 066',
 
     IfModules => {
@@ -436,6 +439,7 @@ sub site_misc_rmdir_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -563,6 +567,7 @@ sub site_misc_symlink_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -650,6 +655,7 @@ sub site_misc_utime_ok {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -767,6 +773,7 @@ sub site_misc_utime_with_sec_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -895,6 +902,7 @@ sub site_misc_utime_abs_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1018,6 +1026,7 @@ sub site_misc_utime_abs_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1147,6 +1156,7 @@ sub site_misc_utime_rel_symlink {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1274,6 +1284,7 @@ sub site_misc_utime_rel_symlink_chrooted_bug4219 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultRoot => '~',
 
@@ -1395,6 +1406,7 @@ sub site_feat_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1525,6 +1537,8 @@ sub site_misc_symlink_ncftpd_chroot_bug {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
     DisplayChdir => '.message',
 
@@ -1675,6 +1689,7 @@ sub site_misc_mkdir_failed_bug3518 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1823,6 +1838,7 @@ sub site_misc_rmdir_failed_bug3518 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1960,6 +1976,7 @@ sub site_misc_symlink_failed_bug3518 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2087,6 +2104,7 @@ sub site_misc_utime_failed_bug3518 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2215,6 +2233,7 @@ sub site_misc_mkdir_failed_bug3519 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2388,6 +2407,7 @@ sub site_misc_rmdir_failed_bug3519 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2547,6 +2567,7 @@ sub site_misc_symlink_failed_bug3519 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2711,6 +2732,7 @@ sub site_misc_utime_failed_bug3519 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2857,6 +2879,7 @@ sub site_misc_mkdir_failed_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3010,6 +3033,7 @@ sub site_misc_rmdir_failed_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3150,6 +3174,7 @@ sub site_misc_symlink_failed_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3281,6 +3306,7 @@ sub site_misc_utime_failed_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3409,6 +3435,7 @@ sub site_misc_utime_atime_mtime_ctime_bug4130 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3539,6 +3566,7 @@ sub site_misc_utime_atime_mtime_ctime_with_spaces_bug4130 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3683,6 +3711,7 @@ sub site_misc_extlog_rmdir_resp_code_empty_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r: %s"',
     ExtendedLog => "$extlog_file MISC custom",
@@ -3861,6 +3890,7 @@ sub site_misc_extlog_rmdir_resp_code_nonempty_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%r: %s"',
     ExtendedLog => "$extlog_file ALL custom",

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp.pm
@@ -533,6 +533,7 @@ sub snmp_start_existing_dirs {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -636,6 +637,7 @@ sub snmp_v1_get_unknown {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -793,6 +795,7 @@ sub snmp_v1_get_wrong_community {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -957,6 +960,7 @@ sub snmp_v1_get_daemon_software {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1124,6 +1128,7 @@ sub snmp_v1_get_daemon_version {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1291,6 +1296,7 @@ sub snmp_v1_get_daemon_admin {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1460,6 +1466,7 @@ sub snmp_v1_get_daemon_admin_with_config {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     ServerAdmin => $server_admin,
 
@@ -1629,6 +1636,7 @@ sub snmp_v1_get_daemon_uptime {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1799,6 +1807,7 @@ sub snmp_v1_get_daemon_vhost_count {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1967,6 +1976,7 @@ sub snmp_v1_get_daemon_conn_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2170,6 +2180,7 @@ sub snmp_v1_get_daemon_restart_count {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2318,6 +2329,7 @@ sub snmp_v1_get_daemon_segfault_count {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2460,6 +2472,8 @@ sub snmp_v1_get_daemon_maxinsts_count {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxInstances => $max_instances,
 
     IfModules => {
@@ -2614,6 +2628,7 @@ sub snmp_v1_get_daemon_connrefused_count {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -2788,6 +2803,8 @@ sub snmp_v1_get_ftp_sess_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -2969,6 +2986,8 @@ sub snmp_v1_get_ftp_xfer_upload_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -3173,6 +3192,7 @@ sub snmp_v1_get_multi {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3343,6 +3363,7 @@ sub snmp_v1_get_multi_with_unknown {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3499,6 +3520,7 @@ sub snmp_v1_get_next {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3667,6 +3689,7 @@ sub snmp_v1_get_next_unknown {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3825,6 +3848,7 @@ sub snmp_v1_get_next_missing_instance_id {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3964,6 +3988,7 @@ sub snmp_v1_get_next_end_of_mib_view {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4125,6 +4150,7 @@ sub snmp_v1_get_next_multi {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4295,6 +4321,7 @@ sub snmp_v1_get_next_multi_with_unknown {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4450,6 +4477,7 @@ sub snmp_v1_set {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4607,6 +4635,7 @@ sub snmp_v1_trap {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4764,6 +4793,7 @@ sub snmp_v2_get_unknown {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4931,6 +4961,7 @@ sub snmp_v2_get_missing_instance_id {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5080,6 +5111,7 @@ sub snmp_v2_get_next_end_of_mib_view {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5244,6 +5276,7 @@ sub snmp_v2_get_bulk {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5418,6 +5451,7 @@ sub snmp_v2_get_bulk_max_repetitions_only {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5591,6 +5625,7 @@ sub snmp_v2_get_bulk_end_of_mib_view {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5762,6 +5797,7 @@ sub snmp_v2_set_no_access {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5919,6 +5955,7 @@ sub snmp_config_limit {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6090,6 +6127,7 @@ sub snmp_config_max_variables {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/ban.pm
@@ -322,6 +322,7 @@ sub snmp_ban_v1_get_conn_info {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 2,
 
@@ -581,6 +582,7 @@ sub snmp_ban_v1_get_ban_info {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerHost => 1,
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/sftp.pm
@@ -585,6 +585,8 @@ sub snmp_sftp_v1_get_sess_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -797,6 +799,8 @@ sub snmp_sftp_v1_get_xfer_dirlist_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -985,6 +989,8 @@ sub snmp_sftp_v1_get_xfer_download_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -1218,6 +1224,8 @@ sub snmp_sftp_v1_get_xfer_upload_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/tls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/tls.pm
@@ -527,6 +527,8 @@ sub snmp_tls_v1_get_sess_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -716,6 +718,8 @@ sub snmp_tls_v1_get_xfer_dirlist_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -906,6 +910,8 @@ sub snmp_tls_v1_get_xfer_download_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {
@@ -1141,6 +1147,8 @@ sub snmp_tls_v1_get_xfer_upload_counts {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     TimeoutIdle => $timeout_idle + 1,
 
     IfModules => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_odbc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_odbc.pm
@@ -163,6 +163,7 @@ EOI
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -1826,6 +1826,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1996,6 +1997,8 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -3514,6 +3517,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -3693,6 +3697,8 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -4180,6 +4186,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4316,6 +4323,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4617,6 +4625,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4767,6 +4776,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -4926,6 +4936,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5085,6 +5096,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5274,6 +5286,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5415,6 +5428,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5595,6 +5609,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5760,6 +5775,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -5950,6 +5966,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6165,6 +6182,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6325,6 +6343,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -6489,6 +6508,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7358,6 +7378,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7577,6 +7598,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -7744,6 +7766,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8092,6 +8115,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -8687,6 +8711,8 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultServer => 'off',
     SocketBindTight => 'off',
     Port => '0',
@@ -8714,6 +8740,8 @@ EOS
 
   AuthUserFile $setup->{auth_user_file}
   AuthGroupFile $setup->{auth_group_file}
+  AuthOrder mod_auth_file.c
+
   RequireValidShell off
   WtmpLog off
 
@@ -8858,6 +8886,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     DefaultServer => 'off',
     SocketBindTight => 'off',
@@ -8896,6 +8925,8 @@ EOS
 
   AuthUserFile $setup->{auth_user_file}
   AuthGroupFile $setup->{auth_group_file}
+  AuthOrder mod_auth_file.c
+
   RequireValidShell off
   WtmpLog off
 
@@ -9057,6 +9088,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9247,6 +9279,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9647,6 +9680,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m %f"',
     ExtendedLog => "$ext_log ALL custom",
@@ -9836,6 +9870,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -9983,6 +10018,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10164,6 +10200,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10348,6 +10385,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10541,6 +10579,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10744,6 +10783,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -10947,6 +10987,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to tickle the "failed" transfer status
     MaxRetrieveFileSize => '12 B',
@@ -11151,6 +11192,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to tickle the "timeout" transfer status
     TimeoutStalled => $timeout_stalled,
@@ -11376,6 +11418,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     PathDenyFilter => '^.*\.csv$',
 
@@ -11604,6 +11647,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -11809,6 +11853,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     # This is used to tickle the "failed" transfer status
     MaxRetrieveFileSize => '12 B',
@@ -12171,6 +12216,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12340,6 +12386,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12725,6 +12772,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -12898,6 +12946,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13071,6 +13120,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -13205,9 +13255,10 @@ EOS
     TraceLog => $setup->{log_file},
     Trace => 'jot:20 sql:20 sql.sqlite:20',
 
-    AuthOrder => 'mod_auth_file.c',
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
     MaxLoginAttempts => $max_login_attempts,
 
     IfModules => {
@@ -13926,11 +13977,12 @@ EOS
       },
 
       'mod_sql.c' => [
+        'AuthOrder mod_sql.c',
         'SQLAuthTypes plaintext',
         'SQLBackend sqlite3',
         "SQLConnectInfo $db_file",
         "SQLLogFile $setup->{log_file}",
-        'SQLMinID 200',
+        'SQLMinID 10',
 
         'SQLNamedQuery get-group-primary-key SELECT "primary_key from groups WHERE groupname = \'%{0}\'"',
         'SQLGroupPrimaryKey custom:/get-group-primary-key',
@@ -14088,6 +14140,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14741,6 +14794,7 @@ EOS
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -14910,6 +14964,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15061,6 +15116,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15342,6 +15398,7 @@ sub sql_sqlite_log_db_enoent_issue654 {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -15466,6 +15523,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Global => {
       AuthOrder => 'mod_sql.c',
@@ -15606,6 +15664,7 @@ EOS
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     Global => {
       AuthOrder => 'mod_sql.c',

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache.pm
@@ -109,6 +109,7 @@ sub statcache_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -327,6 +328,8 @@ sub statcache_file_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -547,6 +550,7 @@ sub statcache_file_tilde {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -760,6 +764,7 @@ sub statcache_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -973,6 +978,8 @@ sub statcache_dir_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1211,6 +1218,7 @@ sub statcache_rel_symlink_file {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -1455,6 +1463,8 @@ sub statcache_rel_symlink_file_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -1690,6 +1700,7 @@ sub statcache_rel_symlink_dir {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -1926,6 +1937,8 @@ sub statcache_rel_symlink_dir_chrooted {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
+
     DefaultRoot => '~',
 
     IfModules => {
@@ -2153,6 +2166,7 @@ sub statcache_config_max_age {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {
@@ -2391,6 +2405,7 @@ sub statcache_config_capacity {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_statcache.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache/sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache/sftp.pm
@@ -116,6 +116,7 @@ sub statcache_sftp_stat_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -392,6 +393,7 @@ sub statcache_sftp_stat_dir {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -649,6 +651,7 @@ sub statcache_sftp_upload_file {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/SMTP.pm
+++ b/tests/t/lib/ProFTPD/Tests/SMTP.pm
@@ -94,6 +94,7 @@ sub smtp_session {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/SSH2.pm
+++ b/tests/t/lib/ProFTPD/Tests/SSH2.pm
@@ -43,6 +43,7 @@ sub ssh2_session {
 
     AuthUserFile => $setup->{auth_user_file},
     AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Signals/HUP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Signals/HUP.pm
@@ -423,6 +423,7 @@ sub hup_allowoverwrite_bug3740 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
  

--- a/tests/t/lib/ProFTPD/Tests/Telnet.pm
+++ b/tests/t/lib/ProFTPD/Tests/Telnet.pm
@@ -104,6 +104,7 @@ sub telnet_iac_bug3521 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -251,6 +252,7 @@ sub telnet_iac_bug3697 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Utils/ftpcount.pm
+++ b/tests/t/lib/ProFTPD/Tests/Utils/ftpcount.pm
@@ -111,6 +111,7 @@ sub ftpcount_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {

--- a/tests/t/lib/ProFTPD/Tests/Utils/ftpwho.pm
+++ b/tests/t/lib/ProFTPD/Tests/Utils/ftpwho.pm
@@ -124,6 +124,7 @@ sub ftpwho_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -270,6 +271,7 @@ sub ftpwho_verbose_ok {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {
@@ -425,6 +427,7 @@ sub ftpwho_bug3714 {
 
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
+    AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
       'mod_delay.c' => {


### PR DESCRIPTION
…'ll run on a Linux container where system logs, and PAM, will be used by default; we thus need to specify that ProFTPD should only use our configured `AuthUserFile`, `AuthGroupFile` files.