### PR TITLE
Issue #1539: Avoid logging the "session closed" message, if we have n…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,8 @@
 - Issue 1533 - mod_tls module unexpectedly allows TLS handshake after
   authentication in some configurations.
 - Issue 1528 - Disable FSCachePolicy by default.
+- Issue 1539 - Avoid logging "session closed" messages unless there is a
+  corresponding "session opened" log message, to avoid user confusion.
 
 1.3.8rc4 - Released 23-Jul-2022
 --------------------------------

--- a/include/session.h
+++ b/include/session.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2009-2016 The ProFTPD Project team
+ * Copyright (c) 2009-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -119,5 +119,8 @@ int pr_session_set_idle(void);
 
 /* Sets the current protocol name. */
 int pr_session_set_protocol(const char *);
+
+/* Internal use only. */
+void session_set_connected(void);
 
 #endif /* PR_SESSION_H */

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -6624,6 +6624,10 @@ static const char *core_get_xfer_bytes_str(void *data, size_t datasz) {
 /* Event handlers
  */
 
+static void core_connected_ev(const void *event_data, void *user_data) {
+  session_set_connected();
+}
+
 static void core_exit_ev(const void *event_data, void *user_data) {
   pr_fs_statcache_free();
 }
@@ -6784,6 +6788,7 @@ static int core_init(void) {
   pr_feat_add(C_SIZE);
   pr_feat_add(C_HOST);
 
+  pr_event_register(&core_module, "core.connected", core_connected_ev, NULL);
   pr_event_register(&core_module, "core.postparse", core_postparse_ev, NULL);
   pr_event_register(&core_module, "core.restart", core_restart_ev, NULL);
   pr_event_register(&core_module, "core.startup", core_startup_ev, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -1495,6 +1495,8 @@ static void fork_server(int fd, conn_t *l, unsigned char no_fork) {
     pr_session_disconnect(NULL, PR_SESS_DISCONNECT_SESSION_INIT_FAILED, NULL);
   }
 
+  pr_event_generate("core.connected", conn);
+
   pr_log_debug(DEBUG4, "connected - local  : %s:%d",
     pr_netaddr_get_ipstr(session.c->local_addr), session.c->local_port);
   pr_log_debug(DEBUG4, "connected - remote : %s:%d",


### PR DESCRIPTION
…ot logged the "session opened" message, for a given TCP connection.

Such "session closed" without "session opened" messages can occur if a module closes/rejects the TCP connection during session initialization, before all modules have successfully initialized themselves for the connection.  This leads to user confusion about such asymmetrical logging.