### PR TITLE
Issue #1384: One possible cause of the infinite loops reported in thi…

### DIFF
--- a/modules/mod_facl.c
+++ b/modules/mod_facl.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2004-2017 The ProFTPD Project team
+ * Copyright (c) 2004-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1269,7 +1269,6 @@ static void unmount_facl(void) {
   fs = pr_unmount_fs("/", "facl");
   if (fs != NULL) {
     destroy_pool(fs->fs_pool);
-    fs->fs_pool = NULL;
     return;
   }
 

--- a/src/fsio.c
+++ b/src/fsio.c
@@ -2208,7 +2208,6 @@ pr_fs_t *pr_register_fs(pool *p, const char *name, const char *path) {
         name, path);
 
       destroy_pool(fs->fs_pool);
-      fs->fs_pool = NULL;
 
       errno = xerrno;
       return NULL;
@@ -2451,7 +2450,6 @@ int pr_unregister_fs(const char *path) {
   fs = pr_remove_fs(path);
   if (fs != NULL) {
     destroy_pool(fs->fs_pool);
-    fs->fs_pool = NULL;
     return 0;
   }
 
@@ -4989,7 +4987,6 @@ pr_fh_t *pr_fsio_open_canon(const char *name, int flags) {
     int xerrno = errno;
 
     destroy_pool(fh->fh_pool);
-    fh->fh_pool = NULL;
 
     errno = xerrno;
     return NULL;
@@ -5050,7 +5047,6 @@ pr_fh_t *pr_fsio_open(const char *name, int flags) {
     int xerrno = errno;
 
     destroy_pool(fh->fh_pool);
-    fh->fh_pool = NULL;
 
     errno = xerrno;
     return NULL;
@@ -5130,8 +5126,6 @@ int pr_fsio_close(pr_fh_t *fh) {
 
   if (fh->fh_pool != NULL) {
     destroy_pool(fh->fh_pool);
-    fh->fh_pool = NULL;
-    fh->fh_path = NULL;
   }
 
   errno = xerrno;

--- a/src/inet.c
+++ b/src/inet.c
@@ -685,7 +685,6 @@ void pr_inet_close(pool *p, conn_t *c) {
 
   if (c->pool != NULL) {
     destroy_pool(c->pool);
-    c->pool = NULL;
   }
 }
 
@@ -697,7 +696,7 @@ void pr_inet_lingering_close(pool *p, conn_t *c, long linger) {
 
   (void) pr_inet_set_block(p, c);
 
-  if (c->outstrm) {
+  if (c->outstrm != NULL) {
     pr_netio_lingering_close(c->outstrm, linger);
   }
 
@@ -722,7 +721,7 @@ void pr_inet_lingering_abort(pool *p, conn_t *c, long linger) {
 
   (void) pr_inet_set_block(p, c);
 
-  if (c->instrm) {
+  if (c->instrm != NULL) {
     pr_netio_lingering_abort(c->instrm, linger);
   }
 
@@ -2038,7 +2037,7 @@ void init_inet(void) {
   endprotoent();
 #endif
 
-  if (inet_pool) {
+  if (inet_pool != NULL) {
     destroy_pool(inet_pool);
   }
 

--- a/src/netio.c
+++ b/src/netio.c
@@ -723,7 +723,6 @@ pr_netio_stream_t *pr_netio_open(pool *parent_pool, int strm_type, int fd,
 
     default:
       destroy_pool(nstrm->strm_pool);
-      nstrm->strm_pool = NULL;
       errno = EINVAL;
       res = NULL;
   }

--- a/src/pool.c
+++ b/src/pool.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2021 The ProFTPD Project team
+ * Copyright (c) 2001-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -498,7 +498,7 @@ struct pool_rec *make_sub_pool(struct pool_rec *p) {
     new_pool->parent = p;
     new_pool->sub_next = p->sub_pools;
 
-    if (new_pool->sub_next) {
+    if (new_pool->sub_next != NULL) {
       new_pool->sub_next->sub_prev = new_pool;
     }
 
@@ -529,7 +529,7 @@ struct pool_rec *pr_pool_create_sz(struct pool_rec *p, size_t sz) {
     new_pool->parent = p;
     new_pool->sub_next = p->sub_pools;
 
-    if (new_pool->sub_next) {
+    if (new_pool->sub_next != NULL) {
       new_pool->sub_next->sub_prev = new_pool;
     }
 
@@ -571,7 +571,7 @@ static void clear_pool(struct pool_rec *p) {
   p->cleanups = NULL;
 
   /* Destroy subpools. */
-  while (p->sub_pools) {
+  while (p->sub_pools != NULL) {
     destroy_pool(p->sub_pools);
   }
 
@@ -594,16 +594,16 @@ void destroy_pool(pool *p) {
 
   pr_alarms_block();
 
-  if (p->parent) {
+  if (p->parent != NULL) {
     if (p->parent->sub_pools == p) {
       p->parent->sub_pools = p->sub_next;
     }
 
-    if (p->sub_prev) {
+    if (p->sub_prev != NULL) {
       p->sub_prev->sub_next = p->sub_next;
     }
 
-    if (p->sub_next) {
+    if (p->sub_next != NULL) {
       p->sub_next->sub_prev = p->sub_prev;
     }
   }
@@ -613,13 +613,13 @@ void destroy_pool(pool *p) {
 
   pr_alarms_unblock();
 
-#ifdef PR_DEVEL_NO_POOL_FREELIST
+#if defined(PR_DEVEL_NO_POOL_FREELIST)
   /* If configured explicitly to do so, call free(3) on the freelist after
    * a pool is destroyed.  This can be useful for tracking down use-after-free
    * and other memory issues using libraries such as dmalloc.
    */
   pool_release_free_block_list();
-#endif /* PR_EVEL_NO_POOL_FREELIST */
+#endif /* PR_DEVEL_NO_POOL_FREELIST */
 }
 
 /* Allocation interface...


### PR DESCRIPTION
…s issue, when freeing pools, is that of corrupted pointers/memory, as from use-after-free occurrences.

With this hypothesis, I compiled ProFTPD using the `-DPR_DEVEL_NO_POOL_FREELIST` flag, and ran it under Valgrind, to see if Valgrind detected any use-after-free occurrences.  And it did report some, for my initial simple use case.

Let's address those, and see if the reported behavior improves.