### PR TITLE
Issue #1384: While examining the reported stack trace closely, I noti…

### DIFF
--- a/modules/mod_auth_file.c
+++ b/modules/mod_auth_file.c
@@ -1077,6 +1077,7 @@ static int af_check_group_syntax(pool *p, const char *path) {
     pr_log_pri(PR_LOG_WARNING,
       "error: unable to open AuthGroupFile file '%s': %s",
       af_group_file->af_path, strerror(xerrno));
+    af_group_file = NULL;
     errno = xerrno;
     return -1;
   }
@@ -1120,6 +1121,7 @@ static int af_check_user_syntax(pool *p, const char *path) {
     pr_log_pri(PR_LOG_WARNING,
       "error: unable to open AuthUserFile file '%s': %s",
       af_user_file->af_path, strerror(xerrno));
+    af_user_file = NULL;
     errno = xerrno;
     return -1;
   }

--- a/src/auth.c
+++ b/src/auth.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2020 The ProFTPD Project team
+ * Copyright (c) 2001-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -365,7 +365,7 @@ static int groupcache_get(const char *name, gid_t *gid) {
 static cmd_rec *make_cmd(pool *cp, unsigned int argc, ...) {
   va_list args;
   cmd_rec *c;
-  pool *sub_pool;
+  pool *sub_pool, *tmp_pool;
 
   c = pcalloc(cp, sizeof(cmd_rec));
   c->argc = argc;
@@ -390,7 +390,12 @@ static cmd_rec *make_cmd(pool *cp, unsigned int argc, ...) {
 
   /* Make sure we provide pool and tmp_pool for the consumers. */
   sub_pool = make_sub_pool(cp);
-  c->pool = c->tmp_pool = sub_pool;
+  pr_pool_tag(sub_pool, "auth cmd subpool");
+  c->pool = sub_pool;
+
+  tmp_pool = make_sub_pool(c->pool);
+  pr_pool_tag(tmp_pool, "auth cmd tmp pool");
+  c->tmp_pool = tmp_pool;
 
   return c;
 }

--- a/src/configdb.c
+++ b/src/configdb.c
@@ -55,13 +55,12 @@ config_rec *pr_config_alloc(pool *p, const char *name, int config_type) {
     return NULL;
   }
 
-  pr_pool_tag(p, "config_rec pool");
   c = (config_rec *) pcalloc(p, sizeof(config_rec));
   c->pool = p;
   c->config_type = config_type;
 
   if (name != NULL) {
-    c->name = pstrdup(p, name);
+    c->name = pstrdup(c->pool, name);
     c->config_id = pr_config_set_id(c->name);
   }
 
@@ -128,6 +127,7 @@ config_rec *pr_config_add_set(xaset_t **set, const char *name, int flags) {
    * for config_rec pools; use a smaller size.
    */
   conf_pool = pr_pool_create_sz((*set)->pool, 128);
+  pr_pool_tag(conf_pool, "config_rec pool");
 
   c = pr_config_alloc(conf_pool, name, 0);
   pr_config_add_config_to_set(*set, c, flags);

--- a/src/parser.c
+++ b/src/parser.c
@@ -68,16 +68,19 @@ static struct config_src *parser_sources = NULL;
  */
 
 static struct config_src *add_config_source(pr_fh_t *fh) {
-  pool *p = pr_pool_create_sz(parser_pool, PARSER_CONFIG_SRC_POOL_SZ);
-  struct config_src *cs = pcalloc(p, sizeof(struct config_src));
+  pool *p;
+  struct config_src *cs;
 
+  p = pr_pool_create_sz(parser_pool, PARSER_CONFIG_SRC_POOL_SZ);
   pr_pool_tag(p, "configuration source pool");
-  cs->cs_next = NULL;
+
+  cs = pcalloc(p, sizeof(struct config_src));
   cs->cs_pool = p;
+  cs->cs_next = NULL;
   cs->cs_fh = fh;
   cs->cs_lineno = 0;
 
-  if (!parser_sources) {
+  if (parser_sources == NULL) {
     parser_sources = cs;
 
   } else {
@@ -529,8 +532,9 @@ int pr_parser_parse_file(pool *p, const char *path, config_rec *start,
           &cmd->stash_index, &cmd->stash_hash);
       }
 
-      if (cmd->tmp_pool) {
+      if (cmd->tmp_pool != NULL) {
         destroy_pool(cmd->tmp_pool);
+        cmd->tmp_pool = NULL;
       }
 
       if (found == FALSE) {

--- a/src/stash.c
+++ b/src/stash.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2010-2021 The ProFTPD Project team
+ * Copyright (c) 2010-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,10 +75,10 @@ static struct stash *sym_alloc(void) {
    * bytes by default) is a bit large for symbols.
    */
   sub_pool = pr_pool_create_sz(symbol_pool, PR_SYM_POOL_SIZE);
+  pr_pool_tag(sub_pool, "symbol");
 
   sym = pcalloc(sub_pool, sizeof(struct stash));
   sym->sym_pool = sub_pool; 
-  pr_pool_tag(sub_pool, "symbol");
 
   return sym;
 }


### PR DESCRIPTION
…ced that the Auth API creates `cmd_recs` whose `pool` and `tmp_pool` pointers point to the same pool, which is somewhat surprising.

So let's use separate pools for those.