### PR TITLE
set_include(): Always return an error if parser fails

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -391,14 +391,8 @@ MODRET set_include(cmd_rec *cmd) {
   PRIVS_RELINQUISH
 
   if (res < 0) {
-    if (xerrno != EINVAL) {
-      pr_log_pri(PR_LOG_WARNING, "warning: unable to include '%s': %s",
-        (char *) cmd->argv[1], strerror(xerrno));
-
-    } else {
-      CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error including '",
-        (char *) cmd->argv[1], "': ", strerror(xerrno), NULL));
-    }
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "error including '",
+      (char *) cmd->argv[1], "': ", strerror(xerrno), NULL));
   }
 
   return PR_HANDLED(cmd);


### PR DESCRIPTION
We've noticed that if you include configuration files from the server config context with only a single unknown directive or error, the configuration parsing stops but the server continues to start.
This leads to an unwanted server configuration which is also potentially insecure.

To reproduce:

*proftpd-unknown.conf*:
```
Include /unknown.conf
DefaultRoot ~
```
*unknown.conf*:
```
UnknownOption
```
```
$ proftpd -c /proftpd-unknown.conf -d 7 -n
[...]
2022-11-12 01:08:21,936 bullseye proftpd[1881363]: fatal: unknown configuration directive 'UnknownOption' on line 1 of '/unknown.conf'
2022-11-12 01:08:21,937 bullseye proftpd[1881363]: warning: unable to include '/unknown.conf': Operation not permitted
2022-11-12 01:08:21,937 bullseye proftpd[1881363] bullseye: 
2022-11-12 01:08:21,937 bullseye proftpd[1881363] bullseye: Config for ProFTPD:
2022-11-12 01:08:21,937 bullseye proftpd[1881363] bullseye: set core resource limits for daemon
2022-11-12 01:08:21,937 bullseye proftpd[1881363] bullseye: opening scoreboard '/usr/local/var/proftpd.scoreboard'
2022-11-12 01:08:21,937 bullseye proftpd[1881363] bullseye: ProFTPD 1.3.8rc5 (git) (built Fri Nov 11 2022 21:43:07 CET) standalone mode STARTUP
```

*proftpd-error.conf*:
```
Include /error.conf
DefaultRoot ~
```

*error.conf*:
```
LoadModule mod_aaaa.c
```

```
$ proftpd -c /proftpd-error.conf -d 7 -n
[...]
2022-11-12 01:35:56,631 bullseye proftpd[1894634]: fatal: LoadModule: error loading module 'mod_aaaa.c': No such file or directory on line 1 of '/root/proftpd/error.conf'
2022-11-12 01:35:56,631 bullseye proftpd[1894634]: warning: unable to include '/error.conf': No such file or directory
2022-11-12 01:35:56,632 bullseye proftpd[1894634] bullseye: 
2022-11-12 01:35:56,632 bullseye proftpd[1894634] bullseye: Config for ProFTPD:
2022-11-12 01:35:56,632 bullseye proftpd[1894634] bullseye: set core resource limits for daemon
2022-11-12 01:35:56,634 bullseye proftpd[1894634] bullseye: opening scoreboard '/usr/local/var/proftpd.scoreboard'
2022-11-12 01:35:56,635 bullseye proftpd[1894634] bullseye: ProFTPD 1.3.8rc5 (git) (built Fri Nov 11 2022 21:43:07 CET) standalone mode STARTUP
```

Notice that the server exits if the included configuration contains more more than one unknown or erroneous directive:

*unknown.conf*:
```
UnknownOption
UnknownOption
```
```
$ proftpd -c /proftpd-unknown.conf -d 7 -n
[...]
2022-11-12 02:03:27,907 bullseye proftpd[1900632]: fatal: unknown configuration directive 'UnknownOption' on line 1 of '/unknown.conf'
2022-11-12 02:03:27,908 bullseye proftpd[1900632]: warning: unable to include '/unknown.conf': Operation not permitted
2022-11-12 02:03:27,908 bullseye proftpd[1900632]: fatal: unknown configuration directive 'UnknownOption' on line 1 of '/proftpd-unknown.conf'
```

The Include directive gets dispatched to `set_include()` from *mod_core*. Then `parse_config_path()` is called which calls `parse_config_path2()` which in turn calls `pr_parser_parse_file()`.
After trying to dispatch the directive by calling `pr_module_call()` and that either is declined (unknown directive) or an error is returned, `errno` gets set to `EPERM` and we ultimately return to `set_include()`.
There `errno` gets copied to `xerrno`. Here we compare `xerrno` against `EINVAL` and because `EPERM` does not match, we log a warning but continue.
I'm not sure how `EPERM` is supposed to be used here but I see no reason why we do not return an error at this point.
This patch does exactly that. I've noticed no issues with *.ftpaccess* files containing unknown or erroneous configuration directives as `Include` is disallowed in *.ftpaccess* anyways.

```
$ proftpd -c /proftpd.conf -d 7 -n
[...]
2022-11-12 02:41:15,046 bullseye proftpd[1902800]: fatal: unknown configuration directive 'UnknownOption' on line 1 of '/unknown.conf'
2022-11-12 02:41:15,046 bullseye proftpd[1902800]: fatal: Include: error including '/unknown.conf': Operation not permitted on line 1 of '/proftpd-unknown.conf'
```