### PR TITLE
configure.ac: fix bashisms in configure.ac

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -852,7 +852,7 @@ AC_ARG_ENABLE(pcre,
   )],
   [
     if test x"$enableval" = xyes ; then
-      if test x"$enable_pcre2" == xyes ; then
+      if test x"$enable_pcre2" = xyes ; then
         AC_MSG_ERROR([cannot support both PCRE and PCRE2 at the same time -- aborting])
       fi
 
@@ -909,7 +909,7 @@ AC_ARG_ENABLE(pcre2,
   )],
   [
     if test x"$enableval" = xyes ; then
-      if test x"$enable_pcre" == xyes ; then
+      if test x"$enable_pcre" = xyes ; then
         AC_MSG_ERROR([cannot support both PCRE and PCRE2 at the same time -- aborting])
       fi
 
@@ -2969,7 +2969,7 @@ if test x"$enable_openssl_api_compat" != xno; then
   AC_DEFINE(PR_USE_OPENSSL_API_COMPAT, 1, [Define if using OPENSSL_API_COMPAT])
 fi
 
-if test x"$enable_ident" == xyes ; then
+if test x"$enable_ident" = xyes ; then
   ac_static_modules="mod_ident.o $ac_static_modules"
   ac_build_static_modules="modules/mod_ident.o $ac_build_static_modules"
 fi


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>