### PR TITLE
Run the unit tests, under ASAN, when built with the `PR_DEVEL_NO_POOL…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,6 @@ jobs:
           echo "PROFTPD_MODULES=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_tls_redis:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap:mod_wrap2:mod_wrap2_file:mod_wrap2_redis:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_unique_id:mod_ifsession" >> $GITHUB_ENV
 
           # for debugging
-          # for debugging
           clang --version
           gcc --version
           lcov --version
@@ -349,7 +348,7 @@ jobs:
         env:
           ASAN_OPTIONS: abort_on_error=1,check_initialization_order=true,debug=true,detect_invalid_pointer_pairs=2,detect_leaks=1,detect_stack_use_after_return=true,strict_string_checks=true,verbosity=0
           CC: ${{ matrix.compiler }}
-          CFLAGS: -fsanitize=address,undefined
+          CFLAGS: -fsanitize=address,undefined -DPR_DEVEL_NO_POOL_FREELIST
           LDFLAGS: -fsanitize=address,undefined
         if: ${{ matrix.compiler == 'clang' && matrix.container == 'ubuntu:18.04' }}
         run: |

--- a/src/configdb.c
+++ b/src/configdb.c
@@ -737,30 +737,23 @@ int pr_config_remove(xaset_t *set, const char *name, int flags, int recurse) {
     found_set = c->set;
     xaset_remove(found_set, (xasetmember_t *) c);
 
-    /* If the set is empty, and has no more contained members in the xas_list,
-     * destroy the set.
-     */
-    if (!found_set->xas_list) {
+    c->set = NULL;
+    (void) pr_table_remove(config_tab, name, NULL);
 
+    if (found_set->xas_list == NULL) {
       /* First, set any pointers to the container of the set to NULL. */
-      if (c->parent &&
+      if (c->parent != NULL &&
           c->parent->subset == found_set) {
         c->parent->subset = NULL;
 
       } else if (s && s->conf == found_set) {
         s->conf = NULL;
       }
+    }
 
-      if (!(flags & PR_CONFIG_FL_PRESERVE_ENTRY)) {
-        /* Next, destroy the set's pool, which destroys the set as well. */
-        destroy_pool(found_set->pool);
-      }
-
-    } else {
-      if (!(flags & PR_CONFIG_FL_PRESERVE_ENTRY)) {
-        /* If the set was not empty, destroy only the requested config_rec. */
-        destroy_pool(c->pool);
-      }
+    if (!(flags & PR_CONFIG_FL_PRESERVE_ENTRY)) {
+      /* If the set was not empty, destroy only the requested config_rec. */
+      destroy_pool(c->pool);
     }
   }
 

--- a/tests/api/data.c
+++ b/tests/api/data.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2015-2021 The ProFTPD Project team
+ * Copyright (c) 2015-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -557,10 +557,12 @@ START_TEST (data_open_passive_test) {
    * be non-NULL.
    */
   session.c = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  ck_assert_msg(session.c != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.c != NULL, "Failed to create conn: %s",
+    strerror(errno));
 
   session.d = data_conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
-  ck_assert_msg(session.d != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(session.d != NULL, "Failed to create conn: %s",
+    strerror(errno));
 
   /* Reset the session flags after every failed open. */
   session.sf_flags |= SF_PASSIVE;
@@ -574,11 +576,14 @@ START_TEST (data_open_passive_test) {
     strerror(errno), errno);
 
   /* Note: we also need session.c to have valid local/remote_addr, too! */
-  session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
+  session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
+    "127.0.0.1", NULL);
   ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
+  data_conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
+  data_conn->listen_fd = 0;
   session.d = data_conn;
   session.sf_flags |= SF_PASSIVE;
   res = pr_data_open(NULL, NULL, dir, 0);
@@ -590,6 +595,8 @@ START_TEST (data_open_passive_test) {
   dir = PR_NETIO_IO_WR;
 
   mark_point();
+  data_conn = pr_inet_create_conn(p, sockfd, NULL, port, FALSE);
+  data_conn->listen_fd = 1;
   session.d = data_conn;
   session.sf_flags |= SF_PASSIVE;
   session.xfer.p = NULL;

--- a/tests/api/json.c
+++ b/tests/api/json.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2017-2021 The ProFTPD Project team
+ * Copyright (c) 2017-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1911,7 +1911,7 @@ START_TEST(json_array_append_object_test) {
 
   val = NULL;
   idx = 0;
- 
+
   mark_point();
   res = pr_json_array_get_object(p, json, idx, &val);
   ck_assert_msg(res == 0, "Failed to handle existing index %u: %s", idx,

--- a/tests/api/modules.c
+++ b/tests/api/modules.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2008-2017 The ProFTPD Project team
+ * Copyright (c) 2008-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,13 +35,14 @@ static void set_up(void) {
     p = permanent_pool = make_sub_pool(NULL);
   }
 
+  init_stash();
   modules_init();
 }
 
 static void tear_down(void) {
   loaded_modules = NULL;
 
-  if (p) {
+  if (p != NULL) {
     destroy_pool(p);
     p = permanent_pool = NULL;
   } 

--- a/tests/api/parser.c
+++ b/tests/api/parser.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2014-2021 The ProFTPD Project team
+ * Copyright (c) 2014-2022 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,6 +46,7 @@ static void set_up(void) {
   init_fs();
   pr_fs_statcache_set_policy(PR_TUNABLE_FS_STATCACHE_SIZE,
     PR_TUNABLE_FS_STATCACHE_MAX_AGE, 0);
+  init_stash();
   modules_init();
 
   if (getenv("TEST_VERBOSE") != NULL) {


### PR DESCRIPTION
…_FREELIST` macro, to help identify memory issues faster.