### PR TITLE
When parsing a directive like `</IfModule mod_foo.c>`, this should fa…

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -324,6 +324,11 @@ MODRET start_ifmodule(cmd_rec *cmd) {
  * will be silently ignored.
  */
 MODRET end_ifmodule(cmd_rec *cmd) {
+  if (cmd->argc != 1) {
+    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "wrong number of parameters: ",
+      cmd->arg, NULL));
+  }
+
   return PR_HANDLED(cmd);
 }
 

--- a/tests/t/config/ifmodule.t
+++ b/tests/t/config/ifmodule.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use lib qw(t/lib);
+use strict;
+
+use Test::Unit::HarnessUnit;
+
+$| = 1;
+
+my $r = Test::Unit::HarnessUnit->new();
+$r->start("ProFTPD::Tests::Config::IfModule");

--- a/tests/t/lib/ProFTPD/Tests/Config/IfModule.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/IfModule.pm
@@ -1,0 +1,91 @@
+package ProFTPD::Tests::Config::IfModule;
+
+use lib qw(t/lib);
+use base qw(ProFTPD::TestSuite::Child);
+use strict;
+
+use File::Spec;
+use IO::Handle;
+
+use ProFTPD::TestSuite::FTP;
+use ProFTPD::TestSuite::Utils qw(:auth :config :running :test :testsuite);
+
+$| = 1;
+
+my $order = 0;
+
+my $TESTS = {
+  ifmodule_close_extra_args => {
+    order => ++$order,
+    test_class => [qw(forking)],
+  },
+
+};
+
+sub new {
+  return shift()->SUPER::new(@_);
+}
+
+sub list_tests {
+  return testsuite_get_runnable_tests($TESTS);
+}
+
+sub ifmodule_close_extra_args {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  if (open(my $fh, ">> $setup->{config_file}")) {
+    print $fh <<EOC;
+<IfModule mod_xfer.c>
+  TransferLog /dev/null
+
+# NOTE: This </IfModule> with the module name should cause the parser to
+# fail; it is unexpected input.
+</IfModule mod_xfer.c>
+EOC
+    unless (close($fh)) {
+      die("Can't write $setup->{config_file}: $!");
+    }
+
+  } else {
+    die("Can't open $setup->{config_file}: $!");
+  }
+
+  my $ex;
+
+  eval { server_start($setup->{config_file}, $setup->{pid_file}) };
+  unless ($@) {
+    $ex = 'Server started up unexpectedly';
+
+    # Allow server to finish starting up
+    sleep(1);
+    eval { server_stop($setup->{pid_file}) };
+
+    test_cleanup($setup->{log_file}, $ex);
+    die($ex);
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+1;

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -140,6 +140,7 @@ if (scalar(@ARGV) > 0) {
     t/config/hidenoaccess.t
     t/config/hideuser.t
     t/config/ifdefine.t
+    t/config/ifmodule.t
     t/config/include.t
     t/config/listoptions.t
     t/config/logoptions.t


### PR DESCRIPTION
…il parsing, as the extra module name in the close is not expected.