### PR TITLE
Issue #1560: Make sure that `mod_auth_otp` fails a plain SSH "keyboar…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,8 @@
 - Issue 1550 - Implement support for the CSID FTP command.
 - Bug 4491 - unable to verify signed data: signature type 'rsa-sha2-512' does
   not match publickey algorithm 'ssh-rsa'.
+- Issue 1560 - mod_auth_otp improperly allows keyboard-interactive logins for
+  users lacking OTP entries.
 
 1.3.8rc4 - Released 23-Jul-2022
 --------------------------------

--- a/contrib/mod_auth_otp/mod_auth_otp.h.in
+++ b/contrib/mod_auth_otp/mod_auth_otp.h.in
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_auth_otp
- * Copyright (c) 2015-2017 TJ Saunders
+ * Copyright (c) 2015-2022 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@
 /* Define if you have mod_sftp support. */
 #undef HAVE_SFTP
 
-#define MOD_AUTH_OTP_VERSION	"mod_auth_otp/0.2"
+#define MOD_AUTH_OTP_VERSION	"mod_auth_otp/0.3"
 
 /* Make sure the version of proftpd is as necessary. */
 #if PROFTPD_VERSION_NUMBER < 0x0001030402

--- a/doc/contrib/mod_auth_otp.html
+++ b/doc/contrib/mod_auth_otp.html
@@ -356,8 +356,12 @@ Now, if you want <code>mod_sftp</code> to <b>only</b> try to use one-time
 passwords (or public keys), and <b>not</b> normal passwords, then you might
 use a <code>mod_sftp</code> configuration like this:
 <pre>
-  SFTPAuthMethods publickey keyboard-interactive
+  SFTPAuthMethods publickey password+keyboard-interactive
 </pre>
+If you allow the "keyboard-interactive" authentication method by itself,
+<i>and</i> the user does not have an OTP entry, then that authentication will
+fail, <b>regardless</b> of any <code>RequireTableEntry</code>
+<code>AuthOTPOption</code> configuration (or lack of).
 
 <p>
 <b>Module Load Order and <code>mod_sftp</code></b><br>
@@ -468,7 +472,7 @@ Then follow the usual steps:
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2015-2019 TJ Saunders<br>
+&copy; Copyright 2015-2022 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp/sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp/sftp.pm
@@ -19,25 +19,73 @@ my $order = 0;
 
 my $TESTS = {
   # HOTP tests
-  auth_otp_sftp_hotp_login_ok => {
+  auth_otp_sftp_hotp_login_ok_via_kbdint => {
     order => ++$order,
     test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
   },
 
-  auth_otp_sftp_hotp_login_failed => {
+  auth_otp_sftp_hotp_login_failed_bad_secret => {
     order => ++$order,
     test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
+  },
+
+  auth_otp_sftp_hotp_login_failed_missing_otp_entry_issue1560 => {
+    order => ++$order,
+    test_class => [qw(
+      bug
+      forking
+      mod_auth_otp
+      mod_sftp
+      mod_sql
+      mod_sql_sqlite
+    )],
+  },
+
+  auth_otp_sftp_hotp_login_ok_missing_otp_entry_chained_auth_issue1560 => {
+    order => ++$order,
+    test_class => [qw(
+      bug
+      forking
+      mod_auth_otp
+      mod_sftp
+      mod_sql
+      mod_sql_sqlite
+    )],
   },
 
   # TOTP tests
-  auth_otp_sftp_totp_login_ok => {
+  auth_otp_sftp_totp_login_ok_via_kbdint => {
     order => ++$order,
     test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
   },
 
-  auth_otp_sftp_totp_login_failed => {
+  auth_otp_sftp_totp_login_failed_bad_secret => {
     order => ++$order,
     test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
+  },
+
+  auth_otp_sftp_totp_login_failed_missing_otp_entry_issue1560 => {
+    order => ++$order,
+    test_class => [qw(
+      bug
+      forking
+      mod_auth_otp
+      mod_sftp
+      mod_sql
+      mod_sql_sqlite
+    )],
+  },
+
+  auth_otp_sftp_totp_login_ok_missing_otp_entry_chained_auth_issue1560 => {
+    order => ++$order,
+    test_class => [qw(
+      bug
+      forking
+      mod_auth_otp
+      mod_sftp
+      mod_sql
+      mod_sql_sqlite
+    )],
   },
 
   auth_otp_sftp_totp_login_authoritative => {
@@ -175,7 +223,7 @@ sub build_db {
 
 # Tests
 
-sub auth_otp_sftp_hotp_login_ok {
+sub auth_otp_sftp_hotp_login_ok_via_kbdint {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'auth_otp');
@@ -300,7 +348,7 @@ EOS
       my $oath = Authen::OATH->new();
       my $hotp = $oath->hotp($secret, $counter);
       if ($ENV{TEST_VERBOSE}) {
-        print STDERR "# Generated HOTP $hotp for counter ", $counter, "\n";
+        print STDERR "# Generated HOTP $hotp for counter $counter\n";
       }
 
       unless ($ssh2->auth_keyboard($setup->{user}, $hotp)) {
@@ -329,13 +377,12 @@ EOS
 
   # Stop server
   server_stop($setup->{pid_file});
-
   $self->assert_child_ok($pid);
 
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub auth_otp_sftp_hotp_login_failed {
+sub auth_otp_sftp_hotp_login_failed_bad_secret {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'auth_otp');
@@ -460,7 +507,7 @@ EOS
       my $oath = Authen::OATH->new();
       my $hotp = $oath->hotp($bad_secret, $counter);
       if ($ENV{TEST_VERBOSE}) {
-        print STDERR "# Generated HOTP $hotp for counter ", $counter, "\n";
+        print STDERR "# Generated HOTP $hotp for counter $counter\n";
       }
 
       if ($ssh2->auth_keyboard($setup->{user}, $hotp)) {
@@ -498,7 +545,334 @@ EOS
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub auth_otp_sftp_totp_login_ok {
+sub auth_otp_sftp_hotp_login_failed_missing_otp_entry_issue1560 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'auth_otp');
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create HOTP tables
+  my $db_script = File::Spec->rel2abs("$tmpdir/hotp.sql");
+
+  # mod_auth_otp wants this secret to be base32-encoded, for interoperability
+  # with Google Authenticator.
+  require MIME::Base32;
+
+  my $secret = 'Sup3rS3Cr3t';
+  my $base32_secret = MIME::Base32::encode_base32($secret);
+  my $counter = 777;
+
+  if (open(my $fh, "> $db_script")) {
+    # Note that we deliberately omit the row for this user from the OTP table.
+
+    print $fh <<EOS;
+CREATE TABLE auth_otp (
+  user TEXT PRIMARY KEY,
+  secret TEXT,
+  counter INTEGER
+);
+EOS
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script, $db_file);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 auth_otp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_auth_otp.c' => {
+        AuthOTPEngine => 'on',
+        AuthOTPLog => $setup->{log_file},
+        AuthOTPAlgorithm => 'hotp',
+
+        # Assumes default table names, column names
+        AuthOTPTable => 'sql:/get-user-hotp/update-user-hotp',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+
+        # Configure mod_sftp to only use the keyboard-interactive method.
+        # NOTE: How to handle this when both mod_auth_otp AND mod_sftp_pam
+        # are used/loaded?
+        'SFTPAuthMethods keyboard-interactive',
+      ],
+
+      'mod_sql.c' => [
+        'SQLEngine log',
+        'SQLBackend sqlite3',
+        "SQLConnectInfo $db_file",
+        "SQLLogFile $setup->{log_file}",
+
+        'SQLNamedQuery get-user-hotp SELECT "secret, counter FROM auth_otp WHERE user = \'%{0}\'"',
+        'SQLNamedQuery update-user-hotp UPDATE "counter = %{1} WHERE user = \'%{0}\'" auth_otp',
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  require Authen::OATH;
+  require Net::SSH2;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      # Calculate HOTP
+      my $oath = Authen::OATH->new();
+      my $hotp = $oath->hotp($secret, $counter);
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Generated HOTP $hotp for counter $counter\n";
+      }
+
+      if ($ssh2->auth_keyboard($setup->{user}, $hotp)) {
+        die("Login to SSH2 server succeeded unexpectedly");
+      }
+
+      my ($err_code, $err_name, $err_str) = $ssh2->error();
+      $self->assert($err_str, qr/Authentication failed \(keyboard-interactive\)/,
+        test_msg("Expected 'Authentication failed (keyboard-interactive), got '$err_str'"));
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub auth_otp_sftp_hotp_login_ok_missing_otp_entry_chained_auth_issue1560 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'auth_otp');
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create HOTP tables
+  my $db_script = File::Spec->rel2abs("$tmpdir/hotp.sql");
+
+  # mod_auth_otp wants this secret to be base32-encoded, for interoperability
+  # with Google Authenticator.
+  require MIME::Base32;
+
+  my $secret = 'Sup3rS3Cr3t';
+  my $base32_secret = MIME::Base32::encode_base32($secret);
+  my $counter = 777;
+
+  if (open(my $fh, "> $db_script")) {
+    # Note that we deliberately omit the row for this user from the OTP table.
+
+    print $fh <<EOS;
+CREATE TABLE auth_otp (
+  user TEXT PRIMARY KEY,
+  secret TEXT,
+  counter INTEGER
+);
+EOS
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script, $db_file);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 auth_otp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_auth_otp.c' => {
+        AuthOTPEngine => 'on',
+        AuthOTPLog => $setup->{log_file},
+        AuthOTPAlgorithm => 'hotp',
+
+        # Assumes default table names, column names
+        AuthOTPTable => 'sql:/get-user-hotp/update-user-hotp',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+
+        'SFTPAuthMethods password+keyboard-interactive',
+      ],
+
+      'mod_sql.c' => [
+        'SQLEngine log',
+        'SQLBackend sqlite3',
+        "SQLConnectInfo $db_file",
+        "SQLLogFile $setup->{log_file}",
+
+        'SQLNamedQuery get-user-hotp SELECT "secret, counter FROM auth_otp WHERE user = \'%{0}\'"',
+        'SQLNamedQuery update-user-hotp UPDATE "counter = %{1} WHERE user = \'%{0}\'" auth_otp',
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  require Authen::OATH;
+  require Net::SSH2;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      if ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
+        die("Password authentication succeeded unexpectedly");
+      }
+
+      # Calculate HOTP
+      my $oath = Authen::OATH->new();
+      my $hotp = $oath->hotp($secret, $counter);
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Generated HOTP $hotp for counter $counter\n";
+      }
+
+      unless ($ssh2->auth_keyboard($setup->{user}, $hotp)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Keyboard-interactive authentication failed: [$err_name] ($err_code) $err_str");
+      }
+
+      my $sftp = $ssh2->sftp();
+      unless ($sftp) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      # To close the SFTP channel, we have to explicitly destroy the object
+      $sftp = undef;
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub auth_otp_sftp_totp_login_ok_via_kbdint {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'auth_otp');
@@ -526,7 +900,6 @@ CREATE TABLE auth_otp (
 INSERT INTO auth_otp (user, secret, counter) VALUES ('$setup->{user}', '$base32_secret', $counter);
 
 EOS
-
     unless (close($fh)) {
       die("Can't write $db_script: $!");
     }
@@ -651,13 +1024,12 @@ EOS
 
   # Stop server
   server_stop($setup->{pid_file});
-
   $self->assert_child_ok($pid);
 
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub auth_otp_sftp_totp_login_failed {
+sub auth_otp_sftp_totp_login_failed_bad_secret {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'auth_otp');
@@ -815,6 +1187,329 @@ EOS
   # Stop server
   server_stop($setup->{pid_file});
 
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub auth_otp_sftp_totp_login_failed_missing_otp_entry_issue1560 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'auth_otp');
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create TOTP tables
+  my $db_script = File::Spec->rel2abs("$tmpdir/totp.sql");
+
+  # mod_auth_otp wants this secret to be base32-encoded, for interoperability
+  # with Google Authenticator.
+  require MIME::Base32;
+
+  my $secret = 'Sup3rS3Cr3t';
+  my $base32_secret = MIME::Base32::encode_base32($secret);
+  my $counter = 777;
+
+  if (open(my $fh, "> $db_script")) {
+    # Note that we deliberately omit the row for this user from the OTP table.
+
+    print $fh <<EOS;
+CREATE TABLE auth_otp (
+  user TEXT PRIMARY KEY,
+  secret TEXT,
+  counter INTEGER
+);
+EOS
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script, $db_file);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 auth_otp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_auth_otp.c' => {
+        AuthOTPEngine => 'on',
+        AuthOTPLog => $setup->{log_file},
+        AuthOTPAlgorithm => 'totp',
+
+        # Assumes default table names, column names
+        AuthOTPTable => 'sql:/get-user-totp/update-user-totp',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+
+        # Configure mod_sftp to only use the keyboard-interactive method.
+        # NOTE: How to handle this when both mod_auth_otp AND mod_sftp_pam
+        # are used/loaded?
+        'SFTPAuthMethods keyboard-interactive',
+      ],
+
+      'mod_sql.c' => [
+        'SQLEngine log',
+        'SQLBackend sqlite3',
+        "SQLConnectInfo $db_file",
+        "SQLLogFile $setup->{log_file}",
+
+        'SQLNamedQuery get-user-totp SELECT "secret, counter FROM auth_otp WHERE user = \'%{0}\'"',
+        'SQLNamedQuery update-user-totp UPDATE "counter = %{1} WHERE user = \'%{0}\'" auth_otp',
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  require Authen::OATH;
+  require Net::SSH2;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      # Calculate TOTP
+      my $oath = Authen::OATH->new();
+      my $totp = $oath->totp($secret);
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Generated TOTP $totp for current time\n";
+      }
+
+      if ($ssh2->auth_keyboard($setup->{user}, $totp)) {
+        die("Login to SSH2 server succeeded unexpectedly");
+      }
+
+      my ($err_code, $err_name, $err_str) = $ssh2->error();
+      $self->assert($err_str, qr/Authentication failed \(keyboard-interactive\)/,
+        test_msg("Expected 'Authentication failed (keyboard-interactive), got '$err_str'"));
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub auth_otp_sftp_totp_login_ok_missing_otp_entry_chained_auth_issue1560 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'auth_otp');
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create TOTP tables
+  my $db_script = File::Spec->rel2abs("$tmpdir/totp.sql");
+
+  # mod_auth_otp wants this secret to be base32-encoded, for interoperability
+  # with Google Authenticator.
+  require MIME::Base32;
+
+  my $secret = 'Sup3rS3Cr3t';
+  my $base32_secret = MIME::Base32::encode_base32($secret);
+  my $counter = 777;
+
+  if (open(my $fh, "> $db_script")) {
+    # Note that we deliberately omit the row for this user from the OTP table.
+
+    print $fh <<EOS;
+CREATE TABLE auth_otp (
+  user TEXT PRIMARY KEY,
+  secret TEXT,
+  counter INTEGER
+);
+EOS
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script, $db_file);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 auth_otp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_auth_otp.c' => {
+        AuthOTPEngine => 'on',
+        AuthOTPLog => $setup->{log_file},
+        AuthOTPAlgorithm => 'totp',
+
+        # Assumes default table names, column names
+        AuthOTPTable => 'sql:/get-user-totp/update-user-totp',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+
+        'SFTPAuthMethods password+keyboard-interactive',
+      ],
+
+      'mod_sql.c' => [
+        'SQLEngine log',
+        'SQLBackend sqlite3',
+        "SQLConnectInfo $db_file",
+        "SQLLogFile $setup->{log_file}",
+
+        'SQLNamedQuery get-user-totp SELECT "secret, counter FROM auth_otp WHERE user = \'%{0}\'"',
+        'SQLNamedQuery update-user-totp UPDATE "counter = %{1} WHERE user = \'%{0}\'" auth_otp',
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  require Authen::OATH;
+  require Net::SSH2;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      if ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
+        die("Password authentication succeeded unexpectedly");
+      }
+
+      # Calculate TOTP
+      my $oath = Authen::OATH->new();
+      my $totp = $oath->totp($secret);
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Generated TOTP $totp for current time\n";
+      }
+
+      unless ($ssh2->auth_keyboard($setup->{user}, $totp)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      my $sftp = $ssh2->sftp();
+
+      # To close the SFTP channel, we have to explicitly destroy the object
+      $sftp = undef;
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   test_cleanup($setup->{log_file}, $ex);


### PR DESCRIPTION
…d-interactive" authentication if the user lacks an OTP entry, regardless of `AuthOTPOptions RequireTableEntry`.

This closes an authentication edge case where clients can authenticate successfully by providing bad credentials.  Using a chain of authentication methods, which include "keyboard-interactive", _is_ allowed, though.