### PR TITLE
Rename the "StandardResponse" `AuthOTPOptions` value to "FTPStandardR…

### DIFF
--- a/contrib/mod_auth_otp/mod_auth_otp.c
+++ b/contrib/mod_auth_otp/mod_auth_otp.c
@@ -36,7 +36,7 @@
 #endif /* HAVE_SFTP */
 
 /* mod_auth_otp option flags */
-#define AUTH_OTP_OPT_STANDARD_RESPONSE		0x001
+#define AUTH_OTP_OPT_FTP_STANDARD_RESPONSE	0x001
 #define AUTH_OTP_OPT_REQUIRE_TABLE_ENTRY	0x002
 #define AUTH_OTP_OPT_DISPLAY_VERIFICATION_CODE	0x004
 
@@ -743,8 +743,9 @@ MODRET set_authotpoptions(cmd_rec *cmd) {
   c = add_config_param(cmd->argv[0], 1, NULL);
 
   for (i = 1; i < cmd->argc; i++) {
-    if (strcmp(cmd->argv[i], "StandardResponse") == 0) {
-      opts |= AUTH_OTP_OPT_STANDARD_RESPONSE;
+    if (strcmp(cmd->argv[i], "FTPStandardResponse") == 0 ||
+        strcmp(cmd->argv[i], "StandardResponse") == 0) {
+      opts |= AUTH_OTP_OPT_FTP_STANDARD_RESPONSE;
 
     } else if (strcmp(cmd->argv[i], "RequireTableEntry") == 0) {
       opts |= AUTH_OTP_OPT_REQUIRE_TABLE_ENTRY;
@@ -857,7 +858,7 @@ MODRET auth_otp_post_user(cmd_rec *cmd) {
    * OTPs from the connecting client.
    */
 
-  if (!(auth_otp_opts & AUTH_OTP_OPT_STANDARD_RESPONSE)) {
+  if (!(auth_otp_opts & AUTH_OTP_OPT_FTP_STANDARD_RESPONSE)) {
     pr_response_clear(&resp_list);
 #if defined(HAVE_SFTP)
     /* Note: for some reason, when building with mod_sftp, the '_' function

--- a/doc/contrib/mod_auth_otp.html
+++ b/doc/contrib/mod_auth_otp.html
@@ -134,7 +134,7 @@ behavior of <code>mod_auth_otp</code>.
 <p>
 For example:
 <pre>
-  AuthOTPOptions StandardResponse
+  AuthOTPOptions FTPStandardResponse
 </pre>
 
 <p>
@@ -149,6 +149,21 @@ The currently implemented options are:
     <pre>
       AuthOTPOptions DisplayVerificationCode
     </pre>
+  </li>
+
+  <p>
+  <li><code>FTPStandardResponse</code><br>
+    <p>
+    When <code>mod_auth_otp</code> is handling FTP sessions, it will respond
+    to a <code>USER</code> command with a response message indicating the
+    expectation of a one-time password:
+    <pre>
+      331 One-time password required for <i>user</i>
+    </pre>
+    However, this change of the response message "leaks" information about
+    the server configuration, <i>i.e.</i> that OTPs will be used.  To
+    tell <code>mod_auth_otp</code> to continue using the standard/normal
+    response message, use this option.
   </li>
 
   <p>
@@ -173,21 +188,6 @@ The currently implemented options are:
       AuthOrder mod_auth_otp.c* ...
       AuthOTPOptions RequireTableEntry StandardResponse
     </pre>
-  </li>
-
-  <p>
-  <li><code>StandardResponse</code><br>
-    <p>
-    When <code>mod_auth_otp</code> is handling FTP sessions, it will respond
-    to a <code>USER</code> command with a response message indicating the
-    expectation of a one-time password:
-    <pre>
-      331 One-time password required for <i>user</i>
-    </pre>
-    However, this change of the response message "leaks" information about
-    the server configuration, <i>i.e.</i> that OTPs will be used.  To
-    tell <code>mod_auth_otp</code> to continue using the standard/normal
-    response message, use this option.
   </li>
 </ul>
 
@@ -324,7 +324,7 @@ have been provisioned with the necessary shared key.  To prevent
 continue using the standard FTP response messages, use the following in
 your configuration for <code>mod_auth_otp</code>:
 <pre>
-  AuthOTPOptions StandardResponse
+  AuthOTPOptions FTPStandardResponse
 </pre>
 
 <p>
@@ -339,7 +339,7 @@ you would use:
 
   # Use the standard FTP response message, and fail the login if we find
   # a user that has not been provisioned.
-  AuthOTPOptions RequireTableEntry StandardResponse
+  AuthOTPOptions FTPStandardResponse RequireTableEntry
 </pre>
 
 <p>

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp.pm
@@ -64,7 +64,7 @@ my $TESTS = {
   },
 
   # AuthOTPOptions tests
-  auth_otp_opt_std_response => {
+  auth_otp_opt_ftp_std_response => {
     order => ++$order,
     test_class => [qw(forking mod_auth_otp mod_sql mod_sql_sqlite)],
   },
@@ -1534,7 +1534,7 @@ EOS
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub auth_otp_opt_std_response {
+sub auth_otp_opt_ftp_std_response {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
   my $setup = test_setup($tmpdir, 'auth_otp');
@@ -1593,7 +1593,7 @@ EOS
         AuthOTPEngine => 'on',
         AuthOTPLog => $setup->{log_file},
         AuthOTPAlgorithm => 'hotp',
-        AuthOTPOptions => 'StandardResponse',
+        AuthOTPOptions => 'FTPStandardResponse',
 
         # Assumes default table names, column names
         AuthOTPTable => 'sql:/get-user-hotp/update-user-hotp',


### PR DESCRIPTION
…esponse", to better indicate that it is specific to FTP/FTPS logins only, and not for SSH/SFTP logins.