### PR TITLE
Issue #1569: Fix the calculation of the block size to use for the SFT…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@
 - Bug 4494 - mod_tls build fails for OpenSSL before 1.1.x.
 - Issue 1570 - mod_sftp should advertise standard extensions for protocol
   version 3.
+- Issue 1569 - mod_sftp "check-file" extension uses wrong block size when
+  offset and length are specified.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -4289,11 +4289,11 @@ static int fxp_handle_ext_check_file(struct fxp_packet *fxp, char *digest_list,
     return fxp_packet_write(resp);
   }
 
-  if (len == 0) {
-    range_len = st.st_size - offset;
+  if (len != 0) {
+    range_len = len;
 
   } else {
-    range_len = offset + len;
+    range_len = st.st_size - offset;
   }
 
   if (blocksz == 0) {


### PR DESCRIPTION
…P "check-file" extension, when both `offset` and `len` are explicitly provided by the client.