### PR TITLE
Issue #1597: Properly handle `From` directives inside a `<Class>` sec…

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2022 The ProFTPD Project team
+ * Copyright (c) 2001-2023 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2790,6 +2790,8 @@ MODRET end_anonymous(cmd_rec *cmd) {
 }
 
 MODRET add_class(cmd_rec *cmd) {
+  config_rec *c;
+
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT|CONF_GLOBAL);
 
@@ -2798,15 +2800,25 @@ MODRET add_class(cmd_rec *cmd) {
       cmd->argv[1], ">: ", strerror(errno), NULL));
   }
 
+  c = pr_parser_config_ctxt_open("Class");
+  c->config_type = CONF_CLASS;
+
   return PR_HANDLED(cmd);
 }
 
 MODRET end_class(cmd_rec *cmd) {
+  int empty_ctx = FALSE;
+
   if (cmd->argc > 1) {
     CONF_ERROR(cmd, "wrong number of parameters");
   }
 
   CHECK_CONF(cmd, CONF_CLASS);
+
+  pr_parser_config_ctxt_close(&empty_ctx);
+  if (empty_ctx == TRUE) {
+    pr_log_debug(DEBUG3, "%s: ignoring empty section", (char *) cmd->argv[0]);
+  }
 
   if (pr_class_close() < 0) {
     pr_log_pri(PR_LOG_WARNING, "warning: empty <Class> definition");

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2022 The ProFTPD Project team
+ * Copyright (c) 2001-2023 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2879,11 +2879,17 @@ void init_dirtree(void) {
 /* These functions are used by modules to help parse configuration. */
 
 unsigned char check_context(cmd_rec *cmd, int allowed) {
-  int ctxt = (cmd->config && cmd->config->config_type != CONF_PARAM ?
-     cmd->config->config_type : cmd->server->config_type ?
-     cmd->server->config_type : CONF_ROOT);
+  int ctx;
 
-  if (ctxt & allowed) {
+  if (cmd == NULL) {
+    return FALSE;
+  }
+
+  ctx = (cmd->config && cmd->config->config_type != CONF_PARAM ?
+    cmd->config->config_type : cmd->server->config_type ?
+    cmd->server->config_type : CONF_ROOT);
+
+  if (ctx & allowed) {
     return TRUE;
   }
 
@@ -2893,36 +2899,50 @@ unsigned char check_context(cmd_rec *cmd, int allowed) {
 
 char *get_context_name(cmd_rec *cmd) {
   static char cbuf[20];
+  char *ctx_name = NULL;
 
-  if (!cmd->config || cmd->config->config_type == CONF_PARAM) {
+  if (cmd->config == NULL ||
+      cmd->config->config_type == CONF_PARAM) {
     if (cmd->server->config_type == CONF_VIRTUAL) {
-      return "<VirtualHost>";
-    }
+      ctx_name = "<VirtualHost>";
 
-    return "server config";
+    } else {
+      ctx_name = "server config";
+    }
+  }
+
+  if (ctx_name != NULL) {
+    return ctx_name;
   }
 
   switch (cmd->config->config_type) {
     case CONF_DIR:
-      return "<Directory>";
+      ctx_name = "<Directory>";
+      break;
 
     case CONF_ANON:
-      return "<Anonymous>";
+      ctx_name = "<Anonymous>";
+      break;
 
     case CONF_CLASS:
-      return "<Class>";
+      ctx_name = "<Class>";
+      break;
 
     case CONF_LIMIT:
-      return "<Limit>";
+      ctx_name = "<Limit>";
+      break;
 
     case CONF_DYNDIR:
-      return ".ftpaccess";
+      ctx_name = ".ftpaccess";
+      break;
 
     case CONF_GLOBAL:
-      return "<Global>";
+      ctx_name = "<Global>";
+      break;
 
     case CONF_USERDATA:
-      return "user data";
+      ctx_name = "user data";
+      break;
 
     default:
       /* XXX should dispatch to modules here, to allow them to create and
@@ -2930,8 +2950,10 @@ char *get_context_name(cmd_rec *cmd) {
        */
       memset(cbuf, '\0', sizeof(cbuf));
       pr_snprintf(cbuf, sizeof(cbuf), "%d", cmd->config->config_type);
-      return cbuf;
+      ctx_name = cbuf;
   }
+
+  return ctx_name;
 }
 
 int get_boolean(cmd_rec *cmd, int av) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2004-2022 The ProFTPD Project team
+ * Copyright (c) 2004-2023 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -261,7 +261,7 @@ config_rec *pr_parser_config_ctxt_open(const char *name) {
     return NULL;
   }
 
-  if (parent) {
+  if (parent != NULL) {
     parent_pool = parent->pool;
     set = &parent->subset;
 
@@ -277,7 +277,7 @@ config_rec *pr_parser_config_ctxt_open(const char *name) {
    * parent server.  This keeps <Global> config recs from being freed
    * prematurely, and helps to avoid memory leaks.
    */
-  if (strncasecmp(name, "<Global>", 9) == 0) {
+  if (strcasecmp(name, "<Global>") == 0) {
     if (global_config_pool == NULL) {
       global_config_pool = make_sub_pool(permanent_pool);
       pr_pool_tag(global_config_pool, "<Global> Pool");
@@ -304,7 +304,7 @@ config_rec *pr_parser_config_ctxt_open(const char *name) {
   c->parent = parent;
   c->name = pstrdup(c->pool, name);
 
-  if (parent) {
+  if (parent != NULL) {
     if (parent->config_type == CONF_DYNDIR) {
       c->flags |= CF_DYNAMIC;
     }


### PR DESCRIPTION
…tion that is itself within a `<Global>` section.

The underlying cause was the lack of creating a "Class" config context on the parser stack for the entire `<Class>` section.  Without this, the `From` directives were not being associated into the `CONF_CLASS` configuration context, which in turn meant that the directive handler checks for proper context were failing unexpectedly.