### PR TITLE
If our OpenSSL version supports it, use `BIO_s_secmem()` for the memo…

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1145,6 +1145,9 @@
 /* Define if using OPENSSL_API_COMPAT.  */
 #undef PR_USE_OPENSSL_API_COMPAT
 
+/* Define if using OpenSSL has BIO_s_secmem().  */
+#undef PR_USE_OPENSSL_BIO_SECMEM
+
 /* Define if OpenSSL Elliptic Curve Cryptography (ECC) support, if available,
  * should be used.
  */

--- a/configure
+++ b/configure
@@ -24718,6 +24718,45 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has BIO_s_secmem support" >&5
+$as_echo_n "checking whether OpenSSL has BIO_s_secmem support... " >&6; }
+  saved_libs="$LIBS"
+  LIBS="-lcrypto $LIBS"
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <openssl/bio.h>
+
+int
+main ()
+{
+
+      BIO *bio = BIO_s_secmem();
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define PR_USE_OPENSSL_BIO_SECMEM 1" >>confdefs.h
+
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$saved_libs"
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenSSL has complete ECC support" >&5
 $as_echo_n "checking whether OpenSSL has complete ECC support... " >&6; }
   saved_libs="$LIBS"

--- a/configure.in
+++ b/configure.in
@@ -3578,6 +3578,27 @@ if test x"$pr_use_openssl" = xyes; then
     ]
   )
 
+  AC_MSG_CHECKING([whether OpenSSL has BIO_s_secmem support])
+  saved_libs="$LIBS"
+  LIBS="-lcrypto $LIBS"
+
+  AC_TRY_LINK(
+    [
+      #include <openssl/bio.h>
+    ],
+    [
+      BIO *bio = BIO_s_secmem();
+    ],
+    [
+      AC_MSG_RESULT(yes)
+      AC_DEFINE(PR_USE_OPENSSL_BIO_SECMEM, 1, [Define if your OpenSSL supports BIO_s_secmem])
+    ],
+    [
+      AC_MSG_RESULT(no)
+    ]
+  )
+  LIBS="$saved_libs"
+
   AC_MSG_CHECKING([whether OpenSSL has complete ECC support])
   saved_libs="$LIBS"
   LIBS="-lcrypto $LIBS"

--- a/contrib/mod_sftp/keys.c
+++ b/contrib/mod_sftp/keys.c
@@ -3675,7 +3675,11 @@ static BIO *load_file_hostkey_bio(pool *p, int fd) {
 
   bufsz = st.st_blksize;
   buf = palloc(p, bufsz);
+#if defined(PR_USE_OPENSSL_BIO_SECMEM)
+  bio = BIO_new(BIO_s_secmem());
+#else
   bio = BIO_new(BIO_s_mem());
+#endif /* PR_USE_OPENSSL_BIO_SECMEM */
 
   res = read(fd, buf, bufsz);
   xerrno = errno;


### PR DESCRIPTION
…ry BIO of our `SFTPHostKey` data; see Issue #1596.