### PR TITLE
Issue #1617: The SSH, SFTP `ExtendedLog` classes have been broken for…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,7 @@
   disk.
 - Issue 1610 - ProFTPD does not detect FIPS when using OpenSSL 3.x built with
   FIPS support.
+- Issue 1617 - ExtendedLog SSH, SFTP classes not working as expected.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp user authentication
- * Copyright (c) 2008-2022 TJ Saunders
+ * Copyright (c) 2008-2023 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -647,7 +647,6 @@ static int setup_env(pool *p, const char *user) {
 
   /* Make sure directory config pointers are set correctly */
   cmd = pr_cmd_alloc(p, 1, C_PASS);
-  cmd->cmd_class = CL_AUTH|CL_SSH;
   cmd->arg = "";
   dir_check_full(p, cmd, G_NONE, session.cwd, NULL);
 
@@ -1130,11 +1129,9 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
   orig_user = sftp_msg_read_string(pkt->pool, &buf, &buflen);
 
   user_cmd = pr_cmd_alloc(pkt->pool, 2, pstrdup(pkt->pool, C_USER), orig_user);
-  user_cmd->cmd_class = CL_AUTH|CL_SSH;
   user_cmd->arg = (char *) orig_user;
 
   pass_cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, C_PASS));
-  pass_cmd->cmd_class = CL_AUTH|CL_SSH;
   pass_cmd->arg = pstrdup(pkt->pool, "(hidden)");
 
   /* Dispatch these as PRE_CMDs, so that mod_delay's tactics can be used
@@ -1237,6 +1234,7 @@ static int handle_userauth_req(struct ssh2_packet *pkt, char **service) {
     pstrdup(pkt->pool, user), pstrdup(pkt->pool, method));
   cmd->arg = pstrcat(pkt->pool, user, " ", method, NULL);
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   if (auth_attempts_max > 0 &&
       auth_attempts > auth_attempts_max) {

--- a/contrib/mod_sftp/channel.c
+++ b/contrib/mod_sftp/channel.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp channels
- * Copyright (c) 2008-2021 TJ Saunders
+ * Copyright (c) 2008-2023 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -406,6 +406,7 @@ static int read_channel_open(struct ssh2_packet *pkt, uint32_t *channel_id) {
     pstrdup(pkt->pool, channel_type));
   cmd->arg = channel_type;
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   if (strncmp(channel_type, "session", 8) != 0) {
     (void) pr_log_writefile(sftp_logfd, MOD_SFTP_VERSION,
@@ -444,6 +445,7 @@ static int handle_channel_close(struct ssh2_packet *pkt) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "CHANNEL_CLOSE"));
   cmd->arg = pstrdup(pkt->pool, chan_str);
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   chan = get_channel(channel_id);
   if (chan == NULL) {
@@ -680,6 +682,7 @@ static int handle_channel_eof(struct ssh2_packet *pkt) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "CHANNEL_EOF"));
   cmd->arg = pstrdup(pkt->pool, chan_str);
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   chan = get_channel(channel_id);
   if (chan == NULL) {
@@ -993,6 +996,7 @@ static int handle_channel_req(struct ssh2_packet *pkt) {
     pstrdup(pkt->pool, channel_request));
   cmd->arg = channel_request;
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   chan = get_channel(channel_id);
   if (chan == NULL) {
@@ -1148,6 +1152,7 @@ static int handle_channel_window_adjust(struct ssh2_packet *pkt) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "CHANNEL_WINDOW_ADJUST"));
   cmd->arg = pstrdup(pkt->pool, adjust_str);
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   chan = get_channel(channel_id);
   if (chan == NULL) {

--- a/contrib/mod_sftp/kex.c
+++ b/contrib/mod_sftp/kex.c
@@ -3112,6 +3112,7 @@ static int handle_kex_dh(struct ssh2_packet *pkt, struct sftp_kex *kex) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "DH_INIT"));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading DH_INIT message from client");
 
@@ -3687,6 +3688,7 @@ static int handle_kex_dh_gex(struct ssh2_packet *pkt, struct sftp_kex *kex,
     cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "DH_GEX_REQUEST"));
     cmd->arg = "(data)";
     cmd->cmd_class = CL_AUTH|CL_SSH;
+    cmd->cmd_id = SFTP_CMD_ID;
 
   } else {
     pr_trace_msg(trace_channel, 9,
@@ -3695,6 +3697,7 @@ static int handle_kex_dh_gex(struct ssh2_packet *pkt, struct sftp_kex *kex,
     cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "DH_GEX_REQUEST_OLD"));
     cmd->arg = "(data)";
     cmd->cmd_class = CL_AUTH|CL_SSH;
+    cmd->cmd_id = SFTP_CMD_ID;
   }
 
   res = read_dh_gex(pkt, &min, &pref, &max, old_request);
@@ -3736,6 +3739,7 @@ static int handle_kex_dh_gex(struct ssh2_packet *pkt, struct sftp_kex *kex,
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "DH_GEX_INIT"));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading DH_GEX_INIT message from client");
 
@@ -4012,6 +4016,7 @@ static int handle_kex_rsa(struct sftp_kex *kex) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "KEXRSA_SECRET"));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading KEXRSA_SECRET message from client");
 
@@ -4367,6 +4372,7 @@ static int handle_kex_curve25519(struct ssh2_packet *pkt,
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, req));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading %s message from client", req);
 
@@ -4808,6 +4814,7 @@ static int handle_kex_curve448(struct ssh2_packet *pkt, struct sftp_kex *kex) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, req));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading %s message from client", req);
 
@@ -5001,6 +5008,7 @@ static int handle_kex_ecdh(struct ssh2_packet *pkt, struct sftp_kex *kex) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, req));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading %s message from client", req);
 
@@ -5194,6 +5202,7 @@ int sftp_kex_handle(struct ssh2_packet *pkt) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "KEXINIT"));
   cmd->arg = "(data)";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_trace_msg(trace_channel, 9, "reading KEXINIT message from client");
 
@@ -5468,6 +5477,7 @@ int sftp_kex_handle(struct ssh2_packet *pkt) {
   cmd = pr_cmd_alloc(pkt->pool, 1, pstrdup(pkt->pool, "NEWKEYS"));
   cmd->arg = "";
   cmd->cmd_class = CL_AUTH|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
   destroy_pool(pkt->pool);
@@ -5502,6 +5512,7 @@ int sftp_kex_handle(struct ssh2_packet *pkt) {
     cmd = pr_cmd_alloc(pkt2->pool, 1, pstrdup(pkt2->pool, "EXT_INFO"));
     cmd->arg = "";
     cmd->cmd_class = CL_AUTH|CL_SSH;
+    cmd->cmd_id = SFTP_CMD_ID;
 
     pr_cmd_dispatch_phase(cmd, LOG_CMD, 0);
 

--- a/contrib/mod_sftp/mod_sftp.h.in
+++ b/contrib/mod_sftp/mod_sftp.h.in
@@ -168,6 +168,9 @@
 #define SFTP_ROLE_SERVER		1
 #define SFTP_ROLE_CLIENT		2
 
+/* mod_sftp generic/fake "command ID" for logging */
+#define SFTP_CMD_ID		128
+
 /* Miscellaneous */
 extern int sftp_logfd;
 extern const char *sftp_logname;

--- a/contrib/mod_sftp/service.c
+++ b/contrib/mod_sftp/service.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp services
- * Copyright (c) 2008-2021 TJ Saunders
+ * Copyright (c) 2008-2023 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +48,7 @@ static int read_service_req(struct ssh2_packet *pkt, char **service) {
     pstrdup(pkt->pool, service_name));
   cmd->arg = service_name;
   cmd->cmd_class = CL_MISC|CL_SSH;
+  cmd->cmd_id = SFTP_CMD_ID;
 
   if (strcmp(service_name, "ssh-userauth") == 0 ||
       strcmp(service_name, "ssh-connection") == 0) {

--- a/src/jot.c
+++ b/src/jot.c
@@ -2135,18 +2135,19 @@ static int is_jottable(pool *p, cmd_rec *cmd, pr_jot_filters_t *filters) {
   int jottable = FALSE;
 
   if (filters == NULL) {
-    return TRUE;
+    jottable = TRUE;
   }
 
-  jottable = is_jottable_class(cmd, filters->included_classes,
-    filters->excluded_classes);
-  if (jottable == TRUE) {
-    return TRUE;
+  if (jottable == FALSE) {
+    jottable = is_jottable_class(cmd, filters->included_classes,
+      filters->excluded_classes);
   }
 
-  if (filters->cmd_ids != NULL) {
-    jottable = is_jottable_cmd(cmd, filters->cmd_ids->elts,
-      filters->cmd_ids->nelts);
+  if (jottable == FALSE) {
+    if (filters->cmd_ids != NULL) {
+      jottable = is_jottable_cmd(cmd, filters->cmd_ids->elts,
+        filters->cmd_ids->nelts);
+    }
   }
 
   return jottable;

--- a/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
@@ -382,6 +382,11 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  extlog_sftp_ssh_ssh_issue1617 => {
+    order => ++$order,
+    test_class => [qw(bug forking mod_sftp)],
+  },
+
   extlog_sftp_ssh_sftp_bug4067 => {
     order => ++$order,
     test_class => [qw(bug forking mod_sftp)],
@@ -12322,50 +12327,17 @@ sub extlog_var_basename_bug3987 {
 sub extlog_exclusion_bug4067 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/extlog.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/extlog.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/extlog.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/extlog.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/extlog.group");
-
-  my $test_file = File::Spec->rel2abs($config_file);
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
+  my $setup = test_setup($tmpdir, 'extlog');
 
   my $ext_log = File::Spec->rel2abs("$tmpdir/custom.log");
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
@@ -12378,7 +12350,8 @@ sub extlog_exclusion_bug4067 {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -12395,13 +12368,15 @@ sub extlog_exclusion_bug4067 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
+      # Allow for server startup
+      sleep(2);
+
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($user, $passwd);
+      $client->login($setup->{user}, $setup->{passwd});
       $client->feat();
       $client->pwd();
       $client->quit();
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -12410,7 +12385,7 @@ sub extlog_exclusion_bug4067 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -12420,8 +12395,7 @@ sub extlog_exclusion_bug4067 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   # Now, read in the ExtendedLog, and see whether the %f variable was
@@ -12437,7 +12411,7 @@ sub extlog_exclusion_bug4067 {
         chomp($line);
 
         if ($ENV{TEST_VERBOSE}) {
-          print STDERR "$line\n";
+          print STDERR "# $line\n";
         }
 
         if ($line eq 'USER' ||
@@ -12448,7 +12422,6 @@ sub extlog_exclusion_bug4067 {
       }
 
       close($fh);
-
       $self->assert($ok, test_msg("Unexpected ExtendedLog messages logged"));
 
     } else {
@@ -12459,54 +12432,28 @@ sub extlog_exclusion_bug4067 {
     $ex = $@;
   }
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
-sub extlog_sftp_ssh_sftp_bug4067 {
+sub extlog_sftp_ssh_ssh_issue1617 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'extlog');
 
-  my $config_file = "$tmpdir/extlog.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/extlog.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/extlog.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/extlog.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/extlog.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  my $sub_dir = File::Spec->rel2abs("$home_dir/sub.d");
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d");
   mkpath($sub_dir);
 
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
-    unless (chmod(0755, $home_dir, $sub_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
+    unless (chmod(0755, $sub_dir)) {
+      die("Can't set perms on $sub_dir to 0755: $!");
     }
 
-    unless (chown($uid, $gid, $home_dir, $sub_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
+      die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -12514,14 +12461,186 @@ sub extlog_sftp_ssh_sftp_bug4067 {
   my $ext_log = File::Spec->rel2abs("$tmpdir/custom.log");
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
-    Trace => 'DEFAULT:10 ssh2:20 sftp:20',
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'jot:30 ssh2:20 sftp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    LogFormat => 'custom "%m"',
+    ExtendedLog => "$ext_log SSH custom",
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::SSH2;
+
+  my $ex;
+
+  # Ignore SIGPIPE
+  local $SIG{PIPE} = sub { };
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Allow for server startup
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      unless ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      my $sftp = $ssh2->sftp();
+      unless ($sftp) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      my $dir = $sftp->opendir('sub.d');
+      unless ($dir) {
+        my ($err_code, $err_name) = $sftp->error();
+        die("Can't open directory 'sub.d': [$err_name] ($err_code)");
+      }
+
+      my $res = {};
+
+      my $file = $dir->read();
+      while ($file) {
+        $res->{$file->{name}} = $file;
+        $file = $dir->read();
+      }
+
+      # To issue the FXP_CLOSE, we have to explicitly destroy the dirhandle
+      $dir = undef;
+
+      # To close the SFTP channel, we have to explicitly destroy the object
+      $sftp = undef;
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $ext_log")) {
+      my $ok = 1;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line eq 'USER' ||
+            $line eq 'PASS') {
+          $ok = 0;
+          last;
+        }
+      }
+
+      close($fh);
+      $self->assert($ok, test_msg("Unexpected ExtendedLog lines seen"));
+
+    } else {
+      die("Can't read $ext_log: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub extlog_sftp_ssh_sftp_bug4067 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'extlog');
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d");
+  mkpath($sub_dir);
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $sub_dir)) {
+      die("Can't set perms on $sub_dir to 0755: $!");
+    }
+
+    unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
+      die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
+    }
+  }
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
+
+  my $ext_log = File::Spec->rel2abs("$tmpdir/custom.log");
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 sftp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
@@ -12534,14 +12653,15 @@ sub extlog_sftp_ssh_sftp_bug4067 {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
       ],
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -12563,15 +12683,17 @@ sub extlog_sftp_ssh_sftp_bug4067 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
+      # Allow for server startup
+      sleep(2);
+
       my $ssh2 = Net::SSH2->new();
-      sleep(1);
 
       unless ($ssh2->connect('127.0.0.1', $port)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      unless ($ssh2->auth_password($user, $passwd)) {
+      unless ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
@@ -12604,7 +12726,6 @@ sub extlog_sftp_ssh_sftp_bug4067 {
 
       $ssh2->disconnect();
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -12613,7 +12734,7 @@ sub extlog_sftp_ssh_sftp_bug4067 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -12623,8 +12744,7 @@ sub extlog_sftp_ssh_sftp_bug4067 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   eval {
@@ -12635,7 +12755,7 @@ sub extlog_sftp_ssh_sftp_bug4067 {
         chomp($line);
 
         if ($ENV{TEST_VERBOSE}) {
-          print STDERR "$line\n";
+          print STDERR "# $line\n";
         }
 
         if ($line eq 'USER' ||
@@ -12647,7 +12767,6 @@ sub extlog_sftp_ssh_sftp_bug4067 {
       }
 
       close($fh);
-
       $self->assert($ok, test_msg("Unexpected ExtendedLog lines seen"));
 
     } else {
@@ -12658,54 +12777,28 @@ sub extlog_sftp_ssh_sftp_bug4067 {
     $ex = $@;
   }
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'extlog');
 
-  my $config_file = "$tmpdir/extlog.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/extlog.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/extlog.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/extlog.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/extlog.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  my $sub_dir = File::Spec->rel2abs("$home_dir/sub.d");
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d");
   mkpath($sub_dir);
 
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
-    unless (chmod(0755, $home_dir, $sub_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
+    unless (chmod(0755, $sub_dir)) {
+      die("Can't set perms on $sub_dir to 0755: $!");
     }
 
-    unless (chown($uid, $gid, $home_dir, $sub_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
+      die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -12713,14 +12806,14 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
   my $ext_log = File::Spec->rel2abs("$tmpdir/custom.log");
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
-    Trace => 'DEFAULT:10 ssh2:20 sftp:20',
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'jot:20 ssh2:20 sftp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
@@ -12733,14 +12826,15 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
       ],
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -12762,15 +12856,17 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
+      # Allow for server startup
+      sleep(2);
+
       my $ssh2 = Net::SSH2->new();
-      sleep(1);
 
       unless ($ssh2->connect('127.0.0.1', $port)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      unless ($ssh2->auth_password($user, $passwd)) {
+      unless ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
@@ -12803,7 +12899,6 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
 
       $ssh2->disconnect();
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -12812,7 +12907,7 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -12822,8 +12917,7 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   eval {
@@ -12834,7 +12928,7 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
         chomp($line);
 
         if ($ENV{TEST_VERBOSE}) {
-          print STDERR "$line\n";
+          print STDERR "# $line\n";
         }
 
         if ($line ne 'USER' &&
@@ -12856,54 +12950,28 @@ sub extlog_sftp_ssh_sftp_exclusion_bug4067 {
     $ex = $@;
   }
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub extlog_sftp_read_write_bug4067 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'extlog');
 
-  my $config_file = "$tmpdir/extlog.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/extlog.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/extlog.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/extlog.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/extlog.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  my $sub_dir = File::Spec->rel2abs("$home_dir/sub.d");
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d");
   mkpath($sub_dir);
 
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
-    unless (chmod(0755, $home_dir, $sub_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
+    unless (chmod(0755, $sub_dir)) {
+      die("Can't set perms on $sub_dir to 0755: $!");
     }
 
-    unless (chown($uid, $gid, $home_dir, $sub_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
+    unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
+      die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -12911,14 +12979,14 @@ sub extlog_sftp_read_write_bug4067 {
   my $ext_log = File::Spec->rel2abs("$tmpdir/custom.log");
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
-    Trace => 'DEFAULT:10 ssh2:20 sftp:20',
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'jot:20 ssh2:20 sftp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     LogFormat => 'custom "%m"',
@@ -12931,14 +12999,15 @@ sub extlog_sftp_read_write_bug4067 {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
       ],
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -12960,15 +13029,17 @@ sub extlog_sftp_read_write_bug4067 {
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
+      # Allow for server startup
+      sleep(2);
+
       my $ssh2 = Net::SSH2->new();
-      sleep(1);
 
       unless ($ssh2->connect('127.0.0.1', $port)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      unless ($ssh2->auth_password($user, $passwd)) {
+      unless ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
@@ -13017,7 +13088,6 @@ sub extlog_sftp_read_write_bug4067 {
 
       $ssh2->disconnect();
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -13026,7 +13096,7 @@ sub extlog_sftp_read_write_bug4067 {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -13036,8 +13106,7 @@ sub extlog_sftp_read_write_bug4067 {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   eval {
@@ -13049,7 +13118,7 @@ sub extlog_sftp_read_write_bug4067 {
         chomp($line);
 
         if ($ENV{TEST_VERBOSE}) {
-          print STDERR "$line\n";
+          print STDERR "# $line\n";
         }
 
         if ($write_ok and $read_ok) {
@@ -13080,14 +13149,7 @@ sub extlog_sftp_read_write_bug4067 {
     $ex = $@;
   }
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub extlog_sftp_xfer_status_filtered {


### PR DESCRIPTION
… a while, due to filtering in the Jot API of commands lacking known command IDs.

The core ProFTPD engine has command IDs for FTP commands, but not for the SSH, SFTP requests supported by the `mod_sftp` module.  The workaround is for `mod_sftp` to manually assign a fake command ID, such that the Jot API will think these commands are known, and thus handle them as expected.