### PR TITLE
Add %S to mod_exec for sftp-non-fatal tagging

### DIFF
--- a/contrib/mod_exec.c
+++ b/contrib/mod_exec.c
@@ -1062,6 +1062,15 @@ static const char *exec_subst_var(pool *tmp_pool, const char *varstr,
     }
   }
 
+  ptr = strstr(varstr, "%S");
+  if (ptr != NULL) {
+    const void *sftp_nonfatal_note;
+
+    sftp_nonfatal_note = pr_table_get(cmd->notes, "mod_sftp.nonfatal-attempt", NULL);
+    varstr = sreplace(tmp_pool, varstr, "%S",
+      sftp_nonfatal_note ? sftp_nonfatal_note : "", NULL);
+  }
+
   ptr = strstr(varstr, "%U");
   if (ptr != NULL) {
     const char *user;

--- a/doc/contrib/mod_exec.html
+++ b/doc/contrib/mod_exec.html
@@ -167,10 +167,13 @@ corresponding value before the script is executed:
   <li><b>%h</b> - client's DNS name
   <li><b>%m</b> - FTP command (e.g. RETR, STOR, etc)
   <li><b>%r</b> - full FTP command
+  <li><b>%S</b> - SFTP non-fatal status - empty string if it is a fatal error, or the auth method in use if it's non-fatal
   <li><b>%U</b> - original username sent by client
   <li><b>%u</b> - name of local user
   <li><b>%v</b> - name of server handling session
+  <li><b>%V</b> - DNS name of the server IP handling session
   <li><b>%w</b> - RNFR path ("whence" a rename comes, <i>i.e.</i> the source path)
+  <li><b>%{time:&lt;format&gt;}</b> - the current time, formatted using strftime(&lt;format&gt;)
 </ul>
 The <i>value</i> parameter may be also be &quot;-&quot;, which indicates that
 the current value of the environment variable of name <i>key</i> should be


### PR DESCRIPTION
This adds %S as a mod_exec substitution, which is replaced by the "mod_sftp.nonfatal-attempt" note or an empty string if it doesn't exist.  Thus an empty string is a fatal error (i.e., failed login) whereas a non-empty string indicates a non-fatal error as part of the login process.

I also added the %V and %{time:} variables to the docs, as they are missing and I use at least one of those (time).  I did not add %l (ident info) since mod_ident is deprecated anyway, or %{env:} because it doesn't appear to work right now.