### PR TITLE
Issue #1636: Use the system/kernel defaults for the TCP backlog for l…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -47,6 +47,7 @@
 - Issue 1626 - SSH key exchange requests should be classifed into the "SEC"
   ExtendedLog class.
 - Issue 1630 - Update mod_exec to use the Jot API for resolving variables.
+- Issue 1636 - Use system TCP backlog value by default.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/config.h.in
+++ b/config.h.in
@@ -186,6 +186,9 @@
 /* Define to `int' if <sys/types.h> doesn't define.  */
 #undef pid_t
 
+/* Define if the listen(2) system call accepts backlog value of -1. */
+#undef LISTEN_NEGATIVE_BACKLOG
+
 /* Define as the return type of signal handlers (int or void).  */
 #undef RETSIGTYPE
 

--- a/configure
+++ b/configure
@@ -24085,6 +24085,80 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether listen supports negative backlog" >&5
+$as_echo_n "checking whether listen supports negative backlog... " >&6; };
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <errno.h>
+    #include <stdio.h>
+    #ifdef HAVE_STDLIB_H
+    # include <stdlib.h>
+    #endif
+    #ifdef HAVE_STRING_H
+    # include <string.h>
+    #endif
+    #ifdef HAVE_UNISTD_H
+    # include <unistd.h>
+    #endif
+    #ifdef HAVE_NETDB_H
+    # include <netdb.h>
+    #endif
+    #ifdef HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    int main(int argc, char *argv[]) {
+      struct protoent *pe;
+      int backlog = -1, proto = -1, fd, res;
+
+      pe = getprotobyname("tcp");
+      if (pe != NULL) {
+        proto = pe->p_proto;
+      }
+
+      fd = socket(AF_INET, SOCK_STREAM, proto);
+      if (fd < 0) {
+        fprintf(stderr, "error creating socket: %s\n", strerror(errno));
+        return 1;
+      }
+
+      res = listen(fd, backlog);
+      if (res < 0) {
+        fprintf(stderr, "error listening on socket: %s\n", strerror(errno));
+        return 1;
+      }
+
+      (void) close(fd);
+      return 0;
+    }
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; };
+
+$as_echo "#define LISTEN_NEGATIVE_BACKLOG 1" >>confdefs.h
+
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
 ac_shared_module_dirs=
 ac_static_module_dirs=
 

--- a/configure.in
+++ b/configure.in
@@ -3128,6 +3128,62 @@ AC_TRY_RUN(
   AC_MSG_RESULT(cross-compiling); AC_DEFINE(HAVE_LU, 1, [Define if you have %lu support])
 )
 
+dnl Run a small test program to see if the host's listen(2) function can
+dnl handle a negative backlog (Issue #1636).
+AC_MSG_CHECKING([whether listen supports negative backlog]);
+AC_TRY_RUN(
+  [
+    #include <errno.h>
+    #include <stdio.h>
+    #ifdef HAVE_STDLIB_H
+    # include <stdlib.h>
+    #endif
+    #ifdef HAVE_STRING_H
+    # include <string.h>
+    #endif
+    #ifdef HAVE_UNISTD_H
+    # include <unistd.h>
+    #endif
+    #ifdef HAVE_NETDB_H
+    # include <netdb.h>
+    #endif
+    #ifdef HAVE_SYS_SOCKET_H
+    # include <sys/socket.h>
+    #endif
+    int main(int argc, char *argv[]) {
+      struct protoent *pe;
+      int backlog = -1, proto = -1, fd, res;
+
+      pe = getprotobyname("tcp");
+      if (pe != NULL) {
+        proto = pe->p_proto;
+      }
+
+      fd = socket(AF_INET, SOCK_STREAM, proto);
+      if (fd < 0) {
+        fprintf(stderr, "error creating socket: %s\n", strerror(errno));
+        return 1;
+      }
+
+      res = listen(fd, backlog);
+      if (res < 0) {
+        fprintf(stderr, "error listening on socket: %s\n", strerror(errno));
+        return 1;
+      }
+
+      (void) close(fd);
+      return 0;
+    }
+  ],
+  [
+    AC_MSG_RESULT(yes);
+    AC_DEFINE(LISTEN_NEGATIVE_BACKLOG, 1, [Define if you have negative backlog support])
+  ],
+  [
+    AC_MSG_RESULT(no)
+  ]
+)
+
 dnl Module handling.
 ac_shared_module_dirs=
 ac_static_module_dirs=

--- a/doc/modules/mod_core.html
+++ b/doc/modules/mod_core.html
@@ -2753,14 +2753,14 @@ See also: <a href="#SyslogFacility"><code>SyslogFacility</code></a>,
 <hr>
 <h3><a name="TCPBacklog">TCPBacklog</a></h3>
 <strong>Syntax:</strong> TCPBacklog <em>backlog-size</em><br>
-<strong>Default:</strong> 5<br>
+<strong>Default:</strong> <em>system</em><br>
 <strong>Context:</strong> server config<br>
 <strong>Module:</strong> mod_core<br>
 <strong>Compatibility:</strong> 0.99.0 and later
 
 <p>
-The <code>TCPBacklog</code> directive controls the TCP connection queue
-size for listening sockets; this directive only applies to <code>proftpd</code>
+The <code>TCPBacklog</code> directive controls the TCP connection queue size
+for listening sockets; this directive only applies to <code>proftpd</code>
 when it is configured with "<code>ServerType standalone</code>".  It has
 <b>no effect</b> if "<code>ServerType inetd</code>" is configured.
 

--- a/include/options.h
+++ b/include/options.h
@@ -47,9 +47,14 @@
 /* "Backlog" is the number of connections that can be received at one
  * burst before the kernel rejects.  This can be configured by the
  * "tcpBackLog" configuration directive, this value is just the default.
+ * If a backlog value of -1 is supported, it means "use system/kernel default".
  */
 #ifndef PR_TUNABLE_DEFAULT_BACKLOG
-# define PR_TUNABLE_DEFAULT_BACKLOG	128
+# ifdef LISTEN_NEGATIVE_BACKLOG
+#   define PR_TUNABLE_DEFAULT_BACKLOG	-1
+# else
+#   define PR_TUNABLE_DEFAULT_BACKLOG	128
+# endif /* LISTEN_NEGATIVE_BACKLOG */
 #endif /* PR_TUNABLE_DEFAULT_BACKLOG */
 
 /* The default TCP send/receive buffer sizes, should explicit sizes not

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -1313,23 +1313,9 @@ MODRET set_tcpbacklog(cmd_rec *cmd) {
 
   backlog = atoi(cmd->argv[1]);
 
-  if (backlog < 1 ||
-      backlog > 255) {
-    CONF_ERROR(cmd, "parameter must be a number between 1 and 255");
+  if (backlog < 1) {
+    CONF_ERROR(cmd, "parameter must be greater than zero");
   }
-
-#if defined(SOMAXCONN) && \
-    SOMAXCONN < 255
-  if (backlog > SOMAXCONN) {
-    char str[32];
-
-    memset(str, '\0', sizeof(str));
-    pr_snprintf(str, sizeof(str)-1, "%u", (unsigned int) SOMAXCONN);
-
-    CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
-      "parameter must be less than SOMAXCONN (", str, ")", NULL));
-  }
-#endif
 
   tcpBackLog = backlog;
   return PR_HANDLED(cmd);


### PR DESCRIPTION
…istening sockets where possible.

Also allow sites to configure different TCP backlog values without imposing unnecessary limits.