### PR TITLE
Reduce the number of times any configured `AuthUserFile`, `AuthGroupF…

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
@@ -1354,36 +1354,7 @@ EOC
 sub ifgroup_displaylogin_bug3882 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/ifsess.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/ifsess.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/ifsess.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/ifsess.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/ifsess.group");
-
-  my $test_file = File::Spec->rel2abs($config_file);
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
+  my $setup = test_setup($tmpdir, 'ifsess');
 
   my $login_file = File::Spec->rel2abs("$tmpdir/login.txt");
   if (open(my $fh, "> $login_file")) {
@@ -1397,20 +1368,18 @@ sub ifgroup_displaylogin_bug3882 {
     die("Unable to open $login_file: $!");
   }
 
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
-
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'auth:20 auth.file:20 fsio:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
-    DefaultRoot => '~',
+#    DefaultRoot => '~',
 
     IfModules => {
       'mod_delay.c' => {
@@ -1419,23 +1388,24 @@ sub ifgroup_displaylogin_bug3882 {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Append the mod_ifsession config to the end of the config file
-  if (open(my $fh, ">> $config_file")) {
+  if (open(my $fh, ">> $setup->{config_file}")) {
     print $fh <<EOC;
 <IfModule mod_ifsession.c>
-  <IfGroup $group>
+  <IfGroup $setup->{group}>
     DisplayLogin $login_file
   </IfGroup>
 </IfModule>
 EOC
     unless (close($fh)) {
-      die("Can't write $config_file: $!");
+      die("Can't write $setup->{config_file}: $!");
     }
 
   } else {
-    die("Can't open $config_file: $!");
+    die("Can't open $setup->{config_file}: $!");
   }
 
   # Open pipes, for use between the parent and child processes.  Specifically,
@@ -1453,15 +1423,16 @@ EOC
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
     eval {
+      # Allow for server startup
+      sleep(2);
+
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($user, $passwd);
+      $client->login($setup->{user}, $setup->{passwd});
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg(0);
 
-      my $expected;
-
-      $expected = 230;
+      my $expected = 230;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
 
@@ -1471,7 +1442,6 @@ EOC
 
       $client->quit();
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -1480,7 +1450,7 @@ EOC
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -1490,18 +1460,10 @@ EOC
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub ifgroup_dir_allow_stor_bug3881 { 


### PR DESCRIPTION
…ile` files are scanned during authentication by refactoring the `mod_ifsession` fix for [Bug#3882](http://bugs.proftpd.org/show_bug.cgi?id=3882) to happen just before any chroot, rather than during the `PRE_CMD` handling of a `PASS` command.