### PR TITLE
Clean up lines of trailing whitespace in the regression testsuite.

### DIFF
--- a/tests/t/lib/ProFTPD/TestSuite/FTP.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/FTP.pm
@@ -14,7 +14,7 @@ sub new {
   my ($addr, $port, $use_port, $conn_timeout, $cmd_timeout) = @_;
   $use_port = 0 unless defined($use_port);
   $conn_timeout = 2 unless defined($conn_timeout);
- 
+
   my $ftp;
 
   my $now = time();

--- a/tests/t/lib/ProFTPD/TestSuite/Utils.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/Utils.pm
@@ -198,7 +198,7 @@ sub auth_user_write {
   if ($existed) {
     # Get current permissions
     $prev_mode = (stat($user_file))[2];
- 
+
     # Set needed permissions
     unless (chmod(0666, $user_file)) {
       croak("Can't set perms on $user_file: $!");
@@ -690,7 +690,7 @@ sub config_write {
           }
 
           print $fh "</Global>\n";
- 
+
         } else {
           print $fh "$k $v\n";
         }
@@ -808,7 +808,7 @@ sub feature_have_feature_enabled {
         # Special-case hack for FIPS-enabled OpenSSL
         if ($feature =~ /OpenSSL/i) {
           if ($line =~ /\(FIPS enabled\)/) {
-            push(@$feat_list, "OpenSSL_FIPS");             
+            push(@$feat_list, "OpenSSL_FIPS");
           }
         }
       }
@@ -1118,7 +1118,7 @@ sub test_append_logfile {
   my $log_file = shift;
   my $ex = shift;
 
-  my ($infh, $outfh); 
+  my ($infh, $outfh);
 
   my $out_file = File::Spec->rel2abs('tests.log');
 
@@ -1439,7 +1439,7 @@ sub testsuite_get_runnable_tests {
   if (scalar(@$runnables) > 0) {
     $runnables = [sort { $tests->{$a}->{order} <=> $tests->{$b}->{order} } @$runnables];
 
-  } else { 
+  } else {
     $runnables = [qw(testsuite_empty_test)];
   }
 

--- a/tests/t/lib/ProFTPD/Tests/Commands.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands.pm
@@ -448,7 +448,7 @@ sub cmds_cwd_ok {
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
   mkpath($sub_dir);
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -823,7 +823,7 @@ sub cmds_xcwd_ok {
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
   mkpath($sub_dir);
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -1567,7 +1567,7 @@ sub cmds_mkd_ok {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -1687,7 +1687,7 @@ sub cmds_mkd_fails_enoent {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo/bar');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -1810,7 +1810,7 @@ sub cmds_mkd_fails_eperm {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -1944,7 +1944,7 @@ sub cmds_xmkd_ok {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -2065,7 +2065,7 @@ sub cmds_rmd_ok {
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
   mkpath($sub_dir);
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -2185,7 +2185,7 @@ sub cmds_rmd_fails_enoent {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -2308,7 +2308,7 @@ sub cmds_rmd_fails_eperm {
   my $home_dir = File::Spec->rel2abs('tmp');
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -2443,7 +2443,7 @@ sub cmds_xrmd_ok {
 
   my $sub_dir = File::Spec->rel2abs('tmp/foo');
   mkpath($sub_dir);
-  
+
   auth_user_write($auth_user_file, $user, $passwd, 500, 500, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', 500, $user);
@@ -3399,7 +3399,7 @@ sub cmds_size_ok {
         print $writeh "done\n";
         die("Failed to TYPE: $err");
       }
-    
+
       my ($resp_code, $resp_msg);
       eval { ($resp_code, $resp_msg) = $client->size($test_file) };
       if ($@) {
@@ -3526,7 +3526,7 @@ sub cmds_size_fails_ascii {
         print $writeh "done\n";
         die("Failed to TYPE: $err");
       }
-    
+
       my ($resp_code, $resp_msg);
       eval { ($resp_code, $resp_msg) = $client->size($test_file) };
       unless ($@) {
@@ -3656,7 +3656,7 @@ sub cmds_size_fails_enoent {
         print $writeh "done\n";
         die("Failed to TYPE: $err");
       }
-    
+
       my ($resp_code, $resp_msg);
       eval { ($resp_code, $resp_msg) = $client->size($test_file) };
       unless ($@) {
@@ -3792,7 +3792,7 @@ sub cmds_size_fails_eperm {
         print $writeh "done\n";
         die("Failed to TYPE: $err");
       }
-    
+
       # Make it such that perms on the home dir do not allow reads
       my $perms = (stat($home_dir))[2];
       unless (chmod(0220, $home_dir)) {

--- a/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/APPE.pm
@@ -2360,7 +2360,7 @@ sub appe_fails_eperm {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
     }
-  
+
     unless (chown($setup->{uid}, $setup->{gid}, $sub_dir)) {
       die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Commands/CWD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/CWD.pm
@@ -1500,7 +1500,7 @@ sub cwd_symlinks_traversing_bug3297 {
   } else {
     die("Can't open $sub_dir4/test.txt: $!");
   }
- 
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir1, $sub_dir2, $sub_dir3, $sub_dir4)) {
       die("Can't set perms on $sub_dir1 to 0755: $!");
@@ -1575,11 +1575,11 @@ sub cwd_symlinks_traversing_bug3297 {
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->cwd('archive');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-    
+
       $expected = "CWD command successful";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
@@ -1685,7 +1685,7 @@ sub cwd_symlinks_oneshot_bug3297 {
   } else {
     die("Can't open $sub_dir4/test.txt: $!");
   }
- 
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir1, $sub_dir2, $sub_dir3, $sub_dir4)) {
       die("Can't set perms on $sub_dir1 to 0755: $!");
@@ -1878,7 +1878,7 @@ sub cwd_tilde_ok {
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/0");
   mkpath($sub_dir);
-  
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -1978,10 +1978,10 @@ sub cwd_tilde_user_ok {
   my $home_dir2 = File::Spec->rel2abs("$tmpdir/1");
   my $uid2 = 501;
   my $gid2 = 501;
-  
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/0");
   mkpath($sub_dir);
-  
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -2085,7 +2085,7 @@ sub cwd_tilde_chrooted_bug3785 {
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/0");
   mkpath($sub_dir);
-  
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -2198,10 +2198,10 @@ sub cwd_tilde_user_chrooted_bug3785 {
   my $home_dir2 = File::Spec->rel2abs("$tmpdir/1");
   my $uid2 = 501;
   my $gid2 = 501;
-  
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/0");
   mkpath($sub_dir);
-  
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");

--- a/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/DELE.pm
@@ -40,12 +40,12 @@ my $TESTS = {
   dele_symlink_ok => {
     order => ++$order,
     test_class => [qw(forking)],
-  }, 
+  },
 
   dele_symlink_bug3754 => {
     order => ++$order,
     test_class => [qw(bug forking)],
-  }, 
+  },
 
 };
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPRT.pm
@@ -95,7 +95,7 @@ sub eprt_ipv4_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -212,7 +212,7 @@ sub eprt_ipv6_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -425,7 +425,7 @@ sub eprt_fails_bad_format {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -550,7 +550,7 @@ sub eprt_fails_bad_values {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -674,7 +674,7 @@ sub eprt_fails_bad_proto {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -810,7 +810,7 @@ sub eprt_fails_bad_addr {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -936,7 +936,7 @@ sub eprt_fails_bad_port {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/EPSV.pm
@@ -85,7 +85,7 @@ sub epsv_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -202,7 +202,7 @@ sub epsv_ipv4_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -319,7 +319,7 @@ sub epsv_ipv6_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -438,7 +438,7 @@ sub epsv_all_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -649,7 +649,7 @@ sub epsv_fails_bad_proto {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/LIST.pm
@@ -823,7 +823,7 @@ sub list_file_after_upload {
       if ($ENV{TEST_VERBOSE}) {
         print STDOUT "# Logged in, sending STOR\n";
       }
- 
+
       my $conn = $client->stor_raw('test.dat');
       unless ($conn) {
         die("STOR test.dat failed: " . $client->response_code() . " " .
@@ -833,7 +833,7 @@ sub list_file_after_upload {
       if ($ENV{TEST_VERBOSE}) {
         print STDOUT "# Data connection opened, writing data\n";
       }
- 
+
       my $start = [gettimeofday()];
       my $buf = "ABCD" x 10240;
       $conn->write($buf, length($buf), 30);
@@ -851,7 +851,7 @@ sub list_file_after_upload {
       if ($ENV{TEST_VERBOSE}) {
         print STDOUT "# File uploaded, sending LIST\n";
       }
- 
+
       $conn = $client->list_raw($test_file);
       unless ($conn) {
         die("LIST $test_file failed: " . $client->response_code() . " " .
@@ -1956,7 +1956,7 @@ sub list_fails_eperm {
 sub list_bug2821 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-  
+
   my $config_file = "$tmpdir/cmds.conf";
   my $pid_file = File::Spec->rel2abs("$tmpdir/cmds.pid");
   my $scoreboard_file = File::Spec->rel2abs("$tmpdir/cmds.scoreboard");
@@ -2132,7 +2132,7 @@ sub list_bug2821 {
 sub list_unsorted_buffering_bug4060 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-  
+
   my $config_file = "$tmpdir/cmds.conf";
   my $pid_file = File::Spec->rel2abs("$tmpdir/cmds.pid");
   my $scoreboard_file = File::Spec->rel2abs("$tmpdir/cmds.scoreboard");

--- a/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
@@ -135,7 +135,7 @@ sub mkd_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -646,7 +646,7 @@ sub mkd_umask_one_param_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -735,7 +735,7 @@ sub mkd_umask_two_params_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -824,7 +824,7 @@ sub mkd_with_spaces_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo bar");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -910,7 +910,7 @@ sub mkd_utf8_with_spaces_ok {
 
   my $sub_path = File::Spec->rel2abs("$tmpdir/$sub_dir");
   my $utf8_path = encode_utf8($sub_path);
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -998,7 +998,7 @@ sub mkd_chrooted_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -1090,7 +1090,7 @@ sub mkd_chrooted_with_cwd_ok {
   mkpath($sub_dir);
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
- 
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -1100,7 +1100,7 @@ sub mkd_chrooted_with_cwd_ok {
       die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -1193,7 +1193,7 @@ sub mkd_sgid_umask_one_param_ok {
   mkpath($sub_dir);
 
   my $test_dir = File::Spec->rel2abs("$sub_dir/test.d");
- 
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -1203,11 +1203,11 @@ sub mkd_sgid_umask_one_param_ok {
       die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
- 
+
   # Make sure that our sub directory has the SGID bit set
   my $mode = 2755;
   unless (chmod($mode, $sub_dir)) {
-    die("Can't set perms on $sub_dir: $!"); 
+    die("Can't set perms on $sub_dir: $!");
   }
 
   my $config = {
@@ -1306,7 +1306,7 @@ sub mkd_sgid_umask_two_params_ok {
   mkpath($sub_dir);
 
   my $test_dir = File::Spec->rel2abs("$sub_dir/test.d");
- 
+
   if ($< == 0) {
     unless (chmod(0755, $sub_dir)) {
       die("Can't set perms on $sub_dir to 0755: $!");
@@ -1316,11 +1316,11 @@ sub mkd_sgid_umask_two_params_ok {
       die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
     }
   }
- 
+
   # Make sure that our sub directory has the SGID bit set
   my $mode = 2755;
   unless (chmod($mode, $sub_dir)) {
-    die("Can't set perms on $sub_dir: $!"); 
+    die("Can't set perms on $sub_dir: $!");
   }
 
   my $config = {
@@ -1769,7 +1769,7 @@ sub mkd_digits_ok {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/001");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -1858,7 +1858,7 @@ sub mkd_embedded_cr_bug4167 {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/ab\015cd");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -1947,7 +1947,7 @@ sub mkd_embedded_lf_bug4167 {
   my $setup = test_setup($tmpdir, 'cmds');
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/ab\012cd");
- 
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -2068,7 +2068,7 @@ sub mkd_embedded_lf_bug4167 {
       $expected = "257 \"$sub_dir\" - Directory successfully created\r\n";
       $self->assert($expected eq $resp,
         test_msg("Expected response '$expected', got '$resp'"));
-      
+
       $cmd = "QUIT\r\n";
       if ($ENV{TEST_VERBOSE}) {
         print STDERR "# Sending: $cmd";

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLSD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLSD.pm
@@ -2520,7 +2520,7 @@ sub mlsd_symlink_showsymlinks_on_chrooted_bug4219 {
 
       # Since ShowSymlinks is on, the type for test.lnk should indicate that
       # it's a symlink
-      $expected = 'OS.unix=symlink'; 
+      $expected = 'OS.unix=symlink';
       $got = $res->{'test.lnk'}->{type};
       $self->assert(qr/$expected/i, $got,
         test_msg("Expected '$expected', got '$got'"));

--- a/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MLST.pm
@@ -275,7 +275,7 @@ sub mlst_dir_ok {
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
   mkpath($sub_dir);
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -966,7 +966,7 @@ sub mlst_no_path_ok {
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
   mkpath($sub_dir);
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Commands/PASS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PASS.pm
@@ -240,7 +240,7 @@ sub pass_fails_no_user {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-     
+
       my ($resp_code, $resp_msg);
       eval { ($resp_code, $resp_msg) = $client->pass($passwd) };
       unless ($@) {

--- a/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/PORT.pm
@@ -1202,7 +1202,7 @@ EOC
   } else {
     die("Can't open $config_file: $!");
   }
- 
+
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
   # to the parent.

--- a/tests/t/lib/ProFTPD/Tests/Commands/RANG.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RANG.pm
@@ -1847,7 +1847,7 @@ sub rang_stor_fails_too_little_data {
       my $buf = 'hel';
       $conn->write($buf, length($buf));
       eval { $conn->close() };
- 
+
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $client->quit();
@@ -1942,7 +1942,7 @@ sub rang_stor_fails_too_much_data {
       my $buf = 'Hello, World!\n';
       $conn->write($buf, length($buf));
       eval { $conn->close() };
- 
+
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
       $client->quit();

--- a/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/REST.pm
@@ -415,7 +415,7 @@ sub rest_fails_bad_offset {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -427,7 +427,7 @@ sub rest_fails_bad_offset {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -540,7 +540,7 @@ sub rest_fails_offset_and_ascii {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -552,7 +552,7 @@ sub rest_fails_offset_and_ascii {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/RETR.pm
@@ -2703,7 +2703,7 @@ sub retr_2nd_transfer_terminates_1st_transfer_bug4010 {
       my $expected = 450;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
- 
+
       $conn1->read($tmpbuf, 8192, 30);
       $buf1 .= $tmpbuf;
 

--- a/tests/t/lib/ProFTPD/Tests/Commands/SITE/CHGRP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/SITE/CHGRP.pm
@@ -121,20 +121,18 @@ sub chgrp_name_ok {
       $client->site('CHGRP', $file_group, 'test.txt');
 
       my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg(); 
+      my $resp_msg = $client->response_msg();
 
-      my $expected;
-
-      $expected = 200;
+      my $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 'SITE CHGRP command successful';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
- 
+
       my $test_gid = (stat($test_file))[5];
       $expected = $file_gid;
       $self->assert($expected == $test_gid,

--- a/tests/t/lib/ProFTPD/Tests/Commands/SITE/CHMOD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/SITE/CHMOD.pm
@@ -120,17 +120,15 @@ sub chmod_octal_ok {
       $client->site('CHMOD', '444', 'test.txt');
 
       my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg(); 
+      my $resp_msg = $client->response_msg();
 
-      my $expected;
-
-      $expected = 200;
+      my $expected = 200;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 'SITE CHMOD command successful';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       my $file_mode = sprintf("%lo", (stat($test_file))[2] & 07777);
       $expected = '444';
@@ -274,7 +272,7 @@ EOC
       }
 
       my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg(); 
+      my $resp_msg = $client->response_msg();
 
       my $expected;
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AccessDenyMsg.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AccessDenyMsg.pm
@@ -52,7 +52,7 @@ sub accessdenymsg_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -72,7 +72,7 @@ sub accessdenymsg_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $access_deny_msg = '"Care to try again?"';
@@ -173,7 +173,7 @@ sub accessdenymsg_var_u_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -193,7 +193,7 @@ sub accessdenymsg_var_u_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $access_deny_msg = '"Care to try again, %u?"';
@@ -294,7 +294,7 @@ sub accessdenymsg_limit_user {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -314,7 +314,7 @@ sub accessdenymsg_limit_user {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $access_deny_msg = '"Care to try again?"';

--- a/tests/t/lib/ProFTPD/Tests/Config/AccessGrantMsg.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AccessGrantMsg.pm
@@ -47,7 +47,7 @@ sub accessgrantmsg_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -67,7 +67,7 @@ sub accessgrantmsg_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $access_grant_msg = '"Speak friend, and enter"';
@@ -162,7 +162,7 @@ sub accessgrantmsg_var_u_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -182,7 +182,7 @@ sub accessgrantmsg_var_u_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $access_grant_msg = '"Welcome %u to my humble abode of files"';

--- a/tests/t/lib/ProFTPD/Tests/Config/AnonRejectPasswords.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AnonRejectPasswords.pm
@@ -141,7 +141,7 @@ sub anon_reject_passwords_ok {
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-   
+
       $client->quit();
     };
 
@@ -275,7 +275,7 @@ sub anon_reject_passwords_flags_nocase {
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-   
+
       $client->quit();
     };
 
@@ -411,7 +411,7 @@ sub anon_reject_passwords_not_and_flags_nocase {
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-   
+
       $client->quit();
     };
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AnonRequirePassword.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AnonRequirePassword.pm
@@ -265,7 +265,7 @@ sub anon_require_password_on {
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
-   
+
       # Now try again, using the password
       ($resp_code, $resp_msg) = $client->login($user, $passwd);
 

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthAliasOnly.pm
@@ -146,7 +146,7 @@ sub authaliasonly_off_anon_bug2070 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -168,9 +168,9 @@ sub authaliasonly_off_anon_bug2070 {
   my $alias = 'ftptest';
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $alias, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, "$user,$alias");
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthOrder.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthOrder.pm
@@ -78,7 +78,7 @@ sub authorder_unix_only {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -199,7 +199,7 @@ sub authorder_unix_authoritative {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -321,7 +321,7 @@ sub authorder_file_authoritative {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -427,7 +427,7 @@ sub authorder_pam_authoritative {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/AuthUsingAlias.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/AuthUsingAlias.pm
@@ -47,7 +47,7 @@ sub authusingalias_on {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -69,9 +69,9 @@ sub authusingalias_on {
   my $alias = 'ftp';
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $alias, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, "$user,$alias");
 
   my $config = {
@@ -174,7 +174,7 @@ sub authusingalias_off {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -196,7 +196,7 @@ sub authusingalias_off {
   my $alias = 'ftp';
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, "$user,$alias");
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/CreateHome.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/CreateHome.pm
@@ -78,7 +78,7 @@ sub createhome_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -86,7 +86,7 @@ sub createhome_ok {
   my $gid = 500;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {
@@ -183,7 +183,7 @@ sub createhome_dirmode_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -191,7 +191,7 @@ sub createhome_dirmode_ok {
   my $gid = 500;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {
@@ -301,7 +301,7 @@ sub createhome_explicit_parent_owner_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -311,7 +311,7 @@ sub createhome_explicit_parent_owner_ok {
   my $explicit_guid = 250;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {
@@ -408,7 +408,7 @@ sub createhome_user_parent_owner_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -416,7 +416,7 @@ sub createhome_user_parent_owner_ok {
   my $gid = 500;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {
@@ -515,7 +515,7 @@ sub createhome_skel_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -553,7 +553,7 @@ sub createhome_skel_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {
@@ -650,7 +650,7 @@ sub createhome_homegid_bug3503 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs("$tmpdir/foo/bar");
@@ -658,7 +658,7 @@ sub createhome_homegid_bug3503 {
   my $gid = 500;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $home_gid = 777;
@@ -758,7 +758,7 @@ sub createhome_dirmode_uid_gid_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -769,7 +769,7 @@ sub createhome_dirmode_uid_gid_ok {
   my $explicit_guid = 250;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   # Trying to debug:
@@ -885,7 +885,7 @@ sub createhome_dirmode_uid_gid_norootprivs_bug3813 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -896,7 +896,7 @@ sub createhome_dirmode_uid_gid_norootprivs_bug3813 {
   my $explicit_guid = 250;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeGroup.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeGroup.pm
@@ -57,7 +57,7 @@ sub dirfakegroup_list {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -78,7 +78,7 @@ sub dirfakegroup_list {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $fake_group = 'foo';
@@ -228,7 +228,7 @@ sub dirfakegroup_mlsd_bug3604 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -252,7 +252,7 @@ sub dirfakegroup_mlsd_bug3604 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
   auth_group_write($auth_group_file, $fake_group, $fake_gid);
 
@@ -496,7 +496,7 @@ sub dirfakegroup_mlsd_bug3715 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -525,7 +525,7 @@ sub dirfakegroup_mlsd_bug3715 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeMode.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeMode.pm
@@ -52,7 +52,7 @@ sub dirfakemode_list {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -73,7 +73,7 @@ sub dirfakemode_list {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -229,7 +229,7 @@ sub dirfakemode_mlsd_bug3604 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -250,7 +250,7 @@ sub dirfakemode_mlsd_bug3604 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $fake_mode = '0311';

--- a/tests/t/lib/ProFTPD/Tests/Config/DirFakeUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DirFakeUser.pm
@@ -67,7 +67,7 @@ sub dirfakeuser_list {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -88,7 +88,7 @@ sub dirfakeuser_list {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $fake_user = 'foo';
@@ -242,7 +242,7 @@ sub dirfakeuser_mlsd_bug3604 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -266,7 +266,7 @@ sub dirfakeuser_mlsd_bug3604 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $fake_user, 'test', $fake_uid, $gid,
     $home_dir, '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -515,7 +515,7 @@ sub dirfakeuser_mlsd_bug3715 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -538,7 +538,7 @@ sub dirfakeuser_mlsd_bug3715 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory.pm
@@ -149,7 +149,7 @@ sub dir_wide_layout {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Directory/Limits.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory/Limits.pm
@@ -142,7 +142,7 @@ sub limits_with_glob_then_nonglob_dirs_for_same_path {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -302,7 +302,7 @@ sub limits_with_nonglob_then_glob_dirs_for_same_path {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -462,7 +462,7 @@ sub limits_with_glob_denied_delete_bug3146 {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -474,7 +474,7 @@ sub limits_with_glob_denied_delete_bug3146 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -630,7 +630,7 @@ sub limits_without_glob_denied_delete_bug3146 {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -642,7 +642,7 @@ sub limits_without_glob_denied_delete_bug3146 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -800,7 +800,7 @@ sub limits_commands_comma_space_delimited_deferred_paths_bug3147 {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -965,7 +965,7 @@ sub limits_commands_comma_delimited_deferred_paths_bug3147 {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1130,7 +1130,7 @@ sub limits_commands_no_commas_deferred_paths_bug3147 {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1291,7 +1291,7 @@ sub limits_rename_dir_ok_write_denied {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1450,7 +1450,7 @@ sub limits_rename_dir_failed_rnfr_denied {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1607,7 +1607,7 @@ sub limits_one_char_dir_bug3337 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1808,7 +1808,7 @@ sub limits_symlink_dir_bug3166 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -1984,7 +1984,7 @@ sub limits_anon_dir_abs_path_bug3283 {
       die("Can't set owner of $anon_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -2145,7 +2145,7 @@ sub limits_with_multi_globs_denied_delete {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -2157,7 +2157,7 @@ sub limits_with_multi_globs_denied_delete {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -2304,7 +2304,7 @@ sub limits_retr_bug3915 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -2460,7 +2460,7 @@ sub limits_retr_bug3915_chrooted {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -2634,7 +2634,7 @@ sub limits_stor_with_multiple_groups_chrooted {
     }
 
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Directory/Lookups.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory/Lookups.pm
@@ -164,7 +164,7 @@ sub dir_lookup_wide_layout_abs_paths {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -358,7 +358,7 @@ sub dir_lookup_deep_layout_abs_paths {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -551,7 +551,7 @@ sub dir_lookup_wide_layout_rel_paths {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -745,7 +745,7 @@ sub dir_lookup_deep_layout_rel_paths {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -940,7 +940,7 @@ sub dir_lookup_many_files_hidefiles_bug3526 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Directory/Umask.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Directory/Umask.pm
@@ -76,7 +76,7 @@ sub umask_root_dir_bug2677 {
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/foo/testdir");
   my $test_file = File::Spec->rel2abs("$tmpdir/foo/test.txt");
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -88,7 +88,7 @@ sub umask_root_dir_bug2677 {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -255,7 +255,7 @@ sub umask_server_config_bug2677 {
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/foo/testdir");
   my $test_file = File::Spec->rel2abs("$tmpdir/foo/test.txt");
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -267,7 +267,7 @@ sub umask_server_config_bug2677 {
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -433,7 +433,7 @@ sub umask_glob_subdirs {
   mkpath($sub_dir1);
   my $test_dir1 = File::Spec->rel2abs("$tmpdir/subdir/foo/testdir");
   my $test_file1 = File::Spec->rel2abs("$tmpdir/subdir/foo/test.txt");
- 
+
   my $sub_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/foo");
   mkpath($sub_dir2);
   my $test_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/foo/testdir");
@@ -450,7 +450,7 @@ sub umask_glob_subdirs {
       die("Can't set owner of $home_dir, $sub_dir1, $sub_dir2 to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -641,7 +641,7 @@ sub umask_glob_dir_bug3491 {
   my $sub_dir1 = File::Spec->rel2abs("$tmpdir/subdir");
   mkpath($sub_dir1);
   my $test_dir1 = File::Spec->rel2abs("$tmpdir/subdir/foo");
- 
+
   my $sub_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/deeperdir");
   mkpath($sub_dir2);
   my $test_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/deeperdir/foo");
@@ -659,7 +659,7 @@ sub umask_glob_dir_bug3491 {
       die("Can't set owner of $home_dir, $sub_dir1, $sub_dir2 to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -821,7 +821,7 @@ sub umask_no_glob_dir_bug3491 {
   my $sub_dir1 = File::Spec->rel2abs("$tmpdir/subdir");
   mkpath($sub_dir1);
   my $test_dir1 = File::Spec->rel2abs("$tmpdir/subdir/foo");
- 
+
   my $sub_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/deeperdir");
   mkpath($sub_dir2);
   my $test_dir2 = File::Spec->rel2abs("$tmpdir/otherdir/deeperdir/foo");
@@ -839,7 +839,7 @@ sub umask_no_glob_dir_bug3491 {
       die("Can't set owner of $home_dir, $sub_dir1, $sub_dir2 to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayChdir.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayChdir.pm
@@ -443,7 +443,7 @@ sub displaychdir_first_chdir {
       $client->cwd('..');
 
       $client->cwd('subdir');
- 
+
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg(0);
 

--- a/tests/t/lib/ProFTPD/Tests/Config/DisplayConnect.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/DisplayConnect.pm
@@ -299,7 +299,7 @@ sub displayconnect_client_count {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -435,7 +435,7 @@ sub displayconnect_class_client_count {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/DELE.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/DELE.pm
@@ -46,7 +46,7 @@ sub dele_bug2321 {
 
   # As per Bug#2321, the reproduction layout looks like:
   #
-  #  $root/web/ 
+  #  $root/web/
   #  $root/web/.ftpaccess
   #  $root/users/$user/
   #  $root/users/$user/web -> $root/web/
@@ -106,7 +106,7 @@ EOL
       die("Can't set owner of $home_dir, $web_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/Empty.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/Empty.pm
@@ -99,7 +99,7 @@ sub empty_bug3240 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -257,7 +257,7 @@ sub empty_bug3279 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -292,11 +292,11 @@ sub empty_bug3279 {
 EOD
     unless (close($fh)) {
       die("Can't write $config_file: $!");
-    } 
-      
+    }
+
   } else {
     die("Can't open $config_file: $!");
-  }   
+  }
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -476,7 +476,7 @@ EOC
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/Merging.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/Merging.pm
@@ -99,7 +99,7 @@ EOC
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -134,11 +134,11 @@ EOC
 EOD
     unless (close($fh)) {
       die("Can't write $config_file: $!");
-    } 
-      
+    }
+
   } else {
     die("Can't open $config_file: $!");
-  }   
+  }
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -309,7 +309,7 @@ EOC
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -344,11 +344,11 @@ EOC
 EOD
     unless (close($fh)) {
       die("Can't write $config_file: $!");
-    } 
-      
+    }
+
   } else {
     die("Can't open $config_file: $!");
-  }   
+  }
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -487,7 +487,7 @@ EOC
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -522,11 +522,11 @@ EOC
 EOD
     unless (close($fh)) {
       die("Can't write $config_file: $!");
-    } 
-      
+    }
+
   } else {
     die("Can't open $config_file: $!");
-  }   
+  }
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message

--- a/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/RETR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/RETR.pm
@@ -65,7 +65,7 @@ sub ftpaccess_retr_bug2038 {
 
   my $fh;
 
-  # Write a .ftpaccess file in the sub dir which denies all access 
+  # Write a .ftpaccess file in the sub dir which denies all access
   my $ftpaccess_file = File::Spec->rel2abs("$tmpdir/foo/.ftpaccess");
   if (open($fh, "> $ftpaccess_file")) {
     print $fh <<EOF;
@@ -106,7 +106,7 @@ EOF
       die("Can't set owner of $home_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -283,7 +283,7 @@ sub ftpaccess_anon_retr_bug2038 {
 
   my $fh;
 
-  # Write a .ftpaccess file in the sub dir which denies all access 
+  # Write a .ftpaccess file in the sub dir which denies all access
   my $ftpaccess_file = File::Spec->rel2abs("$tmpdir/foo/.ftpaccess");
   if (open($fh, "> $ftpaccess_file")) {
     print $fh <<EOF;
@@ -498,7 +498,7 @@ sub ftpaccess_anon_retr_bug2461 {
 
   my $fh;
 
-  # Write a .ftpaccess file in the sub dir which denies all access 
+  # Write a .ftpaccess file in the sub dir which denies all access
   my $ftpaccess_file = File::Spec->rel2abs("$tmpdir/.ftpaccess");
   if (open($fh, "> $ftpaccess_file")) {
     print $fh <<EOF;

--- a/tests/t/lib/ProFTPD/Tests/Config/FactsOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FactsOptions.pm
@@ -183,7 +183,7 @@ sub factsoptions_use_slink_mlsd_rel_symlinked_file {
       # Since ShowSymlinks is on, the type for test.lnk should indicate that
       # it's a symlink.  And since the UseSlink FactOption is used, the
       # type should include the target path.
-      $expected = 'OS.unix=slink:(.*)?'; 
+      $expected = 'OS.unix=slink:(.*)?';
       $got = $res->{'test.lnk'}->{type};
       $self->assert(qr/$expected/i, $got,
         test_msg("Expected '$expected', got '$got'"));
@@ -328,7 +328,7 @@ sub factsoptions_use_slink_mlsd_rel_symlinked_dir {
       # Since ShowSymlinks is on, the type for test.lnk should indicate that
       # it's a symlink.  And since the UseSlink FactOption is used, the
       # type should include the target path.
-      $expected = 'OS.unix=slink:(.*)?'; 
+      $expected = 'OS.unix=slink:(.*)?';
       $got = $res->{'test.lnk'}->{type};
       $self->assert(qr/$expected/i, $got,
         test_msg("Expected '$expected', got '$got'"));

--- a/tests/t/lib/ProFTPD/Tests/Config/GroupOwner.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/GroupOwner.pm
@@ -52,7 +52,7 @@ sub groupowner_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -75,7 +75,7 @@ sub groupowner_ok {
   my $owner_gid = 1000;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
   auth_group_write($auth_group_file, $owner, $owner_gid, 'foo');
 
@@ -198,7 +198,7 @@ sub groupowner_failed_norootprivs {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $owner = 'proftpd2';
   my $owner_gid = 1000;
 
@@ -234,7 +234,7 @@ sub groupowner_failed_norootprivs {
   my ($uid, $gid) = (getpwnam($config_user))[2,3];
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
   auth_group_write($auth_group_file, $owner, $owner_gid, 'foo');
 
@@ -349,7 +349,7 @@ sub groupowner_ok_suppl_group_norootprivs {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $owner = 'proftpd2';
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -386,7 +386,7 @@ sub groupowner_ok_suppl_group_norootprivs {
   my $home_dir = File::Spec->rel2abs($tmpdir);
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
   auth_group_write($auth_group_file, $owner, $owner_gid, $user);
 

--- a/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HiddenStores.pm
@@ -805,8 +805,8 @@ sub find_hiddenstore_files {
     die("Can't open directory '$path': $!");
   }
 
-  my $files  = [grep { /^$prefix/ && -f "$path/$_" } readdir($dirh)]; 
-  closedir($dirh); 
+  my $files  = [grep { /^$prefix/ && -f "$path/$_" } readdir($dirh)];
+  closedir($dirh);
 
   return $files;
 }

--- a/tests/t/lib/ProFTPD/Tests/Config/HideFiles.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideFiles.pm
@@ -165,7 +165,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   my $test_files = [qw(1.txt 2.txt 3.txt 4.txt foo.txt)];
 
   foreach my $test_file (@$test_files) {
@@ -477,7 +477,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   my $test_files = [qw(1.txt 2.txt 3.txt 4.txt foo.txt)];
 
   foreach my $test_file (@$test_files) {
@@ -663,7 +663,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   my $test_files = [qw(1.txt 2.txt 3.txt 4.txt foo.txt)];
 
   foreach my $test_file (@$test_files) {
@@ -838,7 +838,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   my $test_files = [qw(1.txt 2.txt 3.txt 4.txt foo.txt)];
 
   foreach my $test_file (@$test_files) {
@@ -3127,7 +3127,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -3261,7 +3261,7 @@ EOF
   } else {
     die("Can't open $ftpaccess_file: $!");
   }
-  
+
   my $test_files = [qw(1.txt 2.txt 3.txt 4.txt foo.txt)];
 
   foreach my $test_file (@$test_files) {
@@ -3621,7 +3621,7 @@ sub hidefiles_stat {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -3910,7 +3910,7 @@ sub hidefiles_list_symlink_bug3924 {
     AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
-    Directory => { 
+    Directory => {
       '/' => {
         HideFiles => 'foobar',
       },
@@ -4091,7 +4091,7 @@ sub hidefiles_mlsd_symlink_bug3924 {
     AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
-    Directory => { 
+    Directory => {
       '/' => {
         HideFiles => 'foobar',
       },

--- a/tests/t/lib/ProFTPD/Tests/Config/HideGroup.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideGroup.pm
@@ -99,7 +99,7 @@ sub hidegroup_explicit_group_list {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -277,7 +277,7 @@ sub hidegroup_explicit_group_nlst {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -455,7 +455,7 @@ sub hidegroup_explicit_group_mlsd {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -631,7 +631,7 @@ sub hidegroup_session_group {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -819,7 +819,7 @@ sub hidegroup_not_session_group {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -999,7 +999,7 @@ sub hidegroup_hidenoaccess_on_bug3530 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
   auth_group_write($auth_group_file, 'daemon', 1);
 
@@ -1193,7 +1193,7 @@ sub hidegroup_hideuser_bug3530 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, 'daemon', 'x', 1, 1, '/', '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
   auth_group_write($auth_group_file, 'daemon', 1);
@@ -1385,7 +1385,7 @@ sub hidegroup_virtual_group_bug3934 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");

--- a/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideNoAccess.pm
@@ -69,7 +69,7 @@ sub hidenoaccess_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/testdir");
@@ -243,7 +243,7 @@ sub hidenoaccess_with_directory_glob {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   for (my $i = 1; $i < 6; $i++) {

--- a/tests/t/lib/ProFTPD/Tests/Config/HideUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/HideUser.pm
@@ -78,7 +78,7 @@ sub hideuser_explicit_user {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -263,7 +263,7 @@ sub hideuser_session_user {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -452,7 +452,7 @@ sub hideuser_not_session_user {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -637,7 +637,7 @@ sub hideuser_virtual_user_bug3934 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/Anonymous.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/Anonymous.pm
@@ -86,7 +86,7 @@ sub anon_limit_write {
       die("Can't set owner of $anon_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
@@ -247,7 +247,7 @@ sub anon_limit_write_changing_dirs {
       die("Can't set owner of $anon_dir, $sub_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
@@ -439,7 +439,7 @@ EOC
   } else {
     die("Can't open $anon_dir/.ftpaccess: $!");
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
@@ -635,7 +635,7 @@ sub anon_limit_login_dns_name {
       die("Can't set owner of $anon_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
@@ -780,7 +780,7 @@ sub anon_limit_write_allow_stor_using_abs_path {
       die("Can't set owner of $anon_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
@@ -947,7 +947,7 @@ sub anon_limit_write_allow_stor_using_rel_path {
       die("Can't set owner of $anon_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $config_user, 'test', $uid, $gid, '/tmp',
     '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/Filters.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/Filters.pm
@@ -66,7 +66,7 @@ sub filter_dele_allow_bug2067 {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -78,7 +78,7 @@ sub filter_dele_allow_bug2067 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -195,7 +195,7 @@ sub filter_dele_deny_bug2067 {
   } else {
     die("Can't open $test_file: $!");
   }
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -207,7 +207,7 @@ sub filter_dele_deny_bug2067 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -334,7 +334,7 @@ sub filter_stor_allow_bug2067 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/LOGIN.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/LOGIN.pm
@@ -71,7 +71,7 @@ sub login_limit_ip_glob_range_bug3484 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -203,7 +203,7 @@ sub login_limit_allowgroup_backslash {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
@@ -323,7 +323,7 @@ sub login_limit_multiple_sections {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/MFMT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/MFMT.pm
@@ -64,7 +64,7 @@ sub mfmt_limit_bug3399 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/OPTS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/OPTS.pm
@@ -65,7 +65,7 @@ sub opts_limit_utf8_bug3438 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -196,7 +196,7 @@ sub opts_limit_all_bug3438 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/RMD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/RMD.pm
@@ -64,7 +64,7 @@ sub rmd_unremovable_subdir {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -74,7 +74,7 @@ sub rmd_unremovable_subdir {
     $home_dir = '/private' . $home_dir;
     $sub_dir = '/private' . $sub_dir;
   }
- 
+
   my $config = {
     PidFile => $pid_file,
     ScoreboardFile => $scoreboard_file,

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/SubDirectories.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/SubDirectories.pm
@@ -60,7 +60,7 @@ sub subdirs_mkd_denied_pwd_allowed_bug3077 {
   my $gid = 500;
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -72,7 +72,7 @@ sub subdirs_mkd_denied_pwd_allowed_bug3077 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -218,7 +218,7 @@ sub subdirs_mkd_denied_limit_xmkd_bug3077 {
   my $gid = 500;
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -230,7 +230,7 @@ sub subdirs_mkd_denied_limit_xmkd_bug3077 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
@@ -367,7 +367,7 @@ sub subdirs_xmkd_allowed_limit_mkd_bug3077 {
   my $gid = 500;
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -379,7 +379,7 @@ sub subdirs_xmkd_allowed_limit_mkd_bug3077 {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/Limit/XMKD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Limit/XMKD.pm
@@ -96,8 +96,8 @@ sub mkd_allowed {
   my $gid = 500;
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
- 
   # Make sure that, if we're running as root, that the home directory has
+
   # permissions/privs set for the account we create
   if ($< == 0) {
     unless (chmod(0755, $home_dir)) {
@@ -108,7 +108,7 @@ sub mkd_allowed {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
   }
- 
+
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
     '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);

--- a/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ListOptions.pm
@@ -88,7 +88,7 @@ sub listoptions_opt_t {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -109,7 +109,7 @@ sub listoptions_opt_t {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   # Create three files, and use utime() to modify the last-mod time of
@@ -556,7 +556,7 @@ sub listoptions_opt_1_nlst_simple_glob {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -577,7 +577,7 @@ sub listoptions_opt_1_nlst_simple_glob {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_files = [qw(
@@ -731,7 +731,7 @@ sub listoptions_opt_1_nlst_complex_glob {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -752,7 +752,7 @@ sub listoptions_opt_1_nlst_complex_glob {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_files = [qw(
@@ -907,7 +907,7 @@ sub listoptions_listonly {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -928,7 +928,7 @@ sub listoptions_listonly {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_files = [qw(
@@ -1123,7 +1123,7 @@ sub listoptions_nlstonly {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -1144,7 +1144,7 @@ sub listoptions_nlstonly {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_files = [qw(
@@ -1490,7 +1490,7 @@ sub listoptions_maxfiles {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -1511,7 +1511,7 @@ sub listoptions_maxfiles {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   # For this test, we need to create MANY (i.e. 110K) files in the
@@ -1537,7 +1537,7 @@ sub listoptions_maxfiles {
       print STDOUT "# Created file $test_file\n";
     }
   }
- 
+
   $max_files = 100000;
   my $timeout = 900;
 

--- a/tests/t/lib/ProFTPD/Tests/Config/MasqueradeAddress.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MasqueradeAddress.pm
@@ -134,7 +134,7 @@ sub masqaddr_pasv {
       my $resp_addr = $1;
 
       $expected = $masq_addr;
-      $expected =~ s/\./,/g; 
+      $expected =~ s/\./,/g;
 
       $self->assert($expected eq $resp_addr,
         test_msg("Expected PASV address '$expected', got '$resp_addr'"));

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClients.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClients.pm
@@ -292,7 +292,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerClass.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerClass.pm
@@ -68,7 +68,7 @@ sub maxclientsperclass_one {
     SystemLog => $log_file,
 
     AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file, 
+    AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerClass => "$class_name $max_clients",

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerHost.pm
@@ -72,7 +72,7 @@ sub maxclientsperhost_one {
     SystemLog => $log_file,
 
     AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file, 
+    AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerHost => $max_clients_per_host,

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxClientsPerUser.pm
@@ -67,7 +67,7 @@ sub maxclientsperuser_one {
     SystemLog => $log_file,
 
     AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file, 
+    AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
     MaxClientsPerUser => $max_clients,

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxConnectionsPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxConnectionsPerHost.pm
@@ -62,7 +62,7 @@ sub maxconnsperhost_one_multi_conns {
     SystemLog => $log_file,
 
     AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file, 
+    AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
 
     MaxConnectionsPerHost => $max_conns_per_host,

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxRetrieveFileSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxRetrieveFileSize.pm
@@ -60,7 +60,7 @@ sub maxretrievefilesize_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -193,7 +193,7 @@ sub maxretrievefilesize_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxStoreFileSize.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxStoreFileSize.pm
@@ -65,7 +65,7 @@ sub maxstorefilesize_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -188,7 +188,7 @@ sub maxstorefilesize_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -320,7 +320,7 @@ sub maxstorefilesize_appe_bug3649 {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -336,7 +336,7 @@ sub maxstorefilesize_appe_bug3649 {
     unless (close($fh)) {
       die("Can't write $dst_file: $!");
     }
- 
+
   } else {
     die("Can't open $dst_file: $!");
   }

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerHost.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerHost.pm
@@ -49,7 +49,7 @@ sub maxtransfersperhost_retr {
     SystemLog => $setup->{log_file},
 
     AuthUserFile => $setup->{auth_user_file},
-    AuthGroupFile => $setup->{auth_group_file}, 
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     MaxTransfersPerHost => "RETR $max_transfers",
@@ -150,7 +150,7 @@ sub maxtransfersperhost_retr_custom_message {
     SystemLog => $setup->{log_file},
 
     AuthUserFile => $setup->{auth_user_file},
-    AuthGroupFile => $setup->{auth_group_file}, 
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     MaxTransfersPerHost => "RETR $max_transfers \"Too many transfers from your host\"",

--- a/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerUser.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/MaxTransfersPerUser.pm
@@ -49,7 +49,7 @@ sub maxtransfersperuser_retr {
     SystemLog => $setup->{log_file},
 
     AuthUserFile => $setup->{auth_user_file},
-    AuthGroupFile => $setup->{auth_group_file}, 
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     MaxTransfersPerUser => "RETR $max_transfers",
@@ -150,7 +150,7 @@ sub maxtransfersperuser_retr_custom_message {
     SystemLog => $setup->{log_file},
 
     AuthUserFile => $setup->{auth_user_file},
-    AuthGroupFile => $setup->{auth_group_file}, 
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     MaxTransfersPerUser => "RETR $max_transfers \"Too many transfers from your user\"",

--- a/tests/t/lib/ProFTPD/Tests/Config/PassivePorts.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/PassivePorts.pm
@@ -56,7 +56,7 @@ sub pasv_ports_server_config {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -77,7 +77,7 @@ sub pasv_ports_server_config {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -201,7 +201,7 @@ sub pasv_ports_global {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -222,7 +222,7 @@ sub pasv_ports_global {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");

--- a/tests/t/lib/ProFTPD/Tests/Config/RLimitChroot.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RLimitChroot.pm
@@ -134,7 +134,7 @@ sub rlimitchroot_on {
       $expected = 550;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
- 
+
       $expected = '/etc: Permission denied';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
@@ -146,7 +146,7 @@ sub rlimitchroot_on {
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
- 
+
       $expected = 550;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -166,7 +166,7 @@ sub rlimitchroot_on {
       $expected = 550;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
- 
+
       $expected = '/lib: Permission denied';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
@@ -178,7 +178,7 @@ sub rlimitchroot_on {
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
- 
+
       $expected = 550;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -395,7 +395,7 @@ sub rlimitchroot_off {
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
- 
+
       $expected = 'RMD command successful';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
@@ -547,7 +547,7 @@ EOC
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
- 
+
       $expected = 'RMD command successful';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));

--- a/tests/t/lib/ProFTPD/Tests/Config/RequireValidShell.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RequireValidShell.pm
@@ -66,7 +66,7 @@ sub get_shell {
   }
 
   if ($use_valid_shell) {
-    return (keys(%$shells))[0]; 
+    return (keys(%$shells))[0];
 
   } else {
     my $invalid_shells = [qw(/bin/foo /bin/false /bin/notavalidshell /bin/foobarbazquxxquzz)];
@@ -106,7 +106,7 @@ sub requirevalidshell_off_valid_shell {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -212,7 +212,7 @@ sub requirevalidshell_off_invalid_shell {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -318,7 +318,7 @@ sub requirevalidshell_on_valid_shell {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -424,7 +424,7 @@ sub requirevalidshell_on_invalid_shell {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/RewriteHome.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RewriteHome.pm
@@ -127,7 +127,7 @@ sub rewritehome_ok {
       $expected = 257;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
-  
+
       $expected = "\"$home_dir\" is the current directory";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));
@@ -367,7 +367,7 @@ sub rewritehome_chroot_bug3348 {
       $expected = 257;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
-  
+
       $expected = "\"/\" is the current directory";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected '$expected', got '$resp_msg'"));

--- a/tests/t/lib/ProFTPD/Tests/Config/RootRevoke.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/RootRevoke.pm
@@ -254,7 +254,7 @@ sub rootrevoke_on_active_transfer_nonpriv_port {
       my $buf;
       $conn->read($buf, 8192, 25);
       eval { $conn->close() };
-      
+
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
 

--- a/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
@@ -1865,7 +1865,7 @@ sub showsymlinks_on_mlsd_rel_symlinked_file {
 
       # Since ShowSymlinks is on, the type for test.lnk should indicate that
       # it's a symlink
-      $expected = 'OS.unix=symlink'; 
+      $expected = 'OS.unix=symlink';
       $got = $res->{'test.lnk'}->{type};
       $self->assert(qr/$expected/i, $got,
         test_msg("Expected '$expected', got '$got'"));
@@ -2148,7 +2148,7 @@ sub showsymlinks_on_mlsd_rel_symlinked_dir {
 
       # Since ShowSymlinks is on, the type for test.lnk should indicate that
       # it's a symlink
-      $expected = 'OS.unix=symlink'; 
+      $expected = 'OS.unix=symlink';
       $got = $res->{'test.lnk'}->{type};
       $self->assert(qr/$expected/i, $got,
         test_msg("Expected '$expected', got '$got'"));

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutIdle.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutIdle.pm
@@ -61,7 +61,7 @@ sub timeoutidle_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -198,7 +198,7 @@ sub timeoutidle_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutLogin.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutLogin.pm
@@ -60,7 +60,7 @@ sub timeoutlogin_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -170,7 +170,7 @@ sub timeoutlogin_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutNoTransfer.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutNoTransfer.pm
@@ -60,7 +60,7 @@ sub timeoutnoxfer_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -179,7 +179,7 @@ sub timeoutnoxfer_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutSession.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutSession.pm
@@ -60,7 +60,7 @@ sub timeoutsession_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -183,7 +183,7 @@ sub timeoutsession_exceeded {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/TimeoutStalled.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TimeoutStalled.pm
@@ -86,7 +86,7 @@ sub timeoutstalled_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -219,7 +219,7 @@ sub timeoutstalled_exceeded_list {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -355,7 +355,7 @@ sub timeoutstalled_exceeded_nlst {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -491,7 +491,7 @@ sub timeoutstalled_exceeded_mlsd {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -627,7 +627,7 @@ sub timeoutstalled_exceeded_retr {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -763,7 +763,7 @@ sub timeoutstalled_exceeded_stor {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -899,7 +899,7 @@ sub timeoutstalled_exceeded_retr_usesendfile_on {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/TransferRate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/TransferRate.pm
@@ -63,7 +63,7 @@ sub transferrate_retr_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -228,7 +228,7 @@ sub transferrate_stor_ok {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/Umask.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/Umask.pm
@@ -56,7 +56,7 @@ sub umask_new_dir_mode {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -77,7 +77,7 @@ sub umask_new_dir_mode {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
@@ -189,7 +189,7 @@ sub umask_new_dir_mode_subdir {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -210,7 +210,7 @@ sub umask_new_dir_mode_subdir {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d");
@@ -268,7 +268,7 @@ sub umask_new_dir_mode_subdir {
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->cwd('sub.d');
-    
+
       my $expected;
 
       $expected = 250;
@@ -341,7 +341,7 @@ sub umask_new_dir_mode_subdir_userowner_groupowner {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -372,9 +372,9 @@ sub umask_new_dir_mode_subdir_userowner_groupowner {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $file_owner, $passwd, $file_owner_uid,
-    $file_owner_gid, $home_dir, '/bin/bash'); 
+    $file_owner_gid, $home_dir, '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
   auth_group_write($auth_group_file, $file_group, $file_owner_gid, $file_owner);
 
@@ -425,7 +425,7 @@ sub umask_new_dir_mode_subdir_userowner_groupowner {
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->cwd('sub.d');
-    
+
       my $expected;
 
       $expected = 250;

--- a/tests/t/lib/ProFTPD/Tests/Config/UseFtpUsers.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseFtpUsers.pm
@@ -86,7 +86,7 @@ sub get_user {
     return "unknown";
 
   } else {
-    return (keys(%$users))[0]; 
+    return (keys(%$users))[0];
   }
 }
 
@@ -114,7 +114,7 @@ sub useftpusers_off_unlisted_user {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -219,7 +219,7 @@ sub useftpusers_off_listed_user {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -324,7 +324,7 @@ sub useftpusers_on_unlisted_user {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }
@@ -429,7 +429,7 @@ sub useftpusers_on_listed_user {
     unless (chmod(0755, $home_dir)) {
       die("Can't set perms on $home_dir to 0755: $!");
     }
-    
+
     unless (chown($uid, $gid, $home_dir)) {
       die("Can't set owner of $home_dir to $uid/$gid: $!");
     }

--- a/tests/t/lib/ProFTPD/Tests/Config/UseGlobbing.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseGlobbing.pm
@@ -42,7 +42,7 @@ sub useglobbing_off {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -62,7 +62,7 @@ sub useglobbing_off {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/UseSendfile.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UseSendfile.pm
@@ -104,7 +104,7 @@ sub usesendfile_on_ascii {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -124,7 +124,7 @@ sub usesendfile_on_ascii {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $test_file = File::Spec->rel2abs($config_file);
@@ -253,7 +253,7 @@ sub usesendfile_off_ascii {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -273,7 +273,7 @@ sub usesendfile_off_ascii {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $test_file = File::Spec->rel2abs($config_file);
@@ -402,7 +402,7 @@ sub usesendfile_on_binary {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -422,7 +422,7 @@ sub usesendfile_on_binary {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $test_file = File::Spec->rel2abs($config_file);
@@ -552,7 +552,7 @@ sub usesendfile_off_binary {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -572,7 +572,7 @@ sub usesendfile_off_binary {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $test_file = File::Spec->rel2abs($config_file);
@@ -702,7 +702,7 @@ sub usesendfile_on_binary_dir_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -722,7 +722,7 @@ sub usesendfile_on_binary_dir_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -906,7 +906,7 @@ sub usesendfile_off_binary_dir_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -926,7 +926,7 @@ sub usesendfile_off_binary_dir_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -1110,7 +1110,7 @@ sub usesendfile_on_binary_ftpaccess_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -1130,7 +1130,7 @@ sub usesendfile_on_binary_ftpaccess_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -1324,7 +1324,7 @@ sub usesendfile_off_binary_ftpaccess_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -1344,7 +1344,7 @@ sub usesendfile_off_binary_ftpaccess_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -1537,7 +1537,7 @@ sub usesendfile_len_binary_dir_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -1557,7 +1557,7 @@ sub usesendfile_len_binary_dir_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -1751,7 +1751,7 @@ sub usesendfile_len_binary_ftpaccess_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -1771,7 +1771,7 @@ sub usesendfile_len_binary_ftpaccess_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -1974,7 +1974,7 @@ sub usesendfile_len_ascii_ftpaccess_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -1994,7 +1994,7 @@ sub usesendfile_len_ascii_ftpaccess_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -2187,7 +2187,7 @@ sub usesendfile_pct_binary_dir_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -2207,7 +2207,7 @@ sub usesendfile_pct_binary_dir_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
@@ -2401,7 +2401,7 @@ sub usesendfile_pct_binary_ftpaccess_bug3310 {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -2421,7 +2421,7 @@ sub usesendfile_pct_binary_ftpaccess_bug3310 {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");

--- a/tests/t/lib/ProFTPD/Tests/Config/UserAlias.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserAlias.pm
@@ -52,7 +52,7 @@ sub useralias_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -75,7 +75,7 @@ sub useralias_ok {
   my $alias = 'ftp';
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {
@@ -162,7 +162,7 @@ sub useralias_anon_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -171,7 +171,7 @@ sub useralias_anon_ok {
   my $gid = 500;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $alias = 'anonymous';
@@ -266,7 +266,7 @@ sub useralias_with_at_symbol_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -289,7 +289,7 @@ sub useralias_with_at_symbol_ok {
   my $alias = 'ftp@ftp.proftpd.org';
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $config = {

--- a/tests/t/lib/ProFTPD/Tests/Config/UserOwner.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserOwner.pm
@@ -57,7 +57,7 @@ sub userowner_file {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -81,9 +81,9 @@ sub userowner_file {
   my $owner_uid = 1000;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $owner, "none", $owner_uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
@@ -201,7 +201,7 @@ sub userowner_dir {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $group = 'ftpd';
@@ -225,9 +225,9 @@ sub userowner_dir {
   my $owner_uid = 1000;
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $owner, "none", $owner_uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/test.d");
@@ -344,7 +344,7 @@ sub userowner_failed_norootprivs {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $owner = 'proftpd2';
   my $owner_uid = 1000;
 
@@ -381,9 +381,9 @@ sub userowner_failed_norootprivs {
   my ($uid, $gid) = (getpwnam($config_user))[2,3];
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_user_write($auth_user_file, $owner, "none", $owner_uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $group, $gid, $user);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
@@ -490,7 +490,7 @@ sub userowner_anon_mkd {
   }
 
   auth_user_write($auth_user_file, $config_user, 'foo', $uid, $gid, '/tmp',
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
 
   my $test_dir = File::Spec->rel2abs("$anon_dir/test.d");

--- a/tests/t/lib/ProFTPD/Tests/Config/UserPassword.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserPassword.pm
@@ -47,7 +47,7 @@ sub userpassword_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
-  
+
   my $user = 'proftpd';
   my $passwd = 'test';
   my $home_dir = File::Spec->rel2abs($tmpdir);
@@ -67,7 +67,7 @@ sub userpassword_ok {
   }
 
   auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, 'ftpd', $gid, $user);
 
   my $user_pass_cleartext = 'R@lly';
@@ -154,7 +154,7 @@ sub userpassword_anon_ok {
 
   my $auth_user_file = File::Spec->rel2abs("$tmpdir/config.passwd");
   my $auth_group_file = File::Spec->rel2abs("$tmpdir/config.group");
- 
+
   my ($config_user, $config_group) = config_get_identity();
 
   my $anon_dir = File::Spec->rel2abs($tmpdir);
@@ -175,7 +175,7 @@ sub userpassword_anon_ok {
   }
 
   auth_user_write($auth_user_file, $config_user, 'foo', $uid, $gid, '/tmp',
-    '/bin/bash'); 
+    '/bin/bash');
   auth_group_write($auth_group_file, $config_group, $gid, $config_user);
 
   my $user_pass_cleartext = 'test';

--- a/tests/t/lib/ProFTPD/Tests/Contrib/ftpasswd.pm
+++ b/tests/t/lib/ProFTPD/Tests/Contrib/ftpasswd.pm
@@ -125,7 +125,7 @@ $ ls -l /home/astocker/proftpd.passwd
     print STDERR "Executing ftpasswd: $cmd\n";
   }
 
-  eval { 
+  eval {
     if (open(my $cmdh, "| $cmd")) {
       print $cmdh "$passwd1\n";
       unless (close($cmdh)) {
@@ -157,8 +157,8 @@ $ ls -l /home/astocker/proftpd.passwd
   my $gid2 = 501;
 
 =pod
-$ ftpasswd --passwd --name=test2@mail.com --uid=3000 
---gid=3000 --home=/home/test --shell=/bin/false 
+$ ftpasswd --passwd --name=test2@mail.com --uid=3000
+--gid=3000 --home=/home/test --shell=/bin/false
 --file=/home/astocker/proftpd.passwd
 ftpasswd: using alternate file: /home/astocker/proftpd.passwd
 ftpasswd: creating passwd entry for user test2@mail.com

--- a/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/ExtendedLog.pm
@@ -634,7 +634,7 @@ sub extlog_retr_default {
       while (my $line = <$fh>) {
         chomp($line);
 
-        if ($ENV{TEST_VERBOSE}) { 
+        if ($ENV{TEST_VERBOSE}) {
           print STDERR "$line\n";
         }
 
@@ -837,7 +837,7 @@ sub extlog_retr_bug3137 {
     my $line = <$fh>;
     chomp($line);
 
-    if ($ENV{TEST_VERBOSE}) { 
+    if ($ENV{TEST_VERBOSE}) {
       print STDERR "$line\n";
     }
 
@@ -4589,7 +4589,7 @@ sub extlog_ftp_sendfile_raw_bytes_bug3554 {
       my $resp_msg = $client->response_msg();
       $client->quit();
 
-      $self->assert_transfer_ok($resp_code, $resp_msg); 
+      $self->assert_transfer_ok($resp_code, $resp_msg);
     };
 
     if ($@) {
@@ -11674,7 +11674,7 @@ sub extlog_micros_ts_bug3889 {
       close($fh);
 
       if ($line =~ /^\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2},\d{6}\s+(.*)?$/) {
-        my $file = $1; 
+        my $file = $1;
 
         # MacOSX hack
         if ($^O eq 'darwin') {
@@ -11823,7 +11823,7 @@ sub extlog_millis_ts_bug3889 {
     close($fh);
 
     if ($line =~ /^\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+(.*)?$/) {
-      my $file = $1; 
+      my $file = $1;
 
       # MacOSX hack
       if ($^O eq 'darwin') {
@@ -11950,7 +11950,7 @@ sub extlog_iso8601_ts_bug3889 {
       close($fh);
 
       if ($line =~ /^\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+(.*)?$/) {
-        my $file = $1; 
+        my $file = $1;
 
         # MacOSX hack
         if ($^O eq 'darwin') {
@@ -12146,7 +12146,7 @@ sub extlog_dirs_class_var_f_bug3966 {
           } else {
             $ok = 0;
           }
-       
+
           if ($ok == 0) {
             last;
           }

--- a/tests/t/lib/ProFTPD/Tests/Logging/SystemLog.pm
+++ b/tests/t/lib/ProFTPD/Tests/Logging/SystemLog.pm
@@ -338,7 +338,7 @@ sub systemlog_with_sysloglevel_crit {
           if ($line =~ /USER $user: Login successful/) {
             $saw_login = 1;
           }
-        } 
+        }
 
         if (!$saw_closed) {
           if ($line =~ /FTP session closed/) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_auth_otp.pm
@@ -566,8 +566,8 @@ EOS
       my $oath = Authen::OATH->new();
       my $nattempts = 5;
       my $ok = 0;
-    
-      for (my $i = 0; $i < $nattempts; $i++) { 
+
+      for (my $i = 0; $i < $nattempts; $i++) {
         my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
         # Calculate HOTP
@@ -1160,7 +1160,7 @@ EOS
       sleep(2);
 
       my $oath = Authen::OATH->new();
-      my $nattempts = 3; 
+      my $nattempts = 3;
       my $now = time();
       my $ok = 0;
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
@@ -135,8 +135,8 @@ sub server_open_fds {
         $count++;
       }
     }
- 
-    closedir($dirh); 
+
+    closedir($dirh);
     return $count;
 
   } else {
@@ -462,7 +462,7 @@ sub ban_message {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -571,7 +571,7 @@ sub ban_message {
       }
 
       my $conn_ex = ProFTPD::TestSuite::FTP::get_connect_exception();
-      
+
       $expected = "Go away 127.0.0.1 ((none)), or I shall taunt you ((none)) a second time!";
       $self->assert($expected eq $conn_ex,
         test_msg("Expected '$expected', got '$conn_ex'"));
@@ -630,7 +630,7 @@ sub ban_ifclass_engine_on {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -821,7 +821,7 @@ sub ban_ifclass_engine_off {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -990,7 +990,7 @@ sub ban_max_logins_exceeded_bug3281 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1284,7 +1284,7 @@ sub ban_engine_vhost_bug3355 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1336,7 +1336,7 @@ sub ban_engine_vhost_bug3355 {
 
   my ($port, $config_user, $config_group) = config_write($config_file, $config);
   my $vhost_port = $port + 21;
- 
+
   if (open(my $fh, ">> $config_file")) {
     print $fh <<EOC;
 <VirtualHost 127.0.0.1>
@@ -1358,7 +1358,7 @@ EOC
   } else {
     die("Can't open $config_file: $!");
   }
- 
+
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
   # to the parent.
@@ -1476,7 +1476,7 @@ sub ban_unhandled_cmd {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1547,10 +1547,10 @@ sub ban_unhandled_cmd {
       unless ($@) {
           die("FOO command succeeded unexpectedly");
       }
-   
+
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
- 
+
       my $expected;
 
       $expected = 500;
@@ -1565,10 +1565,10 @@ sub ban_unhandled_cmd {
       unless ($@) {
           die("BAR command succeeded unexpectedly");
       }
-   
+
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
- 
+
       $expected = 500;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -1585,9 +1585,9 @@ sub ban_unhandled_cmd {
       unless ($@) {
           die("BAZ command succeeded unexpectedly");
       }
-   
+
       $resp_code = $client->response_code();
- 
+
       $expected = 000;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -1658,7 +1658,7 @@ sub ban_on_event_client_connect_rate {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1826,7 +1826,7 @@ sub ban_sighup_bug3751 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1939,7 +1939,7 @@ sub ban_on_event_tlshandshake {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
@@ -379,7 +379,7 @@ sub copy_file_no_login_bug4169 {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
-      unless ($@) { 
+      unless ($@) {
         die("SITE COPY succeeded unexpectedly");
       }
 
@@ -645,7 +645,7 @@ sub copy_enoent {
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
       unless ($@) {
         die("SITE COPY succeeded unexpectedly");
-      } 
+      }
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
@@ -1051,7 +1051,7 @@ EOC
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
       unless ($@) {
         die("SITE COPY succeeded unexpectedly");
-      } 
+      }
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
@@ -1196,7 +1196,7 @@ sub copy_config_allowoverwrite {
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
       unless ($@) {
         die("SITE COPY succeeded unexpectedly");
-      } 
+      }
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
@@ -1320,7 +1320,7 @@ sub copy_config_pathdenyfilter {
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
       unless ($@) {
         die("SITE COPY succeeded unexpectedly");
-      } 
+      }
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
@@ -2860,7 +2860,7 @@ sub copy_cpfr_cpto_no_login_bug4169 {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
- 
+
       eval { $client->site('CPFR', 'foo.txt') };
       unless ($@) {
         die("SITE CPFR succeeded unexpectedly");

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ctrls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ctrls.pm
@@ -194,7 +194,7 @@ sub ctrls_lsctrl_ok {
     $expected = 'help insctrl lsctrl rmctrl ';
     $self->assert($expected eq $actions,
       test_msg("Expected '$expected', got '$actions'"));
-  }; 
+  };
   if ($@) {
     $ex = $@;
   }
@@ -278,7 +278,7 @@ sub ctrls_lsctrl_system_user_ok {
     $expected = 'help insctrl lsctrl rmctrl ';
     $self->assert($expected eq $actions,
       test_msg("Expected '$expected', got '$actions'"));
-  }; 
+  };
   if ($@) {
     $ex = $@;
   }
@@ -445,8 +445,7 @@ sub ctrls_sighup_bug3756 {
 
     $self->assert($orig_nfds == $restart_nfds,
       test_msg("Expected $orig_nfds open fds, found $restart_nfds"));
-  }; 
-
+  };
   if ($@) {
     $ex = $@;
   }

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_deflate.pm
@@ -294,7 +294,7 @@ sub deflate_feat {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
 
       $client->feat();
- 
+
       my $resp_code = $client->response_code();
       my $resp_msgs = $client->response_msgs();
 
@@ -1314,7 +1314,7 @@ sub deflate_stor {
       }
 
       my $buf = "Ab" x 8192;
-      my $deflated = compress($buf); 
+      my $deflated = compress($buf);
       $conn->write($deflated, length($deflated));
       $conn->close();
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_delay.pm
@@ -274,7 +274,7 @@ sub delay_warm_table {
         my $start = [gettimeofday()];
         $client->login($user, $passwd);
         my $elapsed = tv_interval($start);
- 
+
         $client->quit();
 
         if ($elapsed > $max_elapsed) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_exec.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_exec.pm
@@ -247,7 +247,7 @@ sub exec_on_cmd {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -705,7 +705,7 @@ sub exec_on_error {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -873,7 +873,7 @@ sub exec_on_restart {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -969,7 +969,7 @@ sub exec_opt_log_stdout {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1125,7 +1125,7 @@ sub exec_opt_log_stderr {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1864,7 +1864,7 @@ sub exec_open_fds_bug3553 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -2049,7 +2049,7 @@ sub exec_on_event_as_user_bug3964 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -2346,7 +2346,7 @@ sub exec_ifuser_on_cmd {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ifsession.pm
@@ -128,7 +128,7 @@ sub set_up {
   }
 }
 
-sub ifuser_allowoverwrite { 
+sub ifuser_allowoverwrite {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -290,7 +290,7 @@ EOC
   unlink($log_file);
 }
 
-sub ifgroup_dir_allow_mkd_bug3467 { 
+sub ifgroup_dir_allow_mkd_bug3467 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -307,7 +307,7 @@ sub ifgroup_dir_allow_mkd_bug3467 {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
@@ -407,7 +407,7 @@ EOC
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
 
-      $client->pwd(); 
+      $client->pwd();
       $client->mkd('foo');
       $client->quit();
     };
@@ -444,7 +444,7 @@ EOC
   unlink($log_file);
 }
 
-sub ifuser_dir_allow_mkd_bug3467 { 
+sub ifuser_dir_allow_mkd_bug3467 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -461,7 +461,7 @@ sub ifuser_dir_allow_mkd_bug3467 {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
@@ -587,7 +587,7 @@ EOC
   unlink($log_file);
 }
 
-sub ifclass_dir_allow_mkd_bug3467 { 
+sub ifclass_dir_allow_mkd_bug3467 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -604,7 +604,7 @@ sub ifclass_dir_allow_mkd_bug3467 {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
@@ -635,7 +635,7 @@ sub ifclass_dir_allow_mkd_bug3467 {
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
-    
+
     IfModules => {
       'mod_delay.c' => {
         DelayEngine => 'off',
@@ -1187,7 +1187,7 @@ EOC
   unlink($log_file);
 }
 
-sub ifauthenticated_bug3629 { 
+sub ifauthenticated_bug3629 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -1257,7 +1257,7 @@ sub ifauthenticated_bug3629 {
   if (open(my $fh, ">> $config_file")) {
     my $limit_dir = $home_dir;
     if ($^O eq 'darwin') {
-      # MacOSX hack 
+      # MacOSX hack
       $limit_dir = ('/private' . $home_dir);
     }
 
@@ -1466,7 +1466,7 @@ EOC
   test_cleanup($setup->{log_file}, $ex);
 }
 
-sub ifgroup_dir_allow_stor_bug3881 { 
+sub ifgroup_dir_allow_stor_bug3881 {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -1483,7 +1483,7 @@ sub ifgroup_dir_allow_stor_bug3881 {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs("$tmpdir/users/$user");
   mkpath($home_dir);
   my $uid = 500;
@@ -1642,7 +1642,7 @@ EOC
   unlink($log_file);
 }
 
-sub ifgroup_dir_allow_stor_bug3881_sftp { 
+sub ifgroup_dir_allow_stor_bug3881_sftp {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
 
@@ -1659,7 +1659,7 @@ sub ifgroup_dir_allow_stor_bug3881_sftp {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs("$tmpdir/users/$user");
   mkpath($home_dir);
   my $uid = 500;
@@ -1728,7 +1728,7 @@ sub ifgroup_dir_allow_stor_bug3881_sftp {
       # MacOSX hack
       $limit_dir = ('/private' . $limit_dir);
     }
- 
+
     # XXX Hack, for now:
     $limit_dir = '~/test.d';
 
@@ -1870,7 +1870,7 @@ sub ifclass_global_no_logging {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
@@ -1901,7 +1901,7 @@ sub ifclass_global_no_logging {
     AuthUserFile => $auth_user_file,
     AuthGroupFile => $auth_group_file,
     AuthOrder => 'mod_auth_file.c',
-    
+
     IfModules => {
       'mod_delay.c' => {
         DelayEngine => 'off',
@@ -2042,7 +2042,7 @@ sub ifuser_no_pass_bug4199 {
 
   my $user = 'proftpd';
   my $passwd = 'test';
-  my $group = 'ftpd'; 
+  my $group = 'ftpd';
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_lang.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_lang.pm
@@ -1663,7 +1663,7 @@ sub lang_opts_utf8_useencoding_off {
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
- 
+
       $expected = 451;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -1915,7 +1915,7 @@ sub lang_opts_utf8_useencoding_charsets_strict {
 
       # Make sure the OPTS UTF8 command does not appear in the FEAT listing;
       # see Bug#3737.
-      $client->feat(); 
+      $client->feat();
       my $resp_code = $client->response_code();
       my $resp_msgs = $client->response_msgs();
 
@@ -2070,7 +2070,7 @@ sub lang_opts_utf8_useencoding_charsets_strict_with_utf8 {
 
       # Make sure the OPTS UTF8 command does not appear in the FEAT listing;
       # see Bug#3737.
-      $client->feat(); 
+      $client->feat();
       my $resp_code = $client->response_code();
       my $resp_msgs = $client->response_msgs();
 
@@ -2380,7 +2380,7 @@ sub lang_useencoding_latin1_utf8 {
 
       my $name = "üöä";
 
-      my $conn = $client->stor_raw($name); 
+      my $conn = $client->stor_raw($name);
       unless ($conn) {
         die("STOR $name failed: " . $client->response_code() . " " .
           $client->response_msg());
@@ -2518,7 +2518,7 @@ sub lang_useencoding_utf8_latin1 {
 
       my $name = "Grafik-Zentrumäüu.png";
 
-      my $conn = $client->stor_raw($name); 
+      my $conn = $client->stor_raw($name);
       unless ($conn) {
         die("STOR $name failed: " . $client->response_code() . " " .
           $client->response_msg());
@@ -2650,7 +2650,7 @@ sub lang_opts_utf8_prefer_server_encoding_bug4125 {
 
       # Make sure the OPTS UTF8 command does not appear in the FEAT listing;
       # see Bug#3737.
-      $client->feat(); 
+      $client->feat();
       my $resp_code = $client->response_code();
       my $resp_msgs = $client->response_msgs();
 
@@ -2806,7 +2806,7 @@ sub lang_opts_utf8_useencoding_charsets_prefer_server_encoding_bug4125 {
 
       # Make sure the OPTS UTF8 command does not appear in the FEAT listing;
       # see Bug#3737.
-      $client->feat(); 
+      $client->feat();
       my $resp_code = $client->response_code();
       my $resp_msgs = $client->response_msgs();
 
@@ -2971,14 +2971,14 @@ sub lang_useencoding_ascii_utf8_require_valid_encoding_bug4125 {
 
       my $name = "üöä";
 
-      my $conn = $client->stor_raw($name); 
+      my $conn = $client->stor_raw($name);
       if ($conn) {
         die("STORE $name succeeded unexpectedly");
       }
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
- 
+
       $client->quit();
 
       my $expected = 550;

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_log_forensic.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_log_forensic.pm
@@ -159,12 +159,12 @@ sub forensic_failed_login {
       if ($line =~ /^\-\-\-\-\-BEGIN FAILED LOGIN FORENSICS\-\-\-\-\-/) {
         $begin_ok = 1;
         next;
-      } 
+      }
 
       if ($begin_ok and
           $line =~ /^\-\-\-\-\-END FAILED LOGIN FORENSICS\-\-\-\-\-/) {
         $end_ok = 1;
-        last; 
+        last;
       }
     }
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab/copy.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab/copy.pm
@@ -258,7 +258,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'foo.txt');
- 
+
       my $expected;
 
       $expected = 350;
@@ -270,7 +270,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'bar.txt');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -501,7 +501,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'foo.txt');
- 
+
       my $expected;
 
       $expected = 350;
@@ -513,7 +513,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'bar.txt');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -744,7 +744,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'foo.txt');
- 
+
       my $expected;
 
       $expected = 350;
@@ -756,7 +756,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'bar.txt');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -994,7 +994,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'foo.txt');
- 
+
       my $expected;
 
       $expected = 350;
@@ -1006,7 +1006,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'bar.txt');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -1240,7 +1240,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'foo.txt');
- 
+
       my $expected;
 
       $expected = 350;
@@ -1258,7 +1258,7 @@ EOS
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-      
+
       $expected = 552;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -1505,7 +1505,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -1517,7 +1517,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'dst.d');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -1764,7 +1764,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -1776,7 +1776,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'dst.d');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -2039,7 +2039,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -2051,7 +2051,7 @@ EOS
         test_msg("Expected '$expected', got '$resp_msg'"));
 
       ($resp_code, $resp_msg) = $client->site('CPTO', 'dst.d');
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));
@@ -2298,7 +2298,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -2579,7 +2579,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -2843,7 +2843,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('CPFR', 'src.d');
- 
+
       my $expected;
 
       $expected = 350;
@@ -2857,7 +2857,7 @@ EOS
       $client->site('CPTO', 'dst.d');
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg(0);
-      
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab/site_misc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab/site_misc.pm
@@ -237,7 +237,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('mkdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -460,7 +460,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('mkdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -683,7 +683,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('mkdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -906,7 +906,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('mkdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -1135,7 +1135,7 @@ EOS
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
- 
+
       my $expected;
 
       $expected = 550;
@@ -1370,7 +1370,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('mkdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -1599,7 +1599,7 @@ EOS
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
- 
+
       my $expected;
 
       $expected = 550;
@@ -1821,7 +1821,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('rmdir', 'foo/bar/baz');
- 
+
       my $expected;
 
       $expected = 200;
@@ -2048,7 +2048,7 @@ EOS
       $client->login($user, $passwd);
 
       my ($resp_code, $resp_msg) = $client->site('rmdir', 'foo');
- 
+
       my $expected;
 
       $expected = 200;

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
@@ -6436,7 +6436,7 @@ EOS
       # available file upload slots.
       my $conn = $client->stor_raw('test.txt');
       if ($conn) {
-        die("STOR test.txt succeeded unexpectedly"); 
+        die("STOR test.txt succeeded unexpectedly");
       }
 
       my $resp_code = $client->response_code();

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ratio.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ratio.pm
@@ -141,7 +141,7 @@ sub ratio_bug3600 {
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
 
-      ($resp_code, $resp_msg) = $client->syst(); 
+      ($resp_code, $resp_msg) = $client->syst();
 
       $expected = 215;
       $self->assert($expected == $resp_code,

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_readme.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_readme.pm
@@ -128,7 +128,7 @@ sub readme_login_path {
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(2);
 
       $expected = "Please read the file (.*?)\/README";
@@ -231,7 +231,7 @@ sub readme_login_path_nonexistent {
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(2);
       $self->assert(!defined($resp_msg),
         test_msg("Expected undefined, got '$resp_msg'"));
@@ -336,7 +336,7 @@ sub readme_login_pattern {
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(2);
 
       $expected = "Please read the file README";
@@ -464,7 +464,7 @@ sub readme_cwd_pattern {
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(2);
 
       $expected = "Please read the file README";
@@ -629,7 +629,7 @@ sub readme_cwd_pattern_multiple_matches {
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(2);
 
       $expected = "Please read the file README";
@@ -798,7 +798,7 @@ sub readme_login_path_displaylogin_bug3605 {
       $expected = " User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
- 
+
       $resp_msg = $client->response_msg(8);
 
       $expected = "Please read the file (.*?)\/README";

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_redis.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_redis.pm
@@ -119,7 +119,7 @@ sub redis_list_delete {
   );
 
   $redis->del($key);
-  $redis->quit();  
+  $redis->quit();
   return 1;
 }
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_rewrite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_rewrite.pm
@@ -294,7 +294,7 @@ sub rewrite_map_lowercase {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -443,7 +443,7 @@ sub rewrite_map_spaces_underscores {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -845,7 +845,7 @@ sub rewrite_rule_append_pid {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -981,7 +981,7 @@ sub rewrite_bug2915 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -1127,7 +1127,7 @@ sub rewrite_bug3027 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1275,7 +1275,7 @@ sub rewrite_bug3034 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1415,7 +1415,7 @@ sub rewrite_bug3169 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1569,7 +1569,7 @@ sub rewrite_map_unescape_bug3170 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1718,7 +1718,7 @@ sub rewrite_cond_env_var_failed {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -1876,7 +1876,7 @@ sub rewrite_cond_env_var_ok {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -2028,7 +2028,7 @@ sub rewrite_rule_env_var_failed {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $test_file = 'foo.txt';
   my $test_path = File::Spec->rel2abs("$home_dir/$test_file");
 
@@ -2180,7 +2180,7 @@ sub rewrite_rule_env_var_ok {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $test_file = 'foo.txt';
   my $test_path = File::Spec->rel2abs("$home_dir/$test_file");
 
@@ -2333,7 +2333,7 @@ sub rewrite_escape_rule_backref_bug3028 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -2473,7 +2473,7 @@ sub rewrite_escape_cond_backref_bug3028 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -2613,7 +2613,7 @@ sub rewrite_cond_rename_var_bug3029 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -2743,7 +2743,7 @@ sub rewrite_cond_or_flags_bug3269 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -2880,7 +2880,7 @@ sub rewrite_cond_nc_flags {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -2915,7 +2915,7 @@ sub rewrite_cond_nc_flags {
         'RewriteEngine on',
         "RewriteLog $log_file",
 
-        'RewriteCondition %u ^ProFTPD$ [NC]', 
+        'RewriteCondition %u ^ProFTPD$ [NC]',
         'RewriteCondition %m SIZE',
         'RewriteRule (.*) $1.%P',
       ],
@@ -3099,7 +3099,7 @@ sub rewrite_map_fifo_bug3611 {
       # everything.
       my $path = join('', reverse(split(//, $test_file)));
       my ($resp_code, $resp_msg) = $client->stat($path);
-      
+
       my $expected = 213;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -3175,7 +3175,7 @@ sub rewrite_rule_replaceall_backslash_with_slash {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -3312,7 +3312,7 @@ sub rewrite_map_max_replace_bug3721 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -3598,7 +3598,7 @@ sub rewrite_cond_time_year_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -3754,7 +3754,7 @@ sub rewrite_cond_time_mon_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -3910,7 +3910,7 @@ sub rewrite_cond_time_day_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4066,7 +4066,7 @@ sub rewrite_cond_time_wday_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4222,7 +4222,7 @@ sub rewrite_cond_time_hour_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4378,7 +4378,7 @@ sub rewrite_cond_time_min_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4534,7 +4534,7 @@ sub rewrite_cond_time_sec_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4690,7 +4690,7 @@ sub rewrite_rule_time_year_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4842,7 +4842,7 @@ sub rewrite_rule_time_mon_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -4994,7 +4994,7 @@ sub rewrite_rule_time_day_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -5146,7 +5146,7 @@ sub rewrite_rule_time_wday_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -5298,7 +5298,7 @@ sub rewrite_rule_time_hour_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -5450,7 +5450,7 @@ sub rewrite_rule_time_min_var_bug3673 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -5602,7 +5602,7 @@ sub rewrite_bug3767 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
- 
+
   my $sub_dir = File::Spec->rel2abs("$tmpdir/tmp");
   mkpath($sub_dir);
 
@@ -5749,7 +5749,7 @@ sub rewrite_bug4017 {
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/foo.d");
   mkpath($test_dir);
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -5888,7 +5888,7 @@ sub rewrite_using_pcre_bug4017 {
 
   my $test_dir = File::Spec->rel2abs("$tmpdir/foo.d");
   mkpath($test_dir);
- 
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -2130,13 +2130,13 @@ sub ssh2_connect_bad_version_bad_format {
       my $len = read($sock, $resp, 64);
       $self->assert($len > 0, test_msg("Expected response, got none"));
 
-      chomp($resp); 
+      chomp($resp);
 
       my $expected = 'Protocol mismatch.';
       $self->assert(qr/$expected/, $resp,
         test_msg("Expected '$expected', got '$resp'"));
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2238,13 +2238,13 @@ sub ssh2_connect_bad_version_unsupported_proto_version {
       my $len = read($sock, $resp, 64);
       $self->assert($len > 0, test_msg("Expected response, got none"));
 
-      chomp($resp); 
+      chomp($resp);
 
       my $expected = 'Protocol mismatch.';
       $self->assert(qr/$expected/, $resp,
         test_msg("Expected '$expected', got '$resp'"));
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2346,13 +2346,13 @@ sub ssh2_connect_bad_version_too_long {
       my $len = read($sock, $resp, 64);
       $self->assert($len > 0, test_msg("Expected response, got none"));
 
-      chomp($resp); 
+      chomp($resp);
 
       my $expected = 'Protocol mismatch.';
       $self->assert(qr/$expected/, $resp,
         test_msg("Expected '$expected', got '$resp'"));
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2454,13 +2454,13 @@ sub ssh2_connect_bad_version_too_short {
       my $len = read($sock, $resp, 64);
       $self->assert($len > 0, test_msg("Expected response, got none"));
 
-      chomp($resp); 
+      chomp($resp);
 
       my $expected = 'Protocol mismatch.';
       $self->assert(qr/$expected/, $resp,
         test_msg("Expected '$expected', got '$resp'"));
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2562,13 +2562,13 @@ sub ssh2_connect_version_with_comments {
       my $len = read($sock, $resp, 64);
       $self->assert($len > 0, test_msg("Expected response, got none"));
 
-      chomp($resp); 
+      chomp($resp);
 
       my $expected = '^SSH-2.0-mod_sftp';
       $self->assert(qr/$expected/, $resp,
         test_msg("Expected '$expected', got '$resp'"));
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2705,7 +2705,7 @@ sub ssh2_connect_version_bug3918 {
       print $sock "SSH-2.0-ProFTPD_mod_sftp_TestSuite\r\n";
       sleep(1);
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -2866,7 +2866,7 @@ sub ssh2_connect_timeout_login {
 
       print $sock "AAAA" x 1024;
 
-      close($sock); 
+      close($sock);
     };
 
     if ($@) {
@@ -17325,7 +17325,7 @@ sub ssh2_auth_twice {
 
       my $auth_timed_out = 0;
 
-      eval { 
+      eval {
         local %SIG;
         $SIG{ALRM} = sub { $auth_timed_out = 1; };
 
@@ -22961,8 +22961,8 @@ sub sftp_fsetstat {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-    
-      my $fh = $sftp->open('sftp.conf', O_RDONLY); 
+
+      my $fh = $sftp->open('sftp.conf', O_RDONLY);
       unless ($fh) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't open sftp.conf: [$err_name] ($err_code)");
@@ -22971,7 +22971,7 @@ sub sftp_fsetstat {
       my $res = $fh->setstat(
         atime => 0,
         mtime => 0,
-      ); 
+      );
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't fsetstat sftp.conf: [$err_name] ($err_code)");
@@ -28233,7 +28233,7 @@ sub sftp_ext_upload_bug3550 {
   }
 
   my $expected_sz = (stat($src_file))[7];
- 
+
   my $dst_file = File::Spec->rel2abs("$tmpdir/test.dat");
 
   my $batch_file = File::Spec->rel2abs("$tmpdir/sftp-batch.txt");
@@ -29595,7 +29595,7 @@ sub sftp_ext_download_bug3550 {
   }
 
   my $expected_sz = (stat($orig_file))[7];
- 
+
   my $src_file = File::Spec->rel2abs("$tmpdir/test.dat");
   unless (copy($orig_file, $src_file)) {
     die("Can't copy $orig_file to $src_file: $!");
@@ -29856,7 +29856,7 @@ sub sftp_ext_download_server_rekey {
   }
 
   my $expected_sz = (stat($orig_file))[7];
- 
+
   my $src_file = File::Spec->rel2abs("$tmpdir/test.dat");
   unless (copy($orig_file, $src_file)) {
     die("Can't copy $orig_file to $src_file: $!");
@@ -30083,7 +30083,7 @@ sub sftp_ext_download_rekey_rsa1024_hostkey_bug4097 {
   }
 
   my $expected_sz = (stat($orig_file))[7];
- 
+
   my $src_file = File::Spec->rel2abs("$tmpdir/test.dat");
   unless (copy($orig_file, $src_file)) {
     die("Can't copy $orig_file to $src_file: $!");
@@ -33167,7 +33167,7 @@ sub sftp_mkdir_readdir_bug3481 {
       for (my $i = 0; $i < $count; $i++) {
         my $test_file = 'testdir/test_' . sprintf("%03s", $i);
 
-        my $fh = $sftp->open($test_file, O_CREAT, 0644); 
+        my $fh = $sftp->open($test_file, O_CREAT, 0644);
         unless ($fh) {
           my ($err_code, $err_name) = $sftp->error();
           die("OPEN $test_file failed: [$err_name] ($err_code)");
@@ -42854,7 +42854,7 @@ sub sftp_config_ignore_upload_perms_upload {
   my $expected = 0644;
   $self->assert($expected == $perms,
     test_msg("Expected '$expected', got '$perms'"));
-  
+
   unlink($log_file);
 }
 
@@ -43016,7 +43016,7 @@ sub sftp_config_ignore_upload_perms_mkdir_bug3680 {
   my $expected = 0755;
   $self->assert($expected == $perms,
     test_msg("Expected '$expected', got '$perms'"));
-  
+
   unlink($log_file);
 }
 
@@ -43066,7 +43066,7 @@ sub sftp_config_ignore_set_perms_bug3599 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -43192,7 +43192,7 @@ sub sftp_config_ignore_set_perms_bug3599 {
   my $expected = 0644;
   $self->assert($expected == $perms,
     test_msg("Expected '$expected', got '$perms'"));
-  
+
   unlink($log_file);
 }
 
@@ -43242,7 +43242,7 @@ sub sftp_config_ignore_set_times_bug3706 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -43375,7 +43375,7 @@ sub sftp_config_ignore_set_times_bug3706 {
   $expected = $test_mtime;
   $self->assert($expected == $new_mtime,
     test_msg("Expected mtime $expected, got $new_mtime"));
-  
+
   unlink($log_file);
 }
 
@@ -43425,7 +43425,7 @@ sub sftp_config_ignore_set_owners_bug3757 {
     unless (close($fh)) {
       die("Can't write $test_file: $!");
     }
- 
+
   } else {
     die("Can't open $test_file: $!");
   }
@@ -43558,7 +43558,7 @@ sub sftp_config_ignore_set_owners_bug3757 {
   $expected = $test_gid;
   $self->assert($expected == $new_gid,
     test_msg("Expected gid $expected, got $new_gid"));
-  
+
   unlink($log_file);
 }
 
@@ -44857,7 +44857,7 @@ sub sftp_config_limit_chmod {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-     
+
       my $res = $sftp->setstat('sftp.conf',
         mode => 0777,
       );
@@ -45024,7 +45024,7 @@ sub sftp_config_limit_chgrp_bug3757 {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-     
+
       my $res = $sftp->setstat('sftp.conf',
         uid => $uid,
         gid => $gid,
@@ -45193,7 +45193,7 @@ sub sftp_config_limit_list {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-    
+
       # Make sure that OPENDIR succeeds, but READDIR returns end-of-list.
       my $dir = $sftp->opendir('.');
       unless ($dir) {
@@ -45386,7 +45386,7 @@ sub sftp_config_limit_nlst {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-    
+
       # Make sure that OPENDIR succeeds, but READDIR returns end-of-list.
       my $dir = $sftp->opendir('.');
       unless ($dir) {
@@ -45584,7 +45584,7 @@ sub sftp_config_limit_allowfilter_stor_allowed {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-   
+
       my $fh = $sftp->open('test.txt', O_WRONLY|O_CREAT|O_TRUNC, 0644);
       unless ($fh) {
         my ($err_code, $err_name) = $sftp->error();
@@ -45750,7 +45750,7 @@ sub sftp_config_limit_allowfilter_stor_denied {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-   
+
       my $fh = $sftp->open('test.jpg', O_WRONLY|O_CREAT|O_TRUNC, 0644);
       if ($fh) {
         die("Open of test.jpg succeeded unexpectedly");
@@ -46284,9 +46284,9 @@ EOC
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-   
-      my $file = 'sftp.conf'; 
-      my $fh = $sftp->open($file, O_RDONLY); 
+
+      my $file = 'sftp.conf';
+      my $fh = $sftp->open($file, O_RDONLY);
       unless ($fh) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't open $file: [$err_name] ($err_code)");
@@ -46295,7 +46295,7 @@ EOC
       my $res = $fh->setstat(
         atime => 0,
         mtime => 0,
-      ); 
+      );
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't fsetstat $file: [$err_name] ($err_code)");
@@ -47855,7 +47855,7 @@ sub sftp_multi_channels {
 
       my $sftps = [];
 
-      for (my $i = 0; $i < 3; $i++) { 
+      for (my $i = 0; $i < 3; $i++) {
         my $sftp = $ssh2->sftp();
         unless ($sftp) {
           my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -47887,7 +47887,7 @@ sub sftp_multi_channels {
       for (my $i = 0; $i < scalar(@$sftps); $i++) {
         $sftps->[$i] = undef;
       }
- 
+
       $ssh2->disconnect();
     };
 
@@ -48446,7 +48446,7 @@ sub sftp_multi_channel_downloads {
       my $fhs = [];
       my $md5s = [];
 
-      for (my $i = 0; $i < 3; $i++) { 
+      for (my $i = 0; $i < 3; $i++) {
         my $sftp = $ssh2->sftp();
         unless ($sftp) {
           my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -48500,11 +48500,11 @@ sub sftp_multi_channel_downloads {
       for (my $i = 0; $i < scalar(@$fhs); $i++) {
         $fhs->[$i] = undef;
       }
- 
+
       for (my $i = 0; $i < scalar(@$sftps); $i++) {
         $sftps->[$i] = undef;
       }
- 
+
       $ssh2->disconnect();
 
       my $expected;
@@ -48950,7 +48950,7 @@ sub sftp_log_xferlog_download_incomplete {
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't read test.txt: [$err_name] ($err_code)");
-      } 
+      }
 
       sleep(1);
 
@@ -49908,7 +49908,7 @@ sub sftp_log_xferlog_upload_incomplete {
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't write test.txt: [$err_name] ($err_code)");
-      } 
+      }
 
       # Explicitly disconnect without closing the file, simulating an
       # aborted transfer.
@@ -50339,7 +50339,7 @@ sub sftp_log_extlog_reads {
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't write test.txt: [$err_name] ($err_code)");
-      } 
+      }
 
       # Explicitly disconnect without closing the file, simulating an
       # aborted transfer.
@@ -50528,7 +50528,7 @@ sub sftp_log_extlog_read_close {
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("Can't write test.txt: [$err_name] ($err_code)");
-      } 
+      }
 
       $fh = undef;
 
@@ -51038,7 +51038,7 @@ sub sftp_log_extlog_var_s_reads {
         my $code = $2;
 
         my $expected;
- 
+
         if ($cmd eq 'OPEN') {
           $expected = '-';
 
@@ -51223,12 +51223,12 @@ EOC
 
       # This is expected to fail because of the <Limit>
       $fh->setstat(atime => 0, mtime => 0);
-   
+
       print $fh "abcd" x 1024, "\n";
 
       # This is expected to fail because of the <Limit>
       $fh->setstat(atime => 0, mtime => 0);
-  
+
       # Explicitly disconnect without closing the file, simulating an
       # aborted transfer.
       $ssh2->disconnect();
@@ -51275,7 +51275,7 @@ EOC
         my $code = $2;
 
         my $expected;
- 
+
         if ($cmd eq 'OPEN') {
           $expected = '-';
 
@@ -52385,7 +52385,7 @@ sub sftp_log_extlog_var_w_rename_bug3029 {
           $expected = '-';
           $self->assert($expected eq $whence,
             test_msg("Expected '$expected', got '$whence'"));
- 
+
           $expected = $test_file1;
           if ($^O eq 'darwin') {
             # MacOSX-specific hack to deal with how it handles tmp files
@@ -53657,7 +53657,7 @@ EOC
       }
 
       $sftp = undef;
-      $ssh2->disconnect(); 
+      $ssh2->disconnect();
     };
 
     if ($@) {
@@ -53842,7 +53842,7 @@ sub sftp_log_extlog_env_banner_bug4065 {
       }
 
       $sftp = undef;
-      $ssh2->disconnect(); 
+      $ssh2->disconnect();
     };
 
     if ($@) {
@@ -54019,7 +54019,7 @@ sub sftp_log_extlog_userauth_full_request {
       }
 
       $sftp = undef;
-      $ssh2->disconnect(); 
+      $ssh2->disconnect();
     };
 
     if ($@) {
@@ -54642,7 +54642,7 @@ sub sftp_wrap_login_allowed_bug3352 {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-      
+
       $sftp = undef;
       $ssh2->disconnect();
     };
@@ -56775,7 +56775,7 @@ sub scp_ext_upload_recursive_dir_bug3447 {
   for (my $i = 0; $i < $count; $i++) {
     my $filename = 'aa' . sprintf("%03s", $i);
     my $src_file = File::Spec->rel2abs("$src_subdir/$filename");
-    
+
     if (open(my $fh, "> $src_file")) {
       print $fh "ABCDefgh" x 8192;
 
@@ -56788,7 +56788,7 @@ sub scp_ext_upload_recursive_dir_bug3447 {
     }
   }
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $config = {
@@ -57074,7 +57074,7 @@ sub scp_ext_upload_recursive_dir_bug3792 {
   for (my $i = 0; $i < $count; $i++) {
     my $filename = 'aa' . sprintf("%03s", $i);
     my $src_file = File::Spec->rel2abs("$src_subdir/$filename");
-    
+
     if (open(my $fh, "> $src_file")) {
       print $fh "ABCDefgh" x 8192;
 
@@ -57087,7 +57087,7 @@ sub scp_ext_upload_recursive_dir_bug3792 {
     }
   }
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $config = {
@@ -57388,7 +57388,7 @@ sub scp_ext_upload_recursive_dir_bug4004 {
   for (my $i = 0; $i < $count; $i++) {
     my $filename = 'aa' . sprintf("%03s", $i);
     my $src_file = File::Spec->rel2abs("$src_subdir/$filename");
-    
+
     if (open(my $fh, "> $src_file")) {
       print $fh "ABCDefgh" x 8192;
 
@@ -57401,7 +57401,7 @@ sub scp_ext_upload_recursive_dir_bug4004 {
     }
   }
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $config = {
@@ -58090,7 +58090,7 @@ sub scp_ext_upload_recursive_empty_dir {
   my $src_dir = File::Spec->rel2abs("$tmpdir/src.d");
   mkpath($src_dir);
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $config = {
@@ -58647,7 +58647,7 @@ sub scp_ext_upload_file_with_timestamp_bug4026 {
       $self->assert(-f $dst_file,
         test_msg("File $dst_file does not exist as expected"));
 
-      my ($atime, $mtime) = (stat($dst_file))[8,9]; 
+      my ($atime, $mtime) = (stat($dst_file))[8,9];
       $self->assert($atime == 0, test_msg("Expected atime 0, got $atime"));
       $self->assert($mtime == 0, test_msg("Expected mtime 0, got $mtime"));
     };
@@ -60974,7 +60974,7 @@ sub scp_ext_download_recursive_dir_bug3456 {
   for (my $i = 0; $i < $count; $i++) {
     my $filename = 'aa' . sprintf("%03s", $i);
     my $src_file = File::Spec->rel2abs("$src_subdir/$filename");
-    
+
     if (open(my $fh, "> $src_file")) {
       print $fh "ABCDefgh" x 8192;
 
@@ -60987,7 +60987,7 @@ sub scp_ext_download_recursive_dir_bug3456 {
     }
   }
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $timeout_idle = 60;
@@ -61214,7 +61214,7 @@ sub scp_ext_download_recursive_empty_dir {
   my $src_dir = File::Spec->rel2abs("$tmpdir/src.d");
   mkpath($src_dir);
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $timeout_idle = 60;
@@ -61417,7 +61417,7 @@ sub scp_ext_download_glob_no_matches_bug3935 {
   my $src_dir = File::Spec->rel2abs("$tmpdir/src.d");
   mkpath($src_dir);
 
-  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d"); 
+  my $dst_dir = File::Spec->rel2abs("$tmpdir/dst.d");
   mkpath($dst_dir);
 
   my $timeout_idle = 60;
@@ -62693,7 +62693,7 @@ sub scp_config_groupowner_file_member_norootprivs {
   my $tmpdir = $self->{tmpdir};
 
   my ($config_user, $config_group) = config_get_identity();
- 
+
   my $members = [split(' ', (getgrnam($config_group))[3])];
   if (scalar(@$members) < 2) {
     print STDERR " + unable to run 'scp_config_groupowner_member_norootprivs' test without current user belonging to multiple groups, skipping\n";
@@ -62983,7 +62983,7 @@ sub scp_log_extlog_var_f_upload {
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      my $res = $ssh2->scp_put($test_file, 'upload.txt'); 
+      my $res = $ssh2->scp_put($test_file, 'upload.txt');
       unless ($res) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't upload $test_file to server: [$err_name] ($err_code) $err_str");
@@ -63187,7 +63187,7 @@ sub scp_log_extlog_file_modified_bug3457 {
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      my $res = $ssh2->scp_put($src_file, 'dst.txt'); 
+      my $res = $ssh2->scp_put($src_file, 'dst.txt');
       unless ($res) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't upload $src_file to server: [$err_name] ($err_code) $err_str");
@@ -63497,7 +63497,7 @@ sub scp_log_xferlog_download {
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      my $res = $ssh2->scp_get('sftp.conf', $test_file); 
+      my $res = $ssh2->scp_get('sftp.conf', $test_file);
       unless ($res) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't download sftp.conf from server: [$err_name] ($err_code) $err_str");
@@ -63742,7 +63742,7 @@ sub scp_log_xferlog_upload {
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      my $res = $ssh2->scp_put($test_file, 'upload.txt'); 
+      my $res = $ssh2->scp_put($test_file, 'upload.txt');
       unless ($res) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't upload $test_file to server: [$err_name] ($err_code) $err_str");
@@ -64155,7 +64155,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/FIPS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/FIPS.pm
@@ -140,7 +140,7 @@ sub sftp_fips_cipher_cast128_cbc {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -277,7 +277,7 @@ sub sftp_fips_cipher_blowfish_cbc {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -414,7 +414,7 @@ sub sftp_fips_cipher_3des_cbc {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -554,7 +554,7 @@ sub sftp_fips_cipher_aes128_cbc {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -694,7 +694,7 @@ sub sftp_fips_cipher_aes128_cbc_auth_publickey_rsa {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -849,7 +849,7 @@ sub sftp_fips_cipher_aes128_cbc_auth_publickey_dsa {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1004,7 +1004,7 @@ sub sftp_fips_cipher_aes128_ctr {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1144,7 +1144,7 @@ sub sftp_fips_mac_hmac_md5 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1281,7 +1281,7 @@ sub sftp_fips_mac_hmac_md5_96 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1418,7 +1418,7 @@ sub sftp_fips_mac_ripemd160 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1555,7 +1555,7 @@ sub sftp_fips_mac_hmac_sha1 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/exec.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/exec.pm
@@ -120,7 +120,7 @@ sub sftp_exec_on_connect {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -271,7 +271,7 @@ sub sftp_exec_on_cmd {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -460,7 +460,7 @@ sub sftp_exec_on_cmd_var_total_bytes_xfer {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -648,7 +648,7 @@ sub sftp_exec_on_cmd_var_bytes_xfer {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -840,7 +840,7 @@ sub sftp_exec_on_exit {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1000,7 +1000,7 @@ sub sftp_exec_on_error {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1201,7 +1201,7 @@ sub exec_on_restart {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1296,7 +1296,7 @@ sub exec_opt_log_stdout {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1448,7 +1448,7 @@ sub exec_opt_log_stderr {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -1613,7 +1613,7 @@ sub sftp_exec_opt_send_stdout {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/rewrite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/rewrite.pm
@@ -864,7 +864,7 @@ sub sftp_rewrite_lstat {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-     
+
       my $attrs = $sftp->stat('test link', 0);
       unless ($attrs) {
         my ($err_code, $err_name) = $sftp->error();
@@ -1045,11 +1045,11 @@ sub sftp_rewrite_setstat {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-     
+
       my $res = $sftp->setstat('test file.txt',
         atime => 0,
         mtime => 0,
-      ); 
+      );
       unless ($res) {
         my ($err_code, $err_name) = $sftp->error();
         die("FXP_SETSTAT failed: [$err_name] ($err_code)");
@@ -1405,7 +1405,7 @@ sub sftp_rewrite_realpath_backslashes_bug4017 {
 
       my $munged = $test_file;
       $munged =~ s/\//\\/g;
-      
+
       my $resolved = $sftp->realpath($munged);
       unless ($resolved) {
         my ($err_code, $err_name) = $sftp->error();

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/wrap2.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/wrap2.pm
@@ -235,7 +235,7 @@ sub sftp_wrap2_file_login {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-      
+
       $sftp = undef;
       $ssh2->disconnect();
     };
@@ -440,7 +440,7 @@ EOS
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't use SFTP on SSH2 server: [$err_name] ($err_code) $err_str");
       }
-      
+
       $sftp = undef;
       $ssh2->disconnect();
     };
@@ -555,7 +555,7 @@ sub sftp_wrap2_deny_msg_on_connect_bug3670 {
   # sess_init() callback triggers first, it will disconnect the session
   # (and generate the event) before mod_sftp's sess_init() callback has had
   # a chance to set the "SSH2" bit for the session, then mod_sftp won't
-  # properly send the WrapDenyMsg to the SSH2 client. 
+  # properly send the WrapDenyMsg to the SSH2 client.
 
   my $config = {
     PidFile => $pid_file,

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_pam.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_pam.pm
@@ -151,7 +151,7 @@ sub sftp_pam_failed_login_attempts_bug3921 {
 
       'mod_sftp_pam.c' => {
         AuthOrder => 'mod_sftp_pam.c* mod_auth_unix.c',
-      }, 
+      },
     },
   };
 
@@ -291,7 +291,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -361,7 +361,7 @@ EOS
 
       'mod_sftp_pam.c' => {
         AuthOrder => 'mod_sftp_pam.c* mod_sql.c',
-      }, 
+      },
 
       'mod_sql.c' => {
         SQLAuthTypes => 'plaintext',

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp_sql.pm
@@ -139,7 +139,7 @@ sub list_tests {
 sub set_up {
   my $self = shift;
   $self->SUPER::set_up(@_);
-  
+
   # Make sure that mod_sftp does not complain about permissions on the hostkey
   # files.
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_shaper.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_shaper.pm
@@ -107,7 +107,7 @@ sub shaper_sighup {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -158,7 +158,7 @@ sub shaper_sighup {
 
   # Finally, stop the server
   server_stop($pid_file);
- 
+
   unlink($log_file);
 }
 
@@ -183,7 +183,7 @@ sub shaper_queue_dos {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -315,7 +315,7 @@ sub shaper_resumed_download_bug3928 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -405,7 +405,7 @@ sub shaper_resumed_download_bug3928 {
       while ($conn->read($tmp, 32768, 15)) {
         $buf .= $tmp;
       }
- 
+
       eval { $conn->close() };
 
       my $resp_code = $client->response_code();
@@ -468,7 +468,7 @@ sub shaper_sighup_shaperlog_bug4077 {
   my $home_dir = File::Spec->rel2abs($tmpdir);
   my $uid = 500;
   my $gid = 500;
-  
+
   # Make sure that, if we're running as root, that the home directory has
   # permissions/privs set for the account we create
   if ($< == 0) {
@@ -543,7 +543,7 @@ sub shaper_sighup_shaperlog_bug4077 {
   my $expected_nfds = $orig_nfds-1;
   $self->assert($expected_nfds == $restart_nfds,
     test_msg("Expected $expected_nfds open fds, found $restart_nfds"));
- 
+
   unlink($log_file);
 }
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_site_misc.pm
@@ -1578,7 +1578,7 @@ sub site_misc_symlink_ncftpd_chroot_bug {
 
       $resp_code = $client->response_code();
       $resp_msg = $client->response_msg();
-       
+
       $expected = 550;
       $self->assert($expected == $resp_code,
         test_msg("Expected $expected, got $resp_code"));

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp.pm
@@ -556,7 +556,7 @@ sub snmp_start_existing_dirs {
 
   # First, start the server
   server_start($config_file);
-  
+
   # ...then stop the server.  This means mod_snmp will have created all
   # the necessary directories, etc.
   sleep(2);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/ban.pm
@@ -370,7 +370,7 @@ sub snmp_ban_v1_get_conn_info {
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
-    eval { 
+    eval {
       # Give the server time to start up
       sleep(1);
 
@@ -495,7 +495,7 @@ sub snmp_ban_v1_get_conn_info {
         test_msg("Expected class banned total $expected, got $class_banned"));
 
     };
- 
+
     if ($@) {
       $ex = $@;
     }
@@ -630,7 +630,7 @@ sub snmp_ban_v1_get_ban_info {
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");
   if ($pid) {
-    eval { 
+    eval {
       # Give the server time to start up
       sleep(1);
 
@@ -723,7 +723,7 @@ sub snmp_ban_v1_get_ban_info {
 
       # Now wait for the ban to expire, then try again (and check stats)
       sleep($ban_expiry_secs + 2);
-      
+
       $client1 = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client1->login($user, $passwd);
       $client1->quit();
@@ -763,7 +763,7 @@ sub snmp_ban_v1_get_ban_info {
       $self->assert($ban_info->{class_ban_total} == $expected,
         test_msg("Expected class ban total $expected, got $ban_info->{class_ban_total}"));
     };
- 
+
     if ($@) {
       $ex = $@;
     }

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/sftp.pm
@@ -399,7 +399,7 @@ sub list_dir {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
     die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
   }
- 
+
   my $sftp = $ssh2->sftp();
   unless ($sftp) {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -419,7 +419,7 @@ sub list_dir {
     $res->{$file->{name}} = $file;
     $file = $dir->read();
   }
- 
+
   # To issue the FXP_CLOSE, we have to explicitly destroy the filehandle
   $dir = undef;
 
@@ -449,7 +449,7 @@ sub download_file {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
     die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
   }
- 
+
   my $sftp = $ssh2->sftp();
   unless ($sftp) {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -501,7 +501,7 @@ sub upload_file {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
     die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
   }
- 
+
   my $sftp = $ssh2->sftp();
   unless ($sftp) {
     my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -514,7 +514,7 @@ sub upload_file {
     die("Can't open $file_path: [$err_name] ($err_code)");
   }
 
-  for (my $i = 0; $i < 1024; $i++) { 
+  for (my $i = 0; $i < 1024; $i++) {
     my $buf = ("A" x $file_kb_len);
     print $fh $buf;
   }
@@ -670,7 +670,7 @@ sub snmp_sftp_v1_get_sess_counts {
       unless ($ssh2->auth_password($user, $passwd)) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
-      } 
+      }
 
       # Then, get the session counts again.  Since we've logged in, but NOT
       # yet requested the SFTP service, the counts should still be zero.

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/tls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_snmp/tls.pm
@@ -450,7 +450,7 @@ sub upload_file {
   }
 
   if (open(my $fh, "> $test_file")) {
-    my $buf = ("A" x ($file_kb_len * 1024)); 
+    my $buf = ("A" x ($file_kb_len * 1024));
     print $fh $buf;
 
     unless (close($fh)) {

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_odbc.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_odbc.pm
@@ -294,7 +294,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -410,7 +410,7 @@ EOI
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_passwd.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_passwd.pm
@@ -491,7 +491,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$setup->{user}', '$passwd', $setup->{uid}, $setup->{gid}, '$setup->{home_dir}', '/bin/bash');
@@ -575,7 +575,7 @@ EOS
 
       my $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -641,7 +641,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -725,7 +725,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -802,7 +802,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -886,7 +886,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -962,7 +962,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1046,7 +1046,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -1122,7 +1122,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1206,7 +1206,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -1283,7 +1283,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1367,7 +1367,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -1443,7 +1443,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1530,7 +1530,7 @@ EOS
 
       $expected = 530;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code")); 
+        test_msg("Expected $expected, got $resp_code"));
 
       $expected = "Login incorrect.";
       $self->assert($expected eq $resp_msg,
@@ -1607,7 +1607,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1705,7 +1705,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -1783,7 +1783,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1884,7 +1884,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -1962,7 +1962,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2060,7 +2060,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2136,7 +2136,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2220,7 +2220,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2296,7 +2296,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2380,7 +2380,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2457,7 +2457,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2541,7 +2541,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2617,7 +2617,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2701,7 +2701,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2777,7 +2777,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2861,7 +2861,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2938,7 +2938,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3022,7 +3022,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3098,7 +3098,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3183,7 +3183,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3260,7 +3260,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3352,7 +3352,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3434,7 +3434,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3531,7 +3531,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3611,7 +3611,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3701,7 +3701,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3784,7 +3784,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3880,7 +3880,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3964,7 +3964,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4063,7 +4063,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4143,7 +4143,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4231,7 +4231,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4312,7 +4312,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4407,7 +4407,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4489,7 +4489,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4586,7 +4586,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4668,7 +4668,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$db_passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4763,7 +4763,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4850,7 +4850,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -4951,7 +4951,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5034,7 +5034,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -5135,7 +5135,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5218,7 +5218,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -5319,7 +5319,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5392,7 +5392,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -5493,7 +5493,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5580,7 +5580,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -5690,7 +5690,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5768,7 +5768,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -5877,7 +5877,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -5955,7 +5955,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6048,7 +6048,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6126,7 +6126,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6219,7 +6219,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6297,7 +6297,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6390,7 +6390,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6469,7 +6469,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6568,7 +6568,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6647,7 +6647,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6746,7 +6746,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6825,7 +6825,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -6924,7 +6924,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_passwd/FIPS.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_passwd/FIPS.pm
@@ -71,7 +71,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', 500, 500, '$home_dir', '/bin/bash');
@@ -158,7 +158,7 @@ EOS
 
       $expected = 530;
       $self->assert($expected == $resp_code,
-        test_msg("Expected response code $expected, got $resp_code")); 
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "Login incorrect.";
       $self->assert($expected eq $resp_msg,
@@ -233,7 +233,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', 500, 500, '$home_dir', '/bin/bash');
@@ -317,7 +317,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -521,7 +521,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -658,7 +658,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 
@@ -812,7 +812,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', 500, 500, '$home_dir', '/bin/bash');
@@ -947,7 +947,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', 500, 500, '$home_dir', '/bin/bash');
@@ -1084,7 +1084,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', 500, 500, '$home_dir', '/bin/bash');
@@ -1220,7 +1220,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   allowed TEXT
 );
@@ -1355,7 +1355,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   allowed_ip TEXT
 );
@@ -1497,7 +1497,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -1644,7 +1644,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   host TEXT
 );
@@ -2129,7 +2129,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO ftpusers (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -2210,7 +2210,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2291,7 +2291,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -2378,7 +2378,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2463,7 +2463,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -2549,7 +2549,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2618,7 +2618,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -2708,7 +2708,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2777,7 +2777,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -2868,7 +2868,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -2949,7 +2949,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3034,7 +3034,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3115,7 +3115,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3201,7 +3201,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3282,7 +3282,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -3369,7 +3369,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3818,7 +3818,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -3898,7 +3898,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -3967,7 +3967,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -4047,7 +4047,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -4440,7 +4440,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -4528,7 +4528,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -6622,7 +6622,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -6781,7 +6781,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -6871,7 +6871,7 @@ EOS
 
       my $expected = 230;
       $self->assert($expected == $resp_code,
-        "Expected response code $expected, got $resp_code"); 
+        "Expected response code $expected, got $resp_code");
 
       $expected = "User $setup->{user} logged in";
       $self->assert($expected eq $resp_msg,
@@ -6891,7 +6891,7 @@ EOS
 
       $expected = 226;
       $self->assert($expected == $resp_code,
-        "Expected response code $expected, got $resp_code"); 
+        "Expected response code $expected, got $resp_code");
 
       my $resp_msgs = $client->response_msgs();
       my $nmsgs = scalar(@$resp_msgs);
@@ -6970,7 +6970,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 EOU
@@ -7182,7 +7182,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -8244,7 +8244,7 @@ CREATE TABLE ftpusers (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   lastdir TEXT
 );
@@ -8365,7 +8365,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -8475,7 +8475,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -8585,7 +8585,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -11992,7 +11992,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   secure_only INTEGER
 );
@@ -12096,7 +12096,7 @@ EOS
       my $nmsgs = scalar(@$resp_msgs);
 
       my $expected = 4;
-      $self->assert($expected == $nmsgs, "Expected $expected, got $nmsgs"); 
+      $self->assert($expected == $nmsgs, "Expected $expected, got $nmsgs");
 
       $expected = "Login incorrect.";
       $self->assert($expected eq $resp_msgs->[0],
@@ -13401,7 +13401,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -13578,7 +13578,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT,
   primary_key INTEGER
 );
@@ -13757,7 +13757,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -13922,7 +13922,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$setup->{user}', '$setup->{passwd}', $setup->{uid}, $setup->{gid}, '$setup->{home_dir}', '/bin/bash');
@@ -14346,7 +14346,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -14500,7 +14500,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],
@@ -14570,7 +14570,7 @@ CREATE TABLE users (
   passwd TEXT,
   uid INTEGER,
   gid INTEGER,
-  homedir TEXT, 
+  homedir TEXT,
   shell TEXT
 );
 INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$user', '$passwd', $uid, $gid, '$home_dir', '/bin/bash');
@@ -14649,7 +14649,7 @@ EOS
 
       $expected = 1;
       $self->assert($expected == $nmsgs,
-        test_msg("Expected $expected, got $nmsgs")); 
+        test_msg("Expected $expected, got $nmsgs"));
 
       $expected = "User proftpd logged in";
       $self->assert($expected eq $resp_msgs->[0],

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache.pm
@@ -1045,7 +1045,7 @@ sub statcache_dir_chrooted {
       $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
       ($resp_code, $resp_msg) = $client->mlst('test.d');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -1283,7 +1283,7 @@ sub statcache_rel_symlink_file {
       $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
       ($resp_code, $resp_msg) = $client->mlst('test.lnk');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -1530,7 +1530,7 @@ sub statcache_rel_symlink_file_chrooted {
       $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
       ($resp_code, $resp_msg) = $client->mlst('test.lnk');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -1765,7 +1765,7 @@ sub statcache_rel_symlink_dir {
       $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
       ($resp_code, $resp_msg) = $client->mlst('test.lnk');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
@@ -2004,7 +2004,7 @@ sub statcache_rel_symlink_dir_chrooted {
       $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
       $client->login($user, $passwd);
       ($resp_code, $resp_msg) = $client->mlst('test.lnk');
-    
+
       $expected = 250;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache/sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_statcache/sftp.pm
@@ -169,7 +169,7 @@ sub statcache_sftp_stat_file {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
- 
+
       my $sftp = $ssh2->sftp();
       unless ($sftp) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -446,7 +446,7 @@ sub statcache_sftp_stat_dir {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
- 
+
       my $sftp = $ssh2->sftp();
       unless ($sftp) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
@@ -704,7 +704,7 @@ sub statcache_sftp_upload_file {
         my ($err_code, $err_name, $err_str) = $ssh2->error();
         die("Can't login to SSH2 server: [$err_name] ($err_code) $err_str");
       }
- 
+
       my $sftp = $ssh2->sftp();
       unless ($sftp) {
         my ($err_code, $err_name, $err_str) = $ssh2->error();

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
@@ -3889,7 +3889,7 @@ sub tls_list_no_session_reuse {
       # Since we are requiring SSL session reuse for data transfers,
       # and this client is not using SSL session resumption, I expect
       # this data transfer to fail.
-      eval { 
+      eval {
         my $res = $client->list('.');
         if ($res) {
           die("LIST succeeded unexpectedly");
@@ -5380,9 +5380,9 @@ sub tls_opts_std_env_vars_client_vars {
         my $issuer_dn = $2;
 
         $self->assert(length($subj_dn) > 0,
-          test_msg("Expected subject DN, got '$subj_dn'"));      
+          test_msg("Expected subject DN, got '$subj_dn'"));
         $self->assert(length($issuer_dn) > 0,
-          test_msg("Expected issuer DN, got '$issuer_dn'"));      
+          test_msg("Expected issuer DN, got '$issuer_dn'"));
 
         $ok = 1;
         last;
@@ -5509,7 +5509,7 @@ sub tls_opts_ipaddr_required_ipv4 {
         );
       };
 
-      unless ($@) { 
+      unless ($@) {
         die("Connection to server succeeded unexpectedly");
       }
 
@@ -5665,7 +5665,7 @@ sub tls_opts_ipaddr_required_ipv6 {
         );
       };
 
-      unless ($@) { 
+      unless ($@) {
         die("Connection to server succeeded unexpectedly");
       }
 
@@ -6871,7 +6871,7 @@ sub tls_rest_2gb_last_byte {
   unless (open($tmp_fh, "> $tmp_file")) {
     die("Can't open $tmp_file: $!");
   }
- 
+
   my $config = {
     PidFile => $pid_file,
     ScoreboardFile => $scoreboard_file,
@@ -7083,7 +7083,7 @@ sub tls_rest_4gb_last_byte {
   unless (open($tmp_fh, "> $tmp_file")) {
     die("Can't open $tmp_file: $!");
   }
- 
+
   my $config = {
     PidFile => $pid_file,
     ScoreboardFile => $scoreboard_file,
@@ -8254,7 +8254,7 @@ sub tls_opts_commonname_required_bug3512 {
         );
       };
 
-      unless ($@) { 
+      unless ($@) {
         eval { $client->login($user, $passwd) };
         unless ($@) {
           die("Login succeeded unexpectedly");
@@ -8420,7 +8420,7 @@ sub tls_opts_dns_name_required {
         );
       };
 
-      unless ($@) { 
+      unless ($@) {
         eval { $client->login($user, $passwd) };
         unless ($@) {
           die("Login succeeded unexpectedly");
@@ -8586,7 +8586,7 @@ sub tls_opts_ip_addr_dns_name_cn_required {
         );
       };
 
-      unless ($@) { 
+      unless ($@) {
         eval { $client->login($user, $passwd) };
         unless ($@) {
           die("Login succeeded unexpectedly");
@@ -8751,7 +8751,7 @@ sub tls_site_chmod_ok {
 
       unless ($client->site("CHMOD 777 test.txt")) {
         die("SITE CHMOD failed: " . $client->last_message());
-      } 
+      }
 
       my $resp = $client->last_message();
 
@@ -10606,7 +10606,7 @@ sub tls_client_cert_verify_failed_selfsigned_cert_only_bug3742 {
         #
         #  error:14094418:SSL routines:SSL3_READ_BYTES:tlsv1 alert unknown ca
 
-        unless ($@) { 
+        unless ($@) {
           die("Successfully connected to FTPS server unexpectedly");
         }
 
@@ -10721,7 +10721,7 @@ sub tls_client_cert_verify_failed_selfsigned_cert_in_chain_bug3742 {
       close($infh);
 
       print $outfh $data;
-    
+
     } else {
       die("Can't read $cert: $!");
     }
@@ -10805,7 +10805,7 @@ sub tls_client_cert_verify_failed_selfsigned_cert_in_chain_bug3742 {
         #
         #  error:14094418:SSL routines:SSL3_READ_BYTES:tlsv1 alert unknown ca
 
-        unless ($@) { 
+        unless ($@) {
           die("Successfully connected to FTPS server unexpectedly");
         }
 
@@ -10890,7 +10890,7 @@ sub tls_client_cert_verify_ok_server_selfsigned_cert_in_chain_bug3742 {
       close($infh);
 
       print $outfh $data;
-    
+
     } else {
       die("Can't read $cert: $!");
     }
@@ -13616,8 +13616,8 @@ sub tls_sscn_toggle_bug3955 {
 
       } else {
         $resp_code = $client->quot('SSCN', 'ON');
-      } 
-      
+      }
+
       unless ($resp_code == 2) {
         die("SSCN failed: " . $client->last_message());
       }

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_tls_memcache.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_tls_memcache.pm
@@ -414,7 +414,7 @@ my $openssl = '/Users/tj/local/openssl-1.0.2d/bin/openssl';
         '-starttls',
         'ftp',
         '-sess_out',
-        $sessid_file, 
+        $sessid_file,
       );
 
       my $tls_rh = IO::Handle->new();
@@ -478,7 +478,7 @@ my $openssl = '/Users/tj/local/openssl-1.0.2d/bin/openssl';
         '-starttls',
         'ftp',
         '-sess_in',
-        $sessid_file, 
+        $sessid_file,
       );
 
       $tls_rh = IO::Handle->new();

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_file.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_file.pm
@@ -3248,7 +3248,7 @@ sub wrap2_file_user_plus_global_tables {
 
       my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
- 
+
       my $expected;
 
       $expected = 530;
@@ -3609,7 +3609,7 @@ sub wrap2_sftp_extlog_user_bug3727 {
   my $ex;
 
   # Ignore SIGPIPE
-  local $SIG{PIPE} = sub { }; 
+  local $SIG{PIPE} = sub { };
 
   # Fork child
   $self->handle_sigchld();

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_redis.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_redis.pm
@@ -1578,7 +1578,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
       );
       unless ($client) {
         die("Can't connect to ::1: $!");
-      } 
+      }
 
       # Read the banner
       my $banner = <$client>;
@@ -1593,7 +1593,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
 
       my $expected = "331 Password required for $setup->{user}\r\n";
       $self->assert($expected eq $resp, "Expected '$expected', got '$resp'");
- 
+
       # Send the PASS command
       $cmd = "PASS $setup->{passwd}\r\n";
       $client->print($cmd);
@@ -1604,7 +1604,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
 
       $expected = "530 Access denied\r\n";
       $self->assert($expected eq $resp, "Expected '$expected', got '$resp'");
- 
+
       $client->close();
     };
 
@@ -1647,7 +1647,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
     );
     unless ($client) {
       die("Can't connect to ::1: $!");
-    } 
+    }
 
     # Read the banner
     my $banner = <$client>;
@@ -1662,7 +1662,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
 
     my $expected = "331 Password required for $setup->{user}\r\n";
     $self->assert($expected eq $resp, "Expected '$expected', got '$resp'");
- 
+
     # Send the PASS command
     $cmd = "PASS $setup->{passwd}\r\n";
     $client->print($cmd);
@@ -1673,7 +1673,7 @@ sub wrap2_redis_deny_list_ipv6_netmask_bug3606 {
 
     $expected = "530 Access denied\r\n";
     $self->assert($expected eq $resp, "Expected '$expected', got '$resp'");
- 
+
     $client->close();
   };
 
@@ -2357,7 +2357,7 @@ sub wrap2_bug3341 {
       }
 
       my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg(); 
+      my $resp_msg = $client->response_msg();
 
       my $expected;
 
@@ -2376,7 +2376,7 @@ sub wrap2_bug3341 {
       }
 
       $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg(); 
+      $resp_msg = $client->response_msg();
 
       $expected = 530;
       $self->assert($expected == $resp_code,
@@ -2686,7 +2686,7 @@ sub wrap2_allow_msg_anon_bug3538 {
       $setup->{home_dir} => {
         User => $test_user,
         Group => $test_group,
-        UserAlias => "anonymous $test_user", 
+        UserAlias => "anonymous $test_user",
         RequireValidShell => 'off',
       },
     },

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_sql.pm
@@ -2129,7 +2129,7 @@ EOS
       );
       unless ($client) {
         die("Can't connect to ::1: $!");
-      } 
+      }
 
       # Read the banner
       my $banner = <$client>;
@@ -2145,7 +2145,7 @@ EOS
       my $expected = "331 Password required for $user\r\n";
       $self->assert($expected eq $resp,
         test_msg("Expected '$expected', got '$resp'"));
- 
+
       # Send the PASS command
       $cmd = "PASS $passwd\r\n";
       $client->print($cmd);
@@ -2157,7 +2157,7 @@ EOS
       $expected = "530 Access denied\r\n";
       $self->assert($expected eq $resp,
         test_msg("Expected '$expected', got '$resp'"));
- 
+
       $client->close();
     };
 
@@ -2227,7 +2227,7 @@ EOS
       );
       unless ($client) {
         die("Can't connect to ::1: $!");
-      } 
+      }
 
       # Read the banner
       my $banner = <$client>;
@@ -2243,7 +2243,7 @@ EOS
       my $expected = "331 Password required for $user\r\n";
       $self->assert($expected eq $resp,
         test_msg("Expected '$expected', got '$resp'"));
- 
+
       # Send the PASS command
       $cmd = "PASS $passwd\r\n";
       $client->print($cmd);
@@ -2255,7 +2255,7 @@ EOS
       $expected = "530 Access denied\r\n";
       $self->assert($expected eq $resp,
         test_msg("Expected '$expected', got '$resp'"));
- 
+
       $client->close();
     };
 
@@ -3557,7 +3557,7 @@ EOS
       }
 
       my $resp_code = $client->response_code();
-      my $resp_msg = $client->response_msg(); 
+      my $resp_msg = $client->response_msg();
 
       my $expected;
 
@@ -3576,7 +3576,7 @@ EOS
       }
 
       $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg(); 
+      $resp_msg = $client->response_msg();
 
       $expected = 530;
       $self->assert($expected == $resp_code,
@@ -4181,7 +4181,7 @@ EOS
       $home_dir => {
         User => $test_user,
         Group => $test_group,
-        UserAlias => "anonymous $test_user", 
+        UserAlias => "anonymous $test_user",
         RequireValidShell => 'off',
       },
     },

--- a/tests/t/lib/ProFTPD/Tests/SSH2.pm
+++ b/tests/t/lib/ProFTPD/Tests/SSH2.pm
@@ -95,7 +95,7 @@ sub ssh2_session {
         print STDERR "# Sending request: $req";
       }
       $client->print($req);
-      $client->flush(); 
+      $client->flush();
 
       my $resp = <$client>;
       if ($ENV{TEST_VEROBSE}) {

--- a/tests/t/lib/ProFTPD/Tests/Signals/ABRT.pm
+++ b/tests/t/lib/ProFTPD/Tests/Signals/ABRT.pm
@@ -77,7 +77,7 @@ sub abrt_daemon_ok {
   my $ex;
 
   # Start server
-  server_start($config_file); 
+  server_start($config_file);
 
   # Allow a short interval between startup and shutdown
   sleep(1);

--- a/tests/t/lib/ProFTPD/Tests/Signals/HUP.pm
+++ b/tests/t/lib/ProFTPD/Tests/Signals/HUP.pm
@@ -290,7 +290,7 @@ EOC
   }
 
   # Start server
-  server_start($config_file); 
+  server_start($config_file);
 
   # Give the server some time to start up
   sleep(2);
@@ -426,7 +426,7 @@ sub hup_allowoverwrite_bug3740 {
     AuthOrder => 'mod_auth_file.c',
 
     AllowOverwrite => 'on',
- 
+
     IfModules => {
       'mod_delay.c' => {
         DelayEngine => 'off',
@@ -457,7 +457,7 @@ EOC
   }
 
   # Start server
-  server_start($config_file); 
+  server_start($config_file);
 
   my $nattempts = 10;
 

--- a/tests/t/lib/ProFTPD/Tests/Signals/SEGV.pm
+++ b/tests/t/lib/ProFTPD/Tests/Signals/SEGV.pm
@@ -77,7 +77,7 @@ sub segv_daemon_ok {
   my $ex;
 
   # Start server
-  server_start($config_file); 
+  server_start($config_file);
 
   # Allow a short interval between startup and shutdown
   sleep(1);

--- a/tests/t/lib/ProFTPD/Tests/Signals/TERM.pm
+++ b/tests/t/lib/ProFTPD/Tests/Signals/TERM.pm
@@ -56,7 +56,7 @@ sub term_daemon_ok {
   my $ex;
 
   # Start server
-  server_start($config_file); 
+  server_start($config_file);
 
   # Allow a short interval between startup and shutdown
   sleep(1);

--- a/tests/t/lib/ProFTPD/Tests/Telnet.pm
+++ b/tests/t/lib/ProFTPD/Tests/Telnet.pm
@@ -165,7 +165,7 @@ sub telnet_iac_bug3521 {
         die("USER succeeded expectedly");
       }
 
-      my $ex = $client->errmsg();    
+      my $ex = $client->errmsg();
       unless ($ex =~ /^command\s+timed/) {
         die("Unexpected exception thrown: $ex");
       }

--- a/tests/t/lib/ProFTPD/Tests/Utils/ftpcount.pm
+++ b/tests/t/lib/ProFTPD/Tests/Utils/ftpcount.pm
@@ -131,7 +131,7 @@ sub ftpcount_ok {
   }
 
   my $ex;
- 
+
   # Fork child
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");

--- a/tests/t/lib/ProFTPD/Tests/Utils/ftpwho.pm
+++ b/tests/t/lib/ProFTPD/Tests/Utils/ftpwho.pm
@@ -144,7 +144,7 @@ sub ftpwho_ok {
   }
 
   my $ex;
- 
+
   # Fork child
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");
@@ -291,7 +291,7 @@ sub ftpwho_verbose_ok {
   }
 
   my $ex;
- 
+
   # Fork child
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");
@@ -447,7 +447,7 @@ sub ftpwho_bug3714 {
   }
 
   my $ex;
- 
+
   # Fork child
   $self->handle_sigchld();
   defined(my $pid = fork()) or die("Can't fork: $!");
@@ -462,7 +462,7 @@ sub ftpwho_bug3714 {
         die("RETR $config_file failed: " . $client->response_code() . " " .
           $client->response_msg());
       }
- 
+
       # Before we stop the server, use ftpwho to read the scoreboard
       ftpwho($scoreboard_file, '', $ftpwho_file);
 

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -58,6 +58,7 @@ if (scalar(@ARGV) > 0) {
     t/smtp.t
     t/ssh2.t
     t/logins.t
+    t/commands.t
     t/commands/user.t
     t/commands/pass.t
     t/commands/pwd.t
@@ -69,7 +70,7 @@ if (scalar(@ARGV) > 0) {
     t/commands/rmd.t
     t/commands/dele.t
     t/commands/mdtm.t
-    t/commands/size.t 
+    t/commands/size.t
     t/commands/mode.t
     t/commands/stru.t
     t/commands/allo.t
@@ -129,7 +130,7 @@ if (scalar(@ARGV) > 0) {
     t/config/dirfakeuser.t
     t/config/displaychdir.t
     t/config/displayconnect.t
-    t/config/displayfiletransfer.t 
+    t/config/displayfiletransfer.t
     t/config/displaylogin.t
     t/config/displayquit.t
     t/config/envvars.t


### PR DESCRIPTION
Discovered using:
```
find . -type f -name "*.pm" -print | xargs egrep -n '.* +$' | wc -l
```
No functional change.