### PR TITLE
Issue #1639: When directory creation requests (FTP and SFTP) are rece…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,8 @@
   ExtendedLog class.
 - Issue 1630 - Update mod_exec to use the Jot API for resolving variables.
 - Issue 1636 - Use system TCP backlog value by default.
+- Issue 1639 - Gracefully handle directory creation requests when the directory
+  already exists.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -5777,8 +5777,9 @@ MODRET core_mkd(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-  if (pr_fsio_smkdir(cmd->tmp_pool, dir, 0777, session.fsuid,
-      session.fsgid) < 0) {
+  res = pr_fsio_smkdir(cmd->tmp_pool, dir, 0777, session.fsuid, session.fsgid);
+  if (res < 0 &&
+      errno != EEXIST) {
     int xerrno = errno;
 
     (void) pr_trace_msg("fileperms", 1, "%s, user '%s' (UID %s, GID %s): "

--- a/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/MKD.pm
@@ -119,6 +119,11 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  mkd_already_exists_issue1639 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
 };
 
 sub new {
@@ -2086,6 +2091,107 @@ sub mkd_embedded_lf_bug4167 {
 
       $self->assert(-d $sub_dir,
         test_msg("$sub_dir directory does not exist as expected"));
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub mkd_already_exists_issue1639 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'cmds');
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/foo");
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port, 0, 1);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my ($resp_code, $resp_msg) = $client->mkd($sub_dir);
+
+      my $expected = 257;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "\"$sub_dir\" - Directory successfully created";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      # Now send the same command again, even though the directory should
+      # already exist.  Ideally we do not fail with an EEXIST error
+      # (Issue #1639).
+
+      ($resp_code, $resp_msg) = $client->mkd($sub_dir);
+
+      $expected = 257;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "\"$sub_dir\" - Directory successfully created";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      $client->quit();
+      $self->assert(-d $sub_dir,
+        test_msg("$sub_dir directory does not exist as expected"));
+
+      my $perms = ((stat($sub_dir))[2] & 07777);
+      $expected = 0755;
+      $self->assert($expected == $perms,
+        test_msg("Expected perms $expected, got $perms"));
     };
     if ($@) {
       $ex = $@;


### PR DESCRIPTION
…ived for directories that already exist (leading to `EEXIST` errors), gracefully handle such errors as "success".