### PR TITLE
configure: Remove several implicit function declarations

### DIFF
--- a/configure
+++ b/configure
@@ -18312,7 +18312,7 @@ if ${pr_cv_lib_standalone_crypt+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <crypt.h>
 int
 main ()
 {
@@ -18387,7 +18387,7 @@ if ${pr_cv_lib_standalone_gethost+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <netdb.h>
 int
 main ()
 {
@@ -18507,7 +18507,7 @@ if ${pr_cv_lib_standalone_aton+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <arpa/inet.h>
 int
 main ()
 {
@@ -18583,7 +18583,7 @@ else
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <netdb.h>
 int
 main ()
 {
@@ -18658,7 +18658,7 @@ if ${pr_cv_lib_standalone_sockets+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <sys/socket.h>
 int
 main ()
 {

--- a/configure.in
+++ b/configure.in
@@ -1477,7 +1477,7 @@ AC_ARG_ENABLE(transfer-buffer-size,
 
 dnl Checks for libraries.  Yes, this is the hard way, but it's necessary.
 AC_CACHE_CHECK(for standalone crypt,pr_cv_lib_standalone_crypt,
-  AC_TRY_LINK(,[crypt();],
+  AC_TRY_LINK([#include <crypt.h>],[crypt();],
   	pr_cv_lib_standalone_crypt="yes", pr_cv_lib_standalone_crypt="no" ))
 
 if test "$pr_cv_lib_standalone_crypt" = "no"; then
@@ -1485,7 +1485,7 @@ if test "$pr_cv_lib_standalone_crypt" = "no"; then
 fi
 
 AC_CACHE_CHECK(for standalone gethostbyname,pr_cv_lib_standalone_gethost,
-  AC_TRY_LINK(,[gethostbyname();],
+  AC_TRY_LINK([#include <netdb.h>],[gethostbyname();],
   	pr_cv_lib_standalone_gethost="yes",
 	pr_cv_lib_standalone_gethost="no" ))
 
@@ -1495,7 +1495,7 @@ if test "$pr_cv_lib_standalone_gethost" = "no"; then
 fi
 
 AC_CACHE_CHECK(for standalone inet_aton,pr_cv_lib_standalone_aton,
-  AC_TRY_LINK(,[inet_aton();],
+  AC_TRY_LINK([#include <arpa/inet.h>],[inet_aton();],
   	pr_cv_lib_standalone_aton="yes",
 	pr_cv_lib_standalone_aton="no" ))
 
@@ -1504,7 +1504,7 @@ if test "$pr_cv_lib_standalone_aton" = "no"; then
 fi
 
 AC_CACHE_CHECK(for standalone nsl functions,pr_cv_lib_standalone_nsl,[
-  AC_TRY_LINK(,[gethostent();],
+  AC_TRY_LINK([#include <netdb.h>],[gethostent();],
   pr_cv_lib_standalone_nsl="yes", pr_cv_lib_standalone_nsl="no") ])
 
 if test "$pr_cv_lib_standalone_nsl" = "no"; then
@@ -1512,7 +1512,7 @@ if test "$pr_cv_lib_standalone_nsl" = "no"; then
 fi
 
 AC_CACHE_CHECK(for standalone socket functions,pr_cv_lib_standalone_sockets,
-  AC_TRY_LINK(,[bind();],
+  AC_TRY_LINK([#include <sys/socket.h>],[bind();],
   pr_cv_lib_standalone_sockets="yes", pr_cv_lib_standalone_sockets="no"))
 
 if test "$pr_cv_lib_standalone_sockets" = "no"; then


### PR DESCRIPTION
During configure, some checks omit the corresponding include. A compiler defaulting to C99 mode could cause those checks to fail since C99 does not allow implicit function declarations.  This commit fixes the same. The configure script is re-generated.