### PR TITLE
Add support for sending SSH_MSG_DEBUG messages

### DIFF
--- a/contrib/mod_sftp/Makefile.in
+++ b/contrib/mod_sftp/Makefile.in
@@ -19,13 +19,13 @@ MODULE_OBJS=mod_sftp.o msg.o packet.o cipher.o mac.o umac.o umac128.o \
   compress.o kex.o keys.o crypto.o utf8.o session.o service.o kbdint.o \
   auth-hostbased.o auth-kbdint.o auth-password.o auth-publickey.o auth.o \
   disconnect.o rfc4716.o keystore.o channel.o blacklist.o agent.o \
-  interop.o tap.o fxp.o scp.o display.o misc.o date.o bcrypt.o
+  interop.o tap.o fxp.o scp.o display.o misc.o date.o bcrypt.o debug.o
 SHARED_MODULE_OBJS=mod_sftp.lo msg.lo packet.lo cipher.lo mac.lo umac.lo \
   umac128.lo compress.lo kex.lo keys.lo crypto.lo utf8.lo session.lo \
   service.lo kbdint.lo auth-hostbased.lo auth-kbdint.lo auth-password.lo \
   auth-publickey.lo auth.lo disconnect.lo rfc4716.lo keystore.lo channel.lo \
   blacklist.lo agent.lo interop.lo tap.lo fxp.lo scp.lo display.lo misc.lo \
-  date.lo bcrypt.lo
+  date.lo bcrypt.lo debug.lo
 
 # Necessary redefinitions
 INCLUDES=-I. -I../.. -I../../include -I$(top_srcdir)/../../include @INCLUDES@

--- a/contrib/mod_sftp/debug.c
+++ b/contrib/mod_sftp/debug.c
@@ -1,0 +1,80 @@
+/*
+ * ProFTPD - mod_sftp debug msgs
+ * Copyright (c) 2008-2017 TJ Saunders
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, TJ Saunders and other respective copyright holders
+ * give permission to link this program with OpenSSL, and distribute the
+ * resulting executable, without including the source code for OpenSSL in the
+ * source distribution.
+ */
+
+#include "mod_sftp.h"
+#include "ssh2.h"
+#include "msg.h"
+#include "packet.h"
+#include "debug.h"
+
+extern module sftp_module;
+
+static const char *trace_channel = "ssh2";
+
+static char debug_buf[SFTP_SSH2_DEBUG_MSG_MAX] = {'\0'};
+
+void sftp_debug_message(unsigned char always_show, const char *fmt, ...) {
+  struct ssh2_packet *pkt;
+  const char *lang = "en-US";
+  unsigned char *buf, *ptr;
+  uint32_t buflen, bufsz;
+  int res;
+  va_list msg;
+
+  if (fmt == NULL) {
+    return;
+  }
+
+  va_start(msg, fmt);
+  res = pr_vsnprintf(debug_buf, sizeof(debug_buf), fmt, msg);
+  va_end(msg);
+
+  debug_buf[sizeof(debug_buf) - 1] = '\0';
+
+  /* Send the client a DEBUG mesg. */
+  pkt = sftp_ssh2_packet_create(sftp_pool);
+
+  buflen = bufsz = SFTP_SSH2_DEBUG_MSG_MAX * 2;;
+  ptr = buf = palloc(pkt->pool, bufsz);
+
+  pr_trace_msg(trace_channel, 9, "debug message: '%s'", debug_buf);
+
+  sftp_msg_write_byte(&buf, &buflen, SFTP_SSH2_MSG_DEBUG);
+  sftp_msg_write_bool(&buf, &buflen, always_show);
+  sftp_msg_write_string(&buf, &buflen, debug_buf);
+  sftp_msg_write_string(&buf, &buflen, lang);
+
+  pkt->payload = ptr;
+  pkt->payload_len = (bufsz - buflen);
+
+  if (sftp_ssh2_packet_write(sftp_conn->wfd, pkt) < 0) {
+    int xerrno = errno;
+
+    pr_trace_msg(trace_channel, 12,
+      "error writing DEBUG message: %s", strerror(xerrno));
+  }
+
+  destroy_pool(pkt->pool);
+}
+

--- a/contrib/mod_sftp/debug.h
+++ b/contrib/mod_sftp/debug.h
@@ -1,0 +1,34 @@
+/*
+ * ProFTPD - mod_sftp debug msgs
+ * Copyright (c) 2008-2016 TJ Saunders
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+ *
+ * As a special exemption, TJ Saunders and other respective copyright holders
+ * give permission to link this program with OpenSSL, and distribute the
+ * resulting executable, without including the source code for OpenSSL in the
+ * source distribution.
+ */
+
+#ifndef MOD_SFTP_DEBUG_H
+#define MOD_SFTP_DEBUG_H
+
+#include "mod_sftp.h"
+
+#define SFTP_SSH2_DEBUG_MSG_MAX 1024
+
+void sftp_debug_message(unsigned char always_show, const char *fmt, ...);
+
+#endif /* MOD_SFTP_DEBUG_H */


### PR DESCRIPTION
This adds files debug.c and debug.h, which provide the function sftp_debug_message for sending a SSH_MSG_DEBUG message back to the client.  Not terribly useful, but I've been playing with mod_clamav and wanted a way to report virus detections to SFTP clients and not just FTP.  Of course, the client is free to ignore the messages per the RFC, but it's better than nothing.

I copied the files disconnect.c and disconnect.h and then filed off the serial #s, so to speak, which is why the headers are the way they are (dates, copyright), but I freely assign my portion of copyright on them to you in any event.