### PR TITLE
Update fsio.c - if mkdir fails with EEXIST also clear the cache

### DIFF
--- a/src/fsio.c
+++ b/src/fsio.c
@@ -4071,7 +4071,7 @@ int pr_fsio_mkdir(const char *path, mode_t mode) {
   res = (fs->mkdir)(fs, path, mode);
   xerrno = errno;
 
-  if (res == 0) {
+  if (res == 0 || xerrno == EEXIST) {
     pr_fs_clear_cache2(path);
   }
 


### PR DESCRIPTION
Rationale: if you have two (or more) ftp connections that want to create a mostly identical directory tree, and MKD the same directory single-digit msec apart, the slower client gets a failure and can't work with the new directory. With the patch, the client still gets a failure but can use the directory afterwards.