### PR TITLE
Issue #1679: Update the handling of the `Protocols` directive in the …

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -13424,33 +13424,43 @@ MODRET tls_post_pass(cmd_rec *cmd) {
 
     if (protocols_config != NULL) {
       register unsigned int i;
-      int allow_ftps = FALSE;
+      int allow_sess = FALSE;
       array_header *protocols;
       char **elts;
 
       protocols = protocols_config->argv[0];
       elts = protocols->elts;
 
-      /* We only want to check for 'ftps' in the configured Protocols list
-       * if the RFC2228 mechanism is "TLS".
-       */
-      if (session.rfc2228_mech != NULL &&
-          strncmp(session.rfc2228_mech, "TLS", 4) == 0) {
-        for (i = 0; i < protocols->nelts; i++) {
-          char *proto;
+      for (i = 0; i < protocols->nelts; i++) {
+        char *proto;
 
-          proto = elts[i];
-          if (proto != NULL) {
-            if (strncasecmp(proto, "ftps", 5) == 0) {
-              allow_ftps = TRUE;
+        proto = elts[i];
+        if (proto != NULL) {
+          /* We only want to check for 'ftps' in the configured Protocols list
+           * if the RFC2228 mechanism is "TLS".
+           */
+
+          if (strcasecmp(proto, "ftp") == 0) {
+            if (session.rfc2228_mech == NULL ||
+                strcmp(session.rfc2228_mech, "TLS") != 0) {
+              allow_sess = TRUE;
+              break;
+            }
+          }
+
+          if (strcasecmp(proto, "ftps") == 0) {
+            if (session.rfc2228_mech != NULL &&
+                strcmp(session.rfc2228_mech, "TLS") == 0) {
+              allow_sess = TRUE;
               break;
             }
           }
         }
       }
 
-      if (allow_ftps == FALSE) {
-        tls_log("ftps protocol denied by Protocols config");
+      if (allow_sess == FALSE) {
+        tls_log("%s protocol denied by Protocols config",
+          pr_session_get_protocol(0));
         pr_response_send(R_530, "%s", _("Login incorrect."));
         pr_session_disconnect(&tls_module, PR_SESS_DISCONNECT_CONFIG_ACL,
           "Denied by Protocols setting");

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_tls.pm
@@ -231,6 +231,11 @@ my $TESTS = {
     test_class => [qw(bug forking mod_ifsession)],
   },
 
+  tls_opts_allow_per_user_tlsrequired_off_ifsess_protocols_issue1679 => {
+    order => ++$order,
+    test_class => [qw(bug forking mod_ifsession)],
+  },
+
   tls_opts_allow_weak_security_issue1048 => {
     order => ++$order,
     test_class => [qw(forking)],
@@ -6153,6 +6158,116 @@ EOC
   }
 
   unlink($log_file);
+}
+
+sub tls_opts_allow_per_user_tlsrequired_off_ifsess_protocols_issue1679 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'tls');
+
+  my $cert_file = File::Spec->rel2abs('t/etc/modules/mod_tls/server-cert.pem');
+  my $ca_file = File::Spec->rel2abs('t/etc/modules/mod_tls/ca-cert.pem');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    Protocols => 'ftp ftps',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_tls.c' => {
+        TLSEngine => 'on',
+        TLSLog => $setup->{log_file},
+        TLSRequired => 'on',
+        TLSRSACertificateFile => $cert_file,
+        TLSCACertificateFile => $ca_file,
+        TLSOptions => 'AllowPerUser',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  if (open(my $fh, ">> $setup->{config_file}")) {
+    print $fh <<EOC;
+<IfUser $setup->{user}>
+  TLSRequired off
+</IfUser>
+EOC
+    unless (close($fh)) {
+      die("Can't write $setup->{config_file}: $!");
+    }
+
+  } else {
+    die("Can't open $setup->{config_file}: $!");
+  }
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::FTPSSL;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      # Give the server a chance to start up
+      sleep(2);
+
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+
+      my $expected = 230;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "User $setup->{user} logged in";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub tls_opts_allow_per_user_tlsrequired_ctrl_user_login_bug3325 {


### PR DESCRIPTION
…POST_CMD PASS handler of mod_tls, so that cases of plain FTP, allowed by protocols, do not result in session termination unexpectedly.