### PR TITLE
Issue #1640: Support terminating the connection when TLS is required …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@
   values.
 - Issue 1679 - "TLSRequired off" plus Protocols directive causes mod_tls to
   terminate the session abruptly.
+- Issue 1640 - Support terminating connection after USER command when TLS is
+  required.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/contrib/mod_ifsession.c
+++ b/contrib/mod_ifsession.c
@@ -1175,6 +1175,11 @@ MODRET ifsess_post_user(cmd_rec *cmd) {
   session.group = sess_group;
   session.groups = sess_groups;
 
+  /* Stash a session note indicated that we merged in per-user/group settings
+   * for an unauthenticated client, for use by e.g. mod_tls; see Issue #1640.
+   */
+  (void) pr_table_add_dup(session.notes,
+    "mod_ifsession.per-unauthenticated-user", "true", 0);
   return PR_DECLINED(cmd);
 }
 

--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -2346,6 +2346,31 @@ does not recognize/support one of the ciphers that you configured in your
 does not pinpoint <i>which</i> is the offending ciphersuite; experimenting
 with your cipher list will reveal which ones are problematic.
 
+<p><a name="TLSRequiredNoPassword">
+<font color=red>Question</font>: I want to require TLS for most users, but not
+all of them.  When TLS is required for a user, and they have not performed
+the TLS handshake, I want to prevent them from sending their password in
+plaintext.  Is this possible?<br>
+<font color=blue>Answer</font>: Yes, this is possible with the
+<code>mod_ifsession</code> module:
+<pre>
+  &lt;IfModule mod_tls.c&gt;
+    TLSEngine on
+    ...
+    TLSRequired on
+    TLSOptions AllowPerUser
+  &lt;/IfModule&gt;
+
+  &lt;IfModule mod_ifsession.c&gt;
+    # This is required for this use case
+    IfSessionOptions PerUnauthenticatedUser
+
+    &lt;IfUser ftp&gt;
+      TLSRequired off
+    &lt;/IfUser&gt;
+  &lt;/IfModule&gt;
+</pre>
+
 <p>
 <hr>
 <h2><a name="Installation">Installation</a></h2>
@@ -2378,7 +2403,7 @@ in your <code>configure</code> command, <i>e.g.</i>:
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2002-2022 TJ Saunders<br>
+&copy; Copyright 2002-2023 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>


### PR DESCRIPTION
…for a user, and we want to prevent the client from sending their password unencrypted.