### PR TITLE
Fix write size limits in pr_response_send_async

### DIFF
--- a/src/response.c
+++ b/src/response.c
@@ -348,7 +348,7 @@ void pr_response_send_async(const char *resp_numeric, const char *fmt, ...) {
   len = strlen(resp_numeric);
   sstrcat(buf + len, " ", sizeof(buf) - len);
 
-  max_len = sizeof(buf) - len;
+  max_len = sizeof(buf) - (len + 1);
 
   va_start(msg, fmt);
   res = pr_vsnprintf(buf + len + 1, max_len, fmt, msg);
@@ -359,7 +359,7 @@ void pr_response_send_async(const char *resp_numeric, const char *fmt, ...) {
   resp_last_response_code = pstrdup(resp_pool, resp_numeric);
   resp_last_response_msg = pstrdup(resp_pool, buf + len + 1);
 
-  sstrcat(buf + res, "\r\n", sizeof(buf));
+  sstrcat(buf + res, "\r\n", max_len - res);
 
   pr_trace_msg(trace_channel, 1, "async: %s", buf);
   if (resp_handler_cb != NULL) {


### PR DESCRIPTION
Some of the byte count limits for string buffer writes in pr_response_send_async were overly large, not taking into account some optimizations that had been made in the code.

This manifested in buffer overflows being detected in the "response" API test on some architectures (e.g. s390x) with FORTIFY_SOURCE=3; the buffer was not actually overflowing, but the size limit given could have allowed a buffer overflow to occur.

Sample result:
```
./api-tests
Running suite(s): pool
 array
 str
 sets
 timers
 table
 var
 event
 env
 random
 version
 feat
 netaddr
 netacl
 class
 regexp
 expr
 scoreboard
 stash
 modules
Compiled-in modules:
 cmd
 response
*** buffer overflow detected ***: terminated
 fsio
 netio
 trace
2023-07-21 07:30:07,791
[26927] (client 127.0.0.1, server 127.0.0.1:0) <testsuite:5>: alef bet vet?
[26927] <testsuite:5>: alef bet vet?
2023-07-21 07:30:07,793 [26928] <foo:1>: bar?
2023-07-21 07:30:07,794 [26928] <foo:1>: baz!
[26928] <foo:1>: quxx?
[26928] <foo:1>: QUZZ!
 parser
 pidfile
 config
 auth
 filter
 inet
 data
Hello, World!
 ascii
 ctrls
 help
 rlimit
 encode
 privs
 display
 misc
 json
 jot
 redis
 error
99%: Checks: 815, Failures: 0, Errors: 1
api/response.c:331:E:base:response_send_async_test:0: (after this point) Received signal 6 (Aborted)
-------------------------------------------------
 FAILED 1 test
 Please send email to:
   proftp-devel@lists.sourceforge.net
 containing the `api-tests.log' file (in the tests/ directory)
 and the output from running `proftpd -V'
-------------------------------------------------
```