### PR TITLE
Issue #1700: If we fail to acquire a slot/entry in the ScoreboardFile…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,8 @@
 - Issue 1659 - Unknown named connection error when using different SQL backends.
 - Issue 1697 - mod_sql is not properly closing all named backend connections on
   session exit.
+- Issue 1700 - Clients should be disconnected when unable to be added to the
+  ScoreboardFile.
 
 1.3.8 - Released 04-Dec-2022
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -13,6 +13,8 @@ ChangeLog files.
 
       IfSessionOptions PerUnauthenticatedUser
 
+      ScoreboardOptions AllowMissingEntry (Issue #1700)
+
 
   + Changed Directives
 

--- a/doc/modules/mod_core.html
+++ b/doc/modules/mod_core.html
@@ -73,6 +73,7 @@ The <code>mod_core</code> module handles most of the core FTP commands.
   <li><a href="#RegexOptions">RegexOptions</a>
   <li><a href="#ScoreboardFile">ScoreboardFile</a>
   <li><a href="#ScoreboardMutex">ScoreboardMutex</a>
+  <li><a href="#ScoreboardOptions">ScoreboardOptions</a>
   <li><a href="#ScoreboardScrub">ScoreboardScrub</a>
   <li><a href="#ServerAdmin">ServerAdmin</a>
   <li><a href="#ServerAlias">ServerAlias</a>
@@ -2244,6 +2245,40 @@ For performance reasons, it is <b>strongly recommended</b> that the
 filesystem, but rather be located on a local physical disk.  It is best if
 the <code>ScoreboardMutex</code> be located in the same directory as the
 <a href="#ScoreboardFile"><code>ScoreboardFile</code></a>.
+
+<p>
+<hr>
+<h3><a name="ScoreboardOptions">ScoreboardOptions</a></h3>
+<strong>Syntax:</strong> ScoreboardOptions <em>opt1 ...</em><br>
+<strong>Default:</strong> None<br>
+<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_core<br>
+<strong>Compatibility:</strong> 1.3.9rc1 and later
+
+<p>
+The <code>ScoreboardOptions</code> directive is used to configure various
+optional behavior of the <a href="../howto/ScoreboardFile.html">scoreboard</a>.
+
+<p>
+Example:
+<pre>
+  ScoreboardOptions AllowMissingEntry
+</pre>
+
+<p>
+The currently implemented options are:
+<ul>
+  <li><code>AllowMissingEntry</code><br>
+    <p>
+    Under high load, it may not be possible to acquire an entry in the
+    <code>ScoreboardFile</code> due to high contention.  Clients will
+    be disconnected when this happens, unless this option is specified.
+
+    <p>
+    <b>Note</b> that this option first appeared in
+    <code>proftpd-1.3.9rc1</code>.
+  </li>
+</ul>
 
 <p>
 <hr>

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server daemon
- * Copyright (c) 2001-2015 The ProFTPD Project team
+ * Copyright (c) 2001-2023 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -101,6 +101,9 @@ typedef struct {
 
 /* Scoreboard mode */
 #define PR_SCOREBOARD_MODE		0644
+
+/* Scoreboard option flags */
+#define PR_SCOREBOARD_OPT_ALLOW_MISSING_ENTRY	0x0001
 
 /* Scoreboard update tags */
 #define PR_SCORE_USER		1

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -765,6 +765,36 @@ MODRET set_scoreboardmutex(cmd_rec *cmd) {
   return PR_HANDLED(cmd);
 }
 
+/* usage: ScoreboardOptions opt1 ... */
+MODRET set_scoreboardoptions(cmd_rec *cmd) {
+  register unsigned int i = 0;
+  config_rec *c = NULL;
+  unsigned long opts = 0UL;
+
+  if (cmd->argc-1 == 0) {
+    CONF_ERROR(cmd, "wrong number of parameters");
+  }
+
+  CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
+
+  c = add_config_param(cmd->argv[0], 1, NULL);
+
+  for (i = 1; i < cmd->argc; i++) {
+    if (strcasecmp(cmd->argv[i], "AllowMissingEntry") == 0) {
+      opts |= PR_SCOREBOARD_OPT_ALLOW_MISSING_ENTRY;
+
+    } else {
+      CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown ScoreboardOption '",
+        cmd->argv[i], "'", NULL));
+    }
+  }
+
+  c->argv[0] = pcalloc(c->pool, sizeof(unsigned long));
+  *((unsigned long *) c->argv[0]) = opts;
+
+  return PR_HANDLED(cmd);
+}
+
 /* usage: ScoreboardScrub "on"|"off"|secs */
 MODRET set_scoreboardscrub(cmd_rec *cmd) {
   int bool = -1, nsecs = 0;
@@ -7485,6 +7515,7 @@ static conftable core_conftab[] = {
   { "Satisfy",			set_satisfy,			NULL },
   { "ScoreboardFile",		set_scoreboardfile,		NULL },
   { "ScoreboardMutex",		set_scoreboardmutex,		NULL },
+  { "ScoreboardOptions",	set_scoreboardoptions,		NULL },
   { "ScoreboardScrub",		set_scoreboardscrub,		NULL },
   { "ServerAdmin",		set_serveradmin,		NULL },
   { "ServerAlias",		set_serveralias,		NULL },


### PR DESCRIPTION
… for a new connection, disconnect the client by default.

Provide a new ScoreboardOptions directive for opting out of this behavior, allowing for a fail-open scenario, if needed.