### PR TITLE
Issue #1712: Handle the `SFTPCiphers`, `SFTPDigests`, `SFTPKeyExchang…

### DIFF
--- a/contrib/mod_sftp/mod_sftp.c
+++ b/contrib/mod_sftp/mod_sftp.c
@@ -504,7 +504,6 @@ MODRET set_sftpauthorizedkeys(cmd_rec *cmd) {
 MODRET set_sftpciphers(cmd_rec *cmd) {
   register unsigned int i;
   config_rec *c;
-  xaset_t *set = NULL;
 
   if (cmd->argc < 2) {
     CONF_ERROR(cmd, "Wrong number of parameters");
@@ -519,13 +518,11 @@ MODRET set_sftpciphers(cmd_rec *cmd) {
     }
   }
 
-  set = cmd->server->conf;
-  c = create_config(set->pool, cmd->argv[0], cmd->argc-1);
+  c = add_config_param(cmd->argv[0], cmd->argc-1, NULL);
   for (i = 1; i < cmd->argc; i++) {
     c->argv[i-1] = pstrdup(c->pool, cmd->argv[i]);
   }
 
-  pr_config_add_config_to_set(set, c, 0);
   return PR_HANDLED(cmd);
 }
 
@@ -1239,7 +1236,6 @@ MODRET set_sftpdhparamfile(cmd_rec *cmd) {
 MODRET set_sftpdigests(cmd_rec *cmd) {
   register unsigned int i;
   config_rec *c;
-  xaset_t *set = NULL;
 
   if (cmd->argc < 2) {
     CONF_ERROR(cmd, "Wrong number of parameters");
@@ -1254,13 +1250,11 @@ MODRET set_sftpdigests(cmd_rec *cmd) {
     }
   }
 
-  set = cmd->server->conf;
-  c = create_config(set->pool, cmd->argv[0], cmd->argc-1);
+  c = add_config_param(cmd->argv[0], cmd->argc-1, NULL);
   for (i = 1; i < cmd->argc; i++) {
     c->argv[i-1] = pstrdup(c->pool, cmd->argv[i]);
   }
 
-  pr_config_add_config_to_set(set, c, 0);
   return PR_HANDLED(cmd);
 }
 
@@ -1564,7 +1558,6 @@ MODRET set_sftphostkey(cmd_rec *cmd) {
 MODRET set_sftphostkeys(cmd_rec *cmd) {
   register unsigned int i;
   config_rec *c;
-  xaset_t *set = NULL;
 
   if (cmd->argc < 2) {
     CONF_ERROR(cmd, "Wrong number of parameters");
@@ -1579,13 +1572,11 @@ MODRET set_sftphostkeys(cmd_rec *cmd) {
     }
   }
 
-  set = cmd->server->conf;
-  c = create_config(set->pool, cmd->argv[0], cmd->argc-1);
+  c = add_config_param(cmd->argv[0], cmd->argc-1, NULL);
   for (i = 1; i < cmd->argc; i++) {
     c->argv[i-1] = pstrdup(c->pool, cmd->argv[i]);
   }
 
-  pr_config_add_config_to_set(set, c, 0);
   return PR_HANDLED(cmd);
 }
 
@@ -1614,7 +1605,6 @@ MODRET set_sftpkeyblacklist(cmd_rec *cmd) {
 MODRET set_sftpkeyexchanges(cmd_rec *cmd) {
   register unsigned int i;
   config_rec *c;
-  xaset_t *set = NULL;
   char *exchanges = "";
 
   if (cmd->argc < 2) {
@@ -1630,15 +1620,13 @@ MODRET set_sftpkeyexchanges(cmd_rec *cmd) {
     }
   }
 
-  set = cmd->server->conf;
-  c = create_config(set->pool, cmd->argv[0], 1);
+  c = add_config_param(cmd->argv[0], 1, NULL);
   for (i = 1; i < cmd->argc; i++) {
     exchanges = pstrcat(c->pool, exchanges, *exchanges ? "," : "", cmd->argv[i],
       NULL);
   }
   c->argv[0] = exchanges;
 
-  pr_config_add_config_to_set(set, c, 0);
   return PR_HANDLED(cmd);
 }
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -1936,6 +1936,11 @@ my $TESTS = {
     test_class => [qw(bug forking sftp ssh2)],
   },
 
+  sftp_config_global_algos_issue1712 => {
+    order => ++$order,
+    test_class => [qw(bug forking sftp ssh2)],
+  },
+
 };
 
 sub get_sftplog {
@@ -66983,6 +66988,111 @@ sub sftp_ext_hostkey_rotation_issue1323 {
   if ($@) {
     $ex = $@;
   }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub sftp_config_global_algos_issue1712 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'sftp');
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ssh2:20 sftp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+      ],
+    },
+
+    Global => {
+      SFTPCiphers => 'arcfour128',
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::SSH2;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $ssh2_opts = {};
+
+      if ($ENV{TEST_VERBOSE}) {
+        $ssh2_opts->{trace} = -1;
+      }
+
+      my $ssh2 = Net::SSH2->new(%$ssh2_opts);
+
+      sleep(1);
+
+      my $cipher = 'arcfour128';
+      $ssh2->method('crypt_cs', $cipher);
+
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      my $cipher_used = $ssh2->method('crypt_cs');
+      $self->assert($cipher eq $cipher_used,
+        test_msg("Expected cipher '$cipher', got '$cipher_used'"));
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
 
   test_cleanup($setup->{log_file}, $ex);
 }


### PR DESCRIPTION
…es`, and `SFTPHostKeys` directively normally, reverting some of the changes from Issue #1444.

The use of the added `create_config()` function, for "embedding" a config_rec in the `SFTPClientMatch` config_rec for Issue #1444 worked, but was *not* needed in the directive handlers for the directives, as for non-`SFTPClientMatch`-using configurations.