### PR TITLE
When looking into buffer sizes, and handling of buffers, during downl…

### DIFF
--- a/tests/api/data.c
+++ b/tests/api/data.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2015-2022 The ProFTPD Project team
+ * Copyright (c) 2015-2023 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -948,8 +948,12 @@ START_TEST (data_xfer_write_binary_test) {
   res = pr_data_xfer(buf, buflen);
   ck_assert_msg(res == (int) buflen, "Expected %lu, got %d",
     (unsigned long) buflen, res);
-  ck_assert_msg(strncmp(session.xfer.buf, buf, buflen) == 0,
-    "Expected '%s', got '%.100s'", buf, session.xfer.buf);
+
+  /* Now that we no longer do an egregious memcpy() into session.xfer.buf
+   * for binary transfers, we cannot use the contents of session.xfer.buf
+   * for additional assertions.  The integration tests can cover those
+   * assertions.
+   */
 }
 END_TEST
 


### PR DESCRIPTION
…oads using TLS, I noticed that we _always_ did a `memcpy` of the given buffer (as allocated in mod_xfer, and filled from disk) into a different buffer.

This `memcpy` is necessary if we are performing ASCII translation on that data, yes -- but *not* necessary if we are *not* performing ASCII translation.  Consider the case of a download of a large binary file.  We read a large chunk of the file data from disk into a buffer, then _copy that buffer_, then write out the same data (from the second buffer) to the network.  Why?

This, then, is an experiment to attempt avoiding an unnecessary `memcpy` (and its latency) during downloads that do not need the intermediate buffer.