### PR TITLE
Issue #1730: Fix the `mod_sftp` build when using older OpenSSL versio…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,11 @@
   where `N' is the issue number.
 -----------------------------------------------------------------------------
 
+1.3.9rc2
+--------------------------------
+- Issue 1730 - 1.3.9rc1 mod_sftp fails to compile if EVP_chacha20 is
+  unavailable, as when using older OpenSSL versions.
+
 1.3.9rc1 - Released 08-Oct-2023
 --------------------------------
 - Bug 4494 - mod_tls build fails for OpenSSL before 1.1.x.


### PR DESCRIPTION
…ns, broken by the support for the OpenSSH ChaChaPoly cipher.