### PR TITLE
Update a few more `mod_sftp` code paths to use "direct" reads, avoidi…

### DIFF
--- a/contrib/mod_sftp/channel.c
+++ b/contrib/mod_sftp/channel.c
@@ -678,7 +678,7 @@ static int handle_channel_data(struct ssh2_packet *pkt, uint32_t *channel_id) {
   pr_trace_msg(trace_channel, 17,
     "processing %lu %s of data for channel ID %lu", (unsigned long) datalen,
     datalen != 1 ? "bytes" : "byte", (unsigned long) *channel_id);
-  data = sftp_msg_read_data(pkt->pool, &buf, &buflen, datalen);
+  data = sftp_msg_read_data_direct(pkt->pool, &buf, &buflen, datalen);
 
   return process_channel_data(chan, pkt, data, datalen);
 }

--- a/contrib/mod_sftp/packet.c
+++ b/contrib/mod_sftp/packet.c
@@ -1788,7 +1788,7 @@ void sftp_ssh2_packet_handle_ext_info(struct ssh2_packet *pkt) {
       &pkt->payload_len);
     ext_datalen = sftp_msg_read_int(pkt->pool, &pkt->payload,
       &pkt->payload_len);
-    (void) sftp_msg_read_data(pkt->pool, &pkt->payload,
+    (void) sftp_msg_read_data_direct(pkt->pool, &pkt->payload,
       &pkt->payload_len, ext_datalen);
 
     pr_trace_msg(trace_channel, 9,


### PR DESCRIPTION
…ng unnecessary memory copies.