### PR TITLE
Issue #1746: If we fail to resolve the DNS name for the implicit "ser…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@
 --------------------------------
 - Issue 1730 - 1.3.9rc1 mod_sftp fails to compile if EVP_chacha20 is
   unavailable, as when using older OpenSSL versions.
+- Issue 1476 - Error resolving DNS name for implicit "server config" vhost
+  leads to DelayTable not being found.
 
 1.3.9rc1 - Released 08-Oct-2023
 --------------------------------


### PR DESCRIPTION
…ver config" vhost to an IP address, we need to fail completely on startup.

Failure to do so will lead to unexpected null pointer dereferences elsewhere in modules.