### PR TITLE
configure: Use char ** for the iconv input argument

### DIFF
--- a/configure
+++ b/configure
@@ -21475,7 +21475,7 @@ main ()
 {
 
     size_t res, in_len = 0, out_len = 0;
-    const char *in = NULL;
+    char *in = NULL;
     char *out = NULL;
     res = iconv((iconv_t)-1, &in, &in_len, &out, &out_len);
 

--- a/configure.in
+++ b/configure.in
@@ -2100,7 +2100,7 @@ AC_TRY_LINK(
   ],
   [ 
     size_t res, in_len = 0, out_len = 0;
-    const char *in = NULL;
+    char *in = NULL;
     char *out = NULL;
     res = iconv((iconv_t)-1, &in, &in_len, &out, &out_len);
   ],


### PR DESCRIPTION
The standard `iconv` function uses `char **` even for the input buffer. Using the incompatible `const char **` type causes the check to fail if the compiler treats such type errors as errors, instead of merely warning about it.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
