### PR TITLE
Add a second optional parameter to the SQLPasswordRounds option

### DIFF
--- a/contrib/mod_sql_passwd.c
+++ b/contrib/mod_sql_passwd.c
@@ -93,6 +93,12 @@ static unsigned long sql_passwd_opts = 0UL;
 
 static unsigned long sql_passwd_nrounds = 1;
 
+/* USE salt in rounds */
+#define SQL_USE_SALT_ROUND_APPEND	0x0001
+#define SQL_USE_SALT_ROUND_PREPEND	0x0002
+#define SQL_USE_SALT_ROUND_NONE		0x0004
+static unsigned long sql_use_salt_round = SQL_USE_SALT_ROUND_NONE;
+
 /* For PBKDF2 */
 static const EVP_MD *sql_passwd_pbkdf2_digest = NULL;
 static int sql_passwd_pbkdf2_iter = -1;
@@ -724,8 +730,15 @@ static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
     for (i = 0; i < nrounds; i++) {
       pr_signals_handle();
 
-      hash = sql_passwd_hash(cmd->tmp_pool, md, (unsigned char *) encodedtext,
-        strlen(encodedtext), NULL, 0, NULL, 0, &hash_len);
+      hash = sql_passwd_hash(cmd->tmp_pool,
+			md,
+			(unsigned char *) encodedtext,
+			strlen(encodedtext),
+			(sql_use_salt_round == SQL_USE_SALT_ROUND_PREPEND) ? prefix : NULL,
+			(sql_use_salt_round == SQL_USE_SALT_ROUND_PREPEND) ? prefix_len : 0,
+			(sql_use_salt_round == SQL_USE_SALT_ROUND_APPEND) ? suffix : NULL,
+			(sql_use_salt_round == SQL_USE_SALT_ROUND_APPEND) ? suffix_len : 0,
+			&hash_len);
       encodedtext = sql_passwd_encode(cmd->tmp_pool, sql_passwd_encoding,
         hash, hash_len);
 
@@ -1113,6 +1126,8 @@ MODRET sql_passwd_pre_pass(cmd_rec *cmd) {
   c = find_config(main_server->conf, CONF_PARAM, "SQLPasswordRounds", FALSE);
   if (c != NULL) {
     sql_passwd_nrounds = *((unsigned long *) c->argv[0]);
+	if(c->argc == 2)
+		sql_use_salt_round = *((unsigned long *) c->argv[1]);
   }
 
   c = find_config(main_server->conf, CONF_PARAM, "SQLPasswordPBKDF2", FALSE);
@@ -1527,6 +1542,7 @@ MODRET set_sqlpasswdpbkdf2(cmd_rec *cmd) {
 MODRET set_sqlpasswdrounds(cmd_rec *cmd) {
   config_rec *c;
   long nrounds;
+  unsigned long use_salt = SQL_USE_SALT_ROUND_NONE;
 
   CHECK_ARGS(cmd, 1);
   CHECK_CONF(cmd, CONF_ROOT|CONF_VIRTUAL|CONF_GLOBAL);
@@ -1537,9 +1553,18 @@ MODRET set_sqlpasswdrounds(cmd_rec *cmd) {
       cmd->argv[1], ")", NULL));
   }
 
-  c = add_config_param(cmd->argv[0], 1, NULL);
+  if(cmd->argc == 3) {
+	if(strcasecmp(cmd->argv[2], "PrependSalt") == 0) {
+		use_salt = SQL_USE_SALT_ROUND_PREPEND;
+	}else if(strcasecmp(cmd->argv[2], "AppendSalt") == 0) {
+		use_salt = SQL_USE_SALT_ROUND_APPEND;
+	}
+  }
+  c = add_config_param(cmd->argv[0], 2, NULL);
   c->argv[0] = palloc(c->pool, sizeof(unsigned int));
   *((unsigned long *) c->argv[0]) = nrounds;
+  c->argv[1] = palloc(c->pool, sizeof(unsigned int));
+  *((unsigned long*) c->argv[1]) = use_salt;
 
   return PR_HANDLED(cmd);
 }
@@ -1672,6 +1697,7 @@ static void sql_passwd_sess_reinit_ev(const void *event_data, void *user_data) {
   sql_passwd_user_salt_flags = SQL_PASSWD_SALT_FL_APPEND;
   sql_passwd_opts = 0UL;
   sql_passwd_nrounds = 1;
+  sql_use_salt_round = SQL_USE_SALT_ROUND_NONE;
 
 #ifdef PR_USE_SODIUM
   sql_passwd_scrypt_hash_len = SQL_PASSWD_SCRYPT_DEFAULT_HASH_SIZE;

--- a/doc/contrib/mod_sql_passwd.html
+++ b/doc/contrib/mod_sql_passwd.html
@@ -259,17 +259,25 @@ iteration count, and output length <i>on a per-user basis</i>.  For example:
 
 <hr>
 <h3><a name="SQLPasswordRounds">SQLPasswordRounds</a></h3>
-<strong>Syntax:</strong> SQLPasswordRounds <em>count</em><br>
-<strong>Default:</strong> <em>1</em><br>
+<strong>Syntax:</strong> SQLPasswordRounds <em>count</em> <em>saltround</em><br>
+<strong>Default count:</strong> <em>1</em><br>
+<strong>Default saltround:</strong> <em>None</em><br>
 <strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
 <strong>Module:</strong> mod_sql_passwd<br>
 <strong>Compatibility:</strong> 1.3.4rc2 and later
 
 <p>
-The <code>SQLPasswordRounds</code> directive configures the number of
-rounds through which the password (and possibly salt) data will be hashed
-and encoded.  The <em>count</em> parameter must be greater than 1.
-
+The <code>SQLPasswordRounds</code> directive configures the number of rounds through which the password (and possibly salt) data will be hashed and encoded.<br>
+The <em>count</em> parameter must be greater than 1.<br>
+The <em>saltround</em> parametr following values are currently supported:<br>
+<ul>
+	<li>PrependSalt</li>
+	<li>AppendSalt</li>
+</ul>
+<p>
+The value of second parametr PrependSalt is concatenated at each iteration of Salt with the hash result <code>(salt + hash(data))</code>.<br>
+AppendSalt adds salt to the end <code>(hash(data) + salt)</code>.<br>
+If the second parameter is not specified or has any other value, then salt is not used in this context
 <p>
 See the <a href="#Transformations">transformations</a> section for a fuller
 description of how <code>mod_sql_passwd</code> operates on the password and
@@ -719,6 +727,22 @@ The combination of <code>SQLPasswordOptions</code> and
 values can be supported by the <code>mod_sql_passwd</code> module.
 
 <p>
+If passwords are stored in your database something like this:<br>
+<p>
+<code>sha1(salt + sha1(salt + sha1(password)))<br></code>
+<p>
+This method is often used, for example, in the OpenCart Content Management System.<br>
+Using the above example case, you would configure <code>mod_sql_passwd</code>
+to perform multiple rounds of transformation using the
+<a href="#SQLPasswordRounds"><code>SQLPasswordRounds</code></a> directive,
+like so:
+<pre>
+  SQLAuthTypes sha1
+  SQLPasswordEncoding hex
+  SQLPasswordSaltEncoding none
+  SQLPasswordOptions  HashEncodePassword
+  SQLPasswordRounds   2  PrependSalt
+</pre>
 <hr>
 <font size=2><b><i>
 &copy; Copyright 2009-2019 TJ Saunders<br>


### PR DESCRIPTION
SQLPasswordRounds N [ PrependSalt | AppendSalt ]

The option allows you to add Salt in each iteration of "TRANSFORM" This type of password encryption is used on many websites (for example, CMS OpenCart). Fkr example
sha1(salt + sha1(salt + sha1(password)))