### PR TITLE
Issue #1780: Implement a new FSIO handler akin to the `realpath(3)` f…

### DIFF
--- a/include/fsio.h
+++ b/include/fsio.h
@@ -78,6 +78,7 @@
 #define FSIO_FILE_LREMOVEXATTR	0x1000000
 #define FSIO_FILE_SETXATTR	0x2000000
 #define FSIO_FILE_LSETXATTR	0x4000000
+#define FSIO_FILE_REALPATH	0x8000000
 
 /* Macro that defines the most common file ops */
 #define FSIO_FILE_COMMON	(FSIO_FILE_OPEN|FSIO_FILE_READ|FSIO_FILE_WRITE|\
@@ -157,6 +158,8 @@ struct fs_rec {
   int (*utimes)(pr_fs_t *, const char *, struct timeval *);
   int (*futimes)(pr_fh_t *, int, struct timeval *);
   int (*fsync)(pr_fh_t *, int);
+
+  const char *(*realpath)(pr_fs_t *, pool *p, const char *);
 
   /* Extended attribute support */
   ssize_t (*getxattr)(pool *, pr_fs_t *, const char *, const char *, void *,
@@ -286,6 +289,8 @@ int pr_fsio_utimes_with_root(const char *, struct timeval *);
 int pr_fsio_futimes(pr_fh_t *, struct timeval *);
 int pr_fsio_fsync(pr_fh_t *fh);
 off_t pr_fsio_lseek(pr_fh_t *, off_t, int);
+
+const char *pr_fsio_realpath(pool *p, const char *path);
 
 /* Extended attribute support */
 ssize_t pr_fsio_getxattr(pool *p, const char *, const char *, void *, size_t);

--- a/tests/api/fsio.c
+++ b/tests/api/fsio.c
@@ -1457,6 +1457,28 @@ START_TEST (fsio_sys_fsync_test) {
 }
 END_TEST
 
+START_TEST (fsio_sys_realpath_test) {
+  const char *res;
+
+  mark_point();
+  res = pr_fsio_realpath(NULL, NULL);
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+
+  mark_point();
+  res = pr_fsio_realpath(p, NULL);
+  ck_assert_msg(res == NULL, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+
+  mark_point();
+  res = pr_fsio_realpath(p, "/tmp");
+  ck_assert_msg(res != NULL, "Failed to resolve path '/tmp': %s",
+    strerror(errno));
+}
+END_TEST
+
 START_TEST (fsio_sys_getxattr_test) {
   ssize_t res;
   const char *path, *name;
@@ -5236,6 +5258,8 @@ Suite *tests_get_fsio_suite(void) {
   tcase_add_test(testcase, fsio_sys_utimes_chroot_guard_test);
   tcase_add_test(testcase, fsio_sys_futimes_test);
   tcase_add_test(testcase, fsio_sys_fsync_test);
+
+  tcase_add_test(testcase, fsio_sys_realpath_test);
 
   /* Extended attribute tests */
   tcase_add_test(testcase, fsio_sys_getxattr_test);


### PR DESCRIPTION
…unction, for resolving paths.

Most of the time, this will be a pass-through.  However, modules like mod_vroot play games with filesystem paths, and other modules need a way to play by those same rules.