### PR TITLE
Issue #1288: Work around older OpenSSH clients which do support and u…

### DIFF
--- a/contrib/mod_sftp/interop.c
+++ b/contrib/mod_sftp/interop.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp interoperability
- * Copyright (c) 2008-2022 TJ Saunders
+ * Copyright (c) 2008-2024 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,7 +45,8 @@ static unsigned int default_flags =
   SFTP_SSH2_FEAT_SERVICE_IN_PUBKEY_SIG |
   SFTP_SSH2_FEAT_HAVE_PUBKEY_ALGO_IN_DSA_SIG |
   SFTP_SSH2_FEAT_NO_DATA_WHILE_REKEYING |
-  SFTP_SSH2_FEAT_HOSTKEYS;
+  SFTP_SSH2_FEAT_HOSTKEYS |
+  SFTP_SSH2_FEAT_USE_FULL_FXP_LIMITS;
 
 struct sftp_version_pattern {
   const char *pattern;
@@ -70,6 +71,10 @@ static struct sftp_version_pattern known_versions[] = {
     "^OpenSSH_2\\.5\\.1.*|"
     "^OpenSSH_2\\.5\\.2.*|"
     "^OpenSSH_2\\.5\\.3.*",	SFTP_SSH2_FEAT_REKEYING,		NULL },
+
+  { "^OpenSSH_8\\..*|"
+    "^OpenSSH_9\\.0.*|"
+    "^OpenSSH_9\\.1.*",		SFTP_SSH2_FEAT_USE_FULL_FXP_LIMITS,	NULL },
 
   { "^OpenSSH.*",		0,					NULL },
 

--- a/contrib/mod_sftp/interop.h
+++ b/contrib/mod_sftp/interop.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_sftp interoperability
- * Copyright (c) 2008-2021 TJ Saunders
+ * Copyright (c) 2008-2024 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,6 +82,11 @@
 /* For clients that support the OpenSSH "hostkeys-00@openssh.com" extensions.
  */
 #define SFTP_SSH2_FEAT_HOSTKEYS				0x0800
+
+/* For clients that support the OpenSSH "limits@openssh.com" extension yet
+ * cannot handle the full mod_sftp lengths.
+ */
+#define SFTP_SSH2_FEAT_USE_FULL_FXP_LIMITS		0x1000
 
 /* For scanners. */
 #define SFTP_SSH2_FEAT_SCANNER				0xfffe


### PR DESCRIPTION
…se the `limits@openssh.com` extension, yet cannot properly handle the longer mod_sftp lengths.