### PR TITLE
Registering new event handler as head of the doubly linked list issue.

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -160,8 +160,8 @@ int pr_event_register(module *m, const char *event,
         }
 
         if (evh->module != NULL) {
-          if (evl->handlers->next != NULL) {
-            evl->handlers->next->prev = evh;
+          if (evl->handlers != NULL) {
+            evl->handlers->prev = evh;
           }
 
           evh->next = evl->handlers;


### PR DESCRIPTION
When registering multiple event handlers for the same event (for example in the case that an event should be handled differently by the various loaded modules), the registering of a new handler in the double linked list is not performed correctly.

With this modification the latest added event handler is positioned in the head of the doubly linked list.