### PR TITLE
Don't include <openssl/engine.h> if ENGINE support not detected

### DIFF
--- a/contrib/mod_sftp/mod_sftp.h.in
+++ b/contrib/mod_sftp/mod_sftp.h.in
@@ -112,7 +112,9 @@
 #include <openssl/rsa.h>
 #if OPENSSL_VERSION_NUMBER > 0x000907000L
 # include <openssl/aes.h>
-# include <openssl/engine.h>
+# ifdef PR_USE_OPENSSL_ENGINE
+#  include <openssl/engine.h>
+# endif /* PR_USE_OPENSSL_ENGINE */
 # include <openssl/ocsp.h>
 #endif
 #if defined(PR_USE_OPENSSL_ECC)

--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -69,7 +69,9 @@
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 #if OPENSSL_VERSION_NUMBER > 0x000907000L
-# include <openssl/engine.h>
+# ifdef PR_USE_OPENSSL_ENGINE
+#  include <openssl/engine.h>
+# endif /* PR_USE_OPENSSL_ENGINE */
 # ifdef PR_USE_OPENSSL_OCSP
 #  include <openssl/ocsp.h>
 # endif /* PR_USE_OPENSSL_OCSP */


### PR DESCRIPTION
OpenSSL ENGINE support is deprecated in Fedora 41 onwards: https://fedoraproject.org/wiki/Changes/OpensslDeprecateEngine

As part of this change, OpenSSL is still built with ENGINE support in order to maintain compatibility with existing applications, but the <openssl/engine.h> header is moved to a different package so that users have to make an explicit choice to support it.

Since proftpd already supports building without ENGINE support, we can qualify inclusion of <openssl/engine.h> using the results of the configure check. If there's no ENGINE support, there's no point including it.

It would be nice to include a similar change in mod_proxy. I can do an additional PR for that if it's helpful, though it seems a fairly trivial change.