### PR TITLE
Address some compiler warnings relating to null pointer dereferences

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -4679,7 +4679,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4805,7 +4805,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4918,7 +4918,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4973,7 +4973,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);


### PR DESCRIPTION
This addresses warnings like this:
```
mod_tls.c: In function ‘tls_tlsext_cb’:
mod_tls.c:4975:61: warning: ‘%.*s’ directive argument is null [-Wformat-overflow=]
 4975 |         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
      |                                                             ^~~~
```
The warning is because ext_info (returned from BIO_get_mem_data) can be NULL.

This may not be your preferred method of fixing this warning but it does silence the compiler regarding this issue.

There are similar issues in mod_proxy too.