### PR TITLE
Issue #1836: Always explicitly set the supplemental group membership …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,7 +29,7 @@
   of public key algorithms allowed for authentication.
 - Issue 1819 - Stack trace changing to directory with DisplayChdir file using
   %F variable on a large filesystem.
-- Issue 1863 - Remove inherited supplemental groups when started with root
+- Issue 1836 - Remove inherited supplemental groups when started with root
   privileges.
 
 1.3.9rc2 - Released 19-Dec-2023

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@
   of public key algorithms allowed for authentication.
 - Issue 1819 - Stack trace changing to directory with DisplayChdir file using
   %F variable on a large filesystem.
+- Issue 1863 - Remove inherited supplemental groups when started with root
+  privileges.
 
 1.3.9rc2 - Released 19-Dec-2023
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -9,6 +9,9 @@ ChangeLog files.
 1.3.9rc3
 ---------
 
+  + Clear supplemental groups of daemon process off all except primary
+    GID (Issue #1836)
+
   + New Directives
 
       SFTPAuthPublicKeys (Issue #1806)

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
  * ProFTPD - FTP server daemon
  * Copyright (c) 1997, 1998 Public Flood Software
  * Copyright (c) 1999, 2000 MacGyver aka Habeeb J. Dihu <macgyver@tos.net>
- * Copyright (c) 2001-2023 The ProFTPD Project team
+ * Copyright (c) 2001-2024 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2763,11 +2763,16 @@ int main(int argc, char *argv[], char **envp) {
 
     daemon_uid = (uid != NULL ? *uid : PR_ROOT_UID);
     daemon_gid = (gid != NULL ? *gid : PR_ROOT_GID);
-  }
 
-  if (daemon_uid != PR_ROOT_UID) {
-    pr_log_debug(DEBUG9, "ignoring supplemental groups for non-root UID %lu",
-      (unsigned long) daemon_uid);
+    daemon_gids = make_array(permanent_pool, 2, sizeof(gid_t));
+    *((gid_t *) push_array(daemon_gids)) = daemon_gid;
+
+    if (set_groups(permanent_pool, daemon_gid, daemon_gids) < 0) {
+      if (errno != ENOSYS) {
+        pr_log_pri(PR_LOG_WARNING, "unable to set daemon groups: %s",
+          strerror(errno));
+      }
+    }
   }
 
   /* After configuration is complete, make sure that passwd, group


### PR DESCRIPTION
…of the daemon process to _only_ be the configured primary GID, and no other groups.

This prevents inheritance of any other groups that the `User` might have, which could then be passed to session processes in certain edge cases.