### PR TITLE
Add compile-time option to change the name of SFTP READ and WRITE commands by appending a suffix to them

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1110,6 +1110,12 @@
 /* Define if largefile support is desired.  */
 #undef PR_USE_LARGEFILES
 
+/* Command name to use for SFTP reads. */
+#undef PR_SFTP_READCMD
+
+/* Command name to use for SFTP writes. */
+#undef PR_SFTP_WRITECMD
+
 /* Define if Memcache support is desired.. */
 #undef PR_USE_MEMCACHE
 

--- a/configure
+++ b/configure
@@ -947,6 +947,7 @@ with_mysql_config
 with_openssl_cmdline
 with_postgres_config
 with_pkgconfig
+with-sftp-readwrite-cmdsuffix
 enable_auth_file
 enable_autoshadow
 enable_auth_pam
@@ -1788,6 +1789,11 @@ Optional Packages:
   --with-included-ltdl    use the GNU ltdl sources included here
   --with-ltdl-include=DIR use the ltdl headers installed in DIR
   --with-ltdl-lib=DIR     use the libltdl.la installed in DIR
+  --with-sftp-readwrite-cmdsuffix=SUFFIX
+                          change the SFTP READ and WRITE command names to add
+                          the configured suffix to allow them to differentiate
+                          from the READ and WRITE classes. If no suffix is
+                          given, the default suffix of 'FILE' is used
 
 Some influential environment variables:
   CC          C compiler command
@@ -15099,6 +15105,35 @@ LIB_DEPS="\"\""
 
 
 LIB_OBJS="pr_fnmatch.o sstrncpy.o strsep.o vsnprintf.o glibc-glob.o glibc-hstrerror.o glibc-mkstemp.o pr-syslog.o pwgrent.o hanson-tpl.o ccan-json.o openbsd-blowfish.o openbsd-bcrypt.o"
+
+
+# Check whether --with-sftp-readwrite-cmdsuffix was given.
+if test "${with_sftp_readwrite_cmdsuffix+set}" = set; then :
+  withval=$with_sftp_readwrite_cmdsuffix;
+    if test "x$withval" = "xno" ; then
+      # nothing to do
+      suffix=''
+
+    elif test "x$withval" = "xyes" ; then
+      # use the default suffix of 'FILE'
+      suffix='FILE'
+
+    else
+      suffix="${withval}"
+    fi
+
+cat >>confdefs.h <<_ACEOF
+#define PR_SFTP_READCMD "READ${suffix}"
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define PR_SFTP_WRITECMD "WRITE${suffix}"
+_ACEOF
+
+
+fi
+
 
 
 # Check whether --with-getopt was given.

--- a/configure.in
+++ b/configure.in
@@ -192,6 +192,32 @@ dnl support/handle --without-getopt, to disable use of ProFTPD's getopt.
 dnl I don't know if MySQL supports any similar option.
 LIB_OBJS="pr_fnmatch.o sstrncpy.o strsep.o vsnprintf.o glibc-glob.o glibc-hstrerror.o glibc-mkstemp.o pr-syslog.o pwgrent.o hanson-tpl.o ccan-json.o openbsd-blowfish.o openbsd-bcrypt.o"
 
+dnl Added config option to allow compile-time changes to the names of the SFTP
+dnl READ and WRITE commands to avoid the collision with the same names of
+dnl command classes.
+AC_ARG_WITH(sftp-readwrite-cmdsuffix,
+  [AC_HELP_STRING(
+      [--with-sftp-readwrite-cmdsuffix=SUFFIX],
+      [change the SFTP READ and WRITE command names to add the configured suffix to allow them to differentiate from the READ and WRITE classes.  If no suffix is given, the default suffix of 'FILE' is used])
+  ],
+  [
+    if test "x$withval" = "xno" ; then
+      # nothing to do
+      suffix=''
+
+    elif test "x$withval" = "xyes" ; then
+      # use the default suffix of 'FILE'
+      suffix='FILE'
+
+    else
+      suffix="${withval}"
+    fi
+    AC_DEFINE_UNQUOTED(PR_SFTP_READCMD, "READ${suffix}",
+      [Command name to use for SFTP reads.])
+    AC_DEFINE_UNQUOTED(PR_SFTP_WRITECMD, "WRITE${suffix}",
+      [Command name to use for SFTP writes.])
+  ])
+
 AC_ARG_WITH(getopt,
   [AC_HELP_STRING(
       [--without-getopt],

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -13444,7 +13444,7 @@ static int fxp_handle_write(struct fxp_packet *fxp) {
   cmd->cmd_id = SFTP_CMD_ID;
 
   pr_scoreboard_entry_update(session.pid,
-    PR_SCORE_CMD, "%s", "WRITE", NULL, NULL);
+    PR_SCORE_CMD, "%s", PR_SFTP_WRITECMD, NULL, NULL);
   pr_scoreboard_entry_update(session.pid,
     PR_SCORE_CMD_ARG, "%s", name, NULL, NULL);
 

--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -10381,7 +10381,7 @@ static int fxp_handle_read(struct fxp_packet *fxp) {
   }
 #endif
 
-  cmd = fxp_cmd_alloc(fxp->pool, "READFILE", name);
+  cmd = fxp_cmd_alloc(fxp->pool, PR_SFTP_READCMD, name);
   cmd->cmd_class = CL_READ|CL_SFTP;
   cmd->cmd_id = SFTP_CMD_ID;
 

--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -4681,7 +4681,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4807,7 +4807,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4920,7 +4920,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);
@@ -4975,7 +4975,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
         "[tls.tlsext] TLS %s extension \"%s\" (ID %d, %d %s)%.*s",
         server ? "server" : "client", extension_name, type,
         tlsext_datalen, tlsext_datalen != 1 ? "bytes" : "byte",
-        (int) ext_infolen, ext_info);
+        (int) ext_infolen, ext_info != NULL ? ext_info : "");
 
       if (bio != NULL) {
         BIO_free(bio);


### PR DESCRIPTION
To resolve the issue where there is a namespace collision between the mod_sftp READ and WRITE commands and the proftpd READ and WRITE classes, I propose that a suffix (default of 'FILE') be appended to the SFTP READ and WRITE commands.  However, to avoid it being a mandatory breaking change, this patch adds a configure directive, --with_sftp_readwrite_cmdsuffix to allow the builder the option of changing the name of the mod_sftp commands.  This directive takes an optional argument of the suffix to use, or will use the suffix of 'FILE' if no argument is provided changing the command names to READFILE and WRITEFILE.  Since these commands are still in the READ and WRITE classes, any limit or log directive that use the READ/WRITE classes will still apply to them, but they will now also be able to have those directives applied to just the mod_sftp read and write operations.  This allows, e.g., not logging SFTP read and write records to the log file by excluding just those specific lines rather than the entire class of commands.  If this directive is not given, the command names default to READ and WRITE, maintaining full compatibility with the current implementation.