### PR TITLE
Add command class CL_SFTPRW to allow SFTP READ & WRITE commands to be filtered

### DIFF
--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -10373,7 +10373,7 @@ static int fxp_handle_read(struct fxp_packet *fxp) {
 #endif
 
   cmd = fxp_cmd_alloc(fxp->pool, "READ", name);
-  cmd->cmd_class = CL_READ|CL_SFTP;
+  cmd->cmd_class = CL_READ|CL_SFTP|CL_SFTPRW;
   cmd->cmd_id = SFTP_CMD_ID;
 
   pr_scoreboard_entry_update(session.pid,
@@ -13431,7 +13431,7 @@ static int fxp_handle_write(struct fxp_packet *fxp) {
   pr_snprintf(cmd_arg, sizeof(cmd_arg)-1, "%s %" PR_LU " %lu", name,
     (pr_off_t) offset, (unsigned long) datalen);
   cmd = fxp_cmd_alloc(fxp->pool, "WRITE", cmd_arg);
-  cmd->cmd_class = CL_WRITE|CL_SFTP;
+  cmd->cmd_class = CL_WRITE|CL_SFTP|CL_SFTPRW;
   cmd->cmd_id = SFTP_CMD_ID;
 
   pr_scoreboard_entry_update(session.pid,

--- a/include/modules.h
+++ b/include/modules.h
@@ -87,6 +87,7 @@ typedef struct conftab_rec {
 #define CL_DISCONNECT	0x0100  /* Session end */
 #define CL_SSH		0x0200  /* SSH requests */
 #define CL_SFTP		0x0400  /* SFTP requests */
+#define CL_SFTPRW	0x0800  /* SFTP READ/WRITE requests */
 
 /* Note that CL_ALL explicitly does NOT include CL_DISCONNECT; this is to
  * preserve backward compatible behavior.

--- a/src/jot.c
+++ b/src/jot.c
@@ -3195,6 +3195,15 @@ static int filter_get_classes(pool *p, array_header *names,
         incl |= CL_SFTP;
       }
 
+    } else if (strcasecmp(name, "SFTPRW") == 0) {
+      if (exclude) {
+        incl &= ~CL_SFTPRW;
+        excl |= CL_SFTPRW;
+
+      } else {
+        incl |= CL_SFTPRW;
+      }
+
     } else {
       pr_trace_msg(trace_channel, 2, "ignoring unknown/unsupported class '%s'",
         name);
@@ -3271,6 +3280,10 @@ static array_header *filter_get_cmd_ids(pool *p, array_header *names,
 
         } else if (strcmp(name, "SFTP") == 0) {
           *included_classes |= CL_SFTP;
+          valid = TRUE;
+
+        } else if (strcmp(name, "SFTPRW") == 0) {
+          *included_classes |= CL_SFTPRW;
           valid = TRUE;
 
         } else if (strcmp(name, "SSH") == 0) {


### PR DESCRIPTION
In addition to the common (FTP & SFTP) RETR/STOR command, SFTP logs READ/WRITE commands for every chunk of data sent/received.  This can create large amounts of less-than-helpful log lines making it more difficult to quickly scan the log file.  This adds a class CL_SFTPRW that can be used to filter out the SFTP READ/WRITE commands in ExtendedLog config lines (e.g., ALL,!SFTPRW) without impacting other logging, and since it doesn't remove the commands from their existing classes it makes no change to existing proftpd logging configurations.  I believe that this is both a minimalist solution and avoids any backwards incompatibility.