### PR TITLE
Updating the FreeBSD image used for CirrusCI builds; looks like the `…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ task:
   name: build
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-0
+      image_family: freebsd-14-2
 
   env:
     CIRRUS_CLONE_DEPTH: 10


### PR DESCRIPTION
…freebsd-14-0` image is no longer available.