### PR TITLE
Issue #1898: Restore `LDAPDefaultGID` functionality, broken due to re…

### DIFF
--- a/contrib/mod_ldap.c
+++ b/contrib/mod_ldap.c
@@ -920,6 +920,9 @@ static struct passwd *pr_ldap_user_lookup(pool *p, char *filter_template,
               "LDAPDefaultGID Auto in effect but user name is missing");
             return NULL;
           }
+
+        } else {
+          pw->pw_gid = ldap_defaultgid;
         }
         ++i;
 


### PR DESCRIPTION
…gression in change for Issue #1716.