### PR TITLE
Issue #1923: Re-enable the commented-out `pool_create_sz_with_alloc_t…

### DIFF
--- a/tests/api/pool.c
+++ b/tests/api/pool.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - FTP server testsuite
- * Copyright (c) 2008-2021 The ProFTPD Project team
+ * Copyright (c) 2008-2025 The ProFTPD Project team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -140,37 +140,39 @@ START_TEST (pool_create_sz_with_alloc_test) {
      * the pool.
      */
     pool_sz = (32 * factors[i]);
-#ifdef PR_TEST_VERBOSE
+#if defined(PR_TEST_VERBOSE)
     fprintf(stdout, "pool_sz: %lu bytes (factor %u)\n", pool_sz, factors[i]);
 #endif /* PR_TEST_VERBOSE */
     sub_pool = pr_pool_create_sz(p, pool_sz);
     ck_assert_msg(sub_pool != NULL, "Failed to allocate %lu byte sub-pool", (unsigned long)pool_sz);
 
     alloc_sz = (pool_sz * 2);
-#ifdef PR_TEST_VERBOSE
+#if defined(PR_TEST_VERBOSE)
     fprintf(stdout, "alloc_sz: %lu bytes (factor %u)\n", (unsigned long)alloc_sz, factors[i]);
 #endif /* PR_TEST_VERBOSE */
     data = palloc(sub_pool, alloc_sz);
 
-    /* Initialize our allocated memory with some values. */
+    /* Initialize our allocated memory with some values.  Note that since
+     * we allocated an array of unsigned chars, the value range is 0-255.
+     */
     mark_point();
     for (j = 0; j < alloc_sz; j++) {
-      data[j] = j;
+      data[j] = j % 256;
     }
 
     /* Verify that our values are still there. */
     mark_point();
     for (j = 0; j < alloc_sz; j++) {
-#ifdef PR_TEST_VERBOSE
-      if (data[j] != j) {
+#if defined(PR_TEST_VERBOSE)
+      if (data[j] != j % 256) {
         fprintf(stdout,
           "Iteration #%u: Expected value %u at memory index %u, got %u\n",
-          i + 1, j, j, data[j]);
+          i + 1, j % 256, j, data[j]);
       }
 #endif /* PR_TEST_VERBOSE */
-      ck_assert_msg(data[j] == j,
+      ck_assert_msg(data[j] == j % 256,
         "Iteration #%u: Expected value %u at memory index %u, got %u\n", i + 1,
-        j, j, data[j]);
+        j % 256, j, data[j]);
     }
 
     destroy_pool(sub_pool);
@@ -479,23 +481,7 @@ Suite *tests_get_pool_suite(void) {
   tcase_add_test(testcase, pool_destroy_pool_test);
   tcase_add_test(testcase, pool_make_sub_pool_test);
   tcase_add_test(testcase, pool_create_sz_test);
-
-  /* Seems this particular testcase reveals a bug in the pool code.  On the
-   * third iteration of the loop (pool size = 256, alloc size = 512), the
-   * memory check fails.  Perhaps related to PR_TUNABLE_NEW_POOL_SIZE being
-   * 512 bytes?  Need to dig into this more.  In the mean time, keep the
-   * testcase commented out.
-   *
-   * Note: when it fails, it looks like:
-   *
-   *   api/pool.c:116:F:base:pool_create_sz_with_alloc_test:0: Iteration #3: Expected value 256 at memory index 256, got 0
-   *
-   * If the PR_TEST_VERBOSE macro is defined, you can see the printout of
-   * where the memory read does not meet expectations.
-   */
-#if 0
   tcase_add_test(testcase, pool_create_sz_with_alloc_test);
-#endif
   tcase_add_test(testcase, pool_palloc_test);
   tcase_add_test(testcase, pool_pallocsz_test);
   tcase_add_test(testcase, pool_pcalloc_test);


### PR DESCRIPTION
…est` API unit test, now that it passes by fixing my own bad assumptions.