### PR TITLE
Bug #4037: Adding regression tests that reproduce the provided config…

### DIFF
--- a/tests/t/config/ftpaccess/stor.t
+++ b/tests/t/config/ftpaccess/stor.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use lib qw(t/lib);
+use strict;
+
+use Test::Unit::HarnessUnit;
+
+$| = 1;
+
+my $r = Test::Unit::HarnessUnit->new();
+$r->start("ProFTPD::Tests::Config::FTPAccess::STOR");

--- a/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/STOR.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/FTPAccess/STOR.pm
@@ -1,0 +1,180 @@
+package ProFTPD::Tests::Config::FTPAccess::STOR;
+
+use lib qw(t/lib);
+use base qw(ProFTPD::TestSuite::Child);
+use strict;
+
+use File::Path qw(mkpath);
+use File::Spec;
+use IO::Handle;
+
+use ProFTPD::TestSuite::FTP;
+use ProFTPD::TestSuite::Utils qw(:auth :config :running :test :testsuite);
+
+$| = 1;
+
+my $order = 0;
+
+my $TESTS = {
+  ftpaccess_stor_bug4037 => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
+};
+
+sub new {
+  return shift()->SUPER::new(@_);
+}
+
+sub list_tests {
+  return testsuite_get_runnable_tests($TESTS);
+}
+
+sub ftpaccess_stor_bug4037 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'ftpaccess');
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/foo/bar/upload");
+  mkpath($sub_dir);
+
+  my $ftpaccess_file = File::Spec->rel2abs("$sub_dir/.ftpaccess");
+  if (open(my $fh, "> $ftpaccess_file")) {
+    print $fh <<EOF;
+<Limit WRITE>
+  AllowGroup other
+  DenyAll
+</Limit>
+EOF
+
+    unless (close($fh)) {
+      die("Can't write $ftpaccess_file: $!");
+    }
+
+  } else {
+    die("Can't open $ftpaccess_file: $!");
+  }
+
+  my $upload_dir = File::Spec->rel2abs("$tmpdir/foo/bar/upload");
+  mkpath($upload_dir);
+
+  $ftpaccess_file = File::Spec->rel2abs("$upload_dir/.ftpaccess");
+  if (open(my $fh, "> $ftpaccess_file")) {
+    print $fh <<EOF;
+<Limit WRITE>
+  AllowGroup ftpd
+  AllowGroup other
+  DenyAll
+</Limit>
+EOF
+
+    unless (close($fh)) {
+      die("Can't write $ftpaccess_file: $!");
+    }
+
+  } else {
+    die("Can't open $ftpaccess_file: $!");
+  }
+
+  # Make sure that, if we're running as root, that the home directory has
+  # permissions/privs set for the account we create
+  if ($< == 0) {
+    unless (chmod(0755, $sub_dir, $upload_dir)) {
+      die("Can't set perms on $sub_dir to 0755: $!");
+    }
+
+    unless (chown($setup->{uid}, $setup->{gid}, $sub_dir, $upload_dir)) {
+      die("Can't set owner of $sub_dir to $setup->{uid}/$setup->{gid}: $!");
+    }
+  }
+
+  # Note that I also tested (as of 2025-04-17, using ProFTPD 1.3.10rc1)
+  # this config with "DefaultRoot ~" enabled; it still succeeded.
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    AllowOverride => 'on',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+
+    Limit => {
+      WRITE => {
+        DenyAll => '',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $conn = $client->stor_raw("foo/bar/upload/test.txt");
+      unless ($conn) {
+        die("STOR foo/bar/upload/test.txt failed: " . $client->response_code() .
+          " " . $client->response_msg());
+      }
+
+      my $buf = "Hello, World!\n";
+      $conn->write($buf, length($buf), 25);
+      eval { $conn->close() };
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+1;

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -205,7 +205,9 @@ if (scalar(@ARGV) > 0) {
     t/config/ftpaccess/empty.t
     t/config/ftpaccess/merging.t
     t/config/ftpaccess/retr.t
+    t/config/ftpaccess/stor.t
     t/config/limit/anonymous.t
+    t/config/limit/list.t
     t/config/limit/login.t
     t/config/limit/mfmt.t
     t/config/limit/opts.t


### PR DESCRIPTION
…uration; the test behavior shows uploads as expected via `.ftpaccess` configurations.