### PR TITLE
use $(LIBTOOL) to install proftpd

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -134,7 +134,7 @@ $(DESTDIR)$(localedir) $(DESTDIR)$(includedir) $(DESTDIR)$(includedir)/proftpd $
 	fi
 
 install-proftpd: $(DESTDIR)$(includedir) $(DESTDIR)$(localstatedir) $(DESTDIR)$(sysconfdir) $(DESTDIR)$(sbindir)
-	$(INSTALL_SBIN) $(top_builddir)/proftpd $(DESTDIR)$(sbindir)/proftpd
+	$(LIBTOOL) --mode=install --tag=CC $(INSTALL_SBIN) $(top_builddir)/proftpd $(DESTDIR)$(sbindir)/proftpd
 	if [ -f $(DESTDIR)$(sbindir)/in.proftpd ] ; then \
 		rm -f $(DESTDIR)$(sbindir)/in.proftpd ; \
 	fi


### PR DESCRIPTION
With slibtool `make install` will install the slibtool wrapper script instead of the actual executable file. This is because with slibtool the executable is compiled into the `.libs` directory while the file in the root directory is a wrapper script where with GNU libtool the executable will be placed into the root directory. Using `$(LIBTOOL)` to install the executable will ensure that both implementations install the correct file.

Gentoo-Issue: https://bugs.gentoo.org/953968