### PR TITLE
don't include attr/xattr.h

### DIFF
--- a/include/fsio.h
+++ b/include/fsio.h
@@ -37,10 +37,9 @@
 #  include <sys/extattr.h>
 # elif defined(HAVE_SYS_XATTR_H)
 #  include <sys/xattr.h>
-#  if defined(HAVE_ATTR_XATTR_H)
+# elif defined(HAVE_ATTR_XATTR_H)
 #   include <attr/xattr.h>
-#  endif /* HAVE_ATTR_XATTR_H */
-# endif /* HAVE_SYS_XATTR_H */
+# endif
 #endif /* PR_USE_XATTR */
 
 /* This is a Tru64-specific hack, to work around some macro funkiness


### PR DESCRIPTION
There is no reason to include `attr/xattr.h` when `sys/xattr.h` is included.

This silences a very verbose warning.
```
In file included from ../include/fsio.h:41,
                 from ../include/conf.h:105,
                 from ftpdctl.c:27:
/usr/include/attr/xattr.h:5:2: warning: #warning "Please change your <attr/xattr.h> includes to <sys/xattr.h>" [-Wcpp]
    5 | #warning "Please change your <attr/xattr.h> includes to <sys/xattr.h>"
      |  ^~~~~~~
```