### PR TITLE
Fix: Prevent potential NULL dereference of fh in pr_fsio_open()

### DIFF
--- a/src/fsio.c
+++ b/src/fsio.c
@@ -5091,6 +5091,10 @@ pr_fh_t *pr_fsio_open_canon(const char *name, int flags) {
   pr_pool_tag(tmp_pool, "pr_fsio_open_canon() subpool");
 
   fh = pcalloc(tmp_pool, sizeof(pr_fh_t));
+  if (fh == NULL) {
+	  destroy_pool(tmp_pool);
+	  return NULL;
+	}
   fh->fh_pool = tmp_pool;
   fh->fh_path = pstrdup(fh->fh_pool, name);
   fh->fh_fd = -1;


### PR DESCRIPTION
### Description

Hi,
This patch addresses a potential CWE-476: NULL Pointer Dereference vulnerability by ensuring the fh pointer returned from pcalloc() is valid before use.

Previously, the fh pointer was used immediately after allocation without a null check. If pcalloc() fails (e.g., due to out-of-memory conditions), accessing fh->fh_pool would result in undefined behavior or a server crash.

### Expected Behavior

The function pr_fsio_open() should:
- Allocate memory safely for the pr_fh_t structure
- Handle allocation failures gracefully
- Avoid dereferencing fh unless it is verified to be non-NULL

### Actual Behavior (Before Patch)

In the original implementation:
- pcalloc() is called to allocate a pr_fh_t structure
- The result is immediately dereferenced without checking for NULL
- On allocation failure, this can lead to a NULL pointer dereference

fh = pcalloc(tmp_pool, sizeof(pr_fh_t));
fh->fh_pool = tmp_pool;  // ← if fh is NULL, this will crash


### Patch
This patch adds a NULL check to guard against dereferencing fh when memory allocation fails:
``` c
fh = pcalloc(tmp_pool, sizeof(pr_fh_t));
if (fh == NULL) {
  destroy_pool(tmp_pool);
  return NULL;
}
``` 
This ensures that the function exits early if pcalloc() fails, preventing unsafe memory access.

### Notes

This fix is minimal, localized, and introduces no side effects
Fully backward-compatible; does not affect normal control flow
Aligns with secure coding best practices

Thank you for your consideration. I look forward to your feedback.