### PR TITLE
Fix GNU/Hurd build

### DIFF
--- a/contrib/mod_sftp/utf8.c
+++ b/contrib/mod_sftp/utf8.c
@@ -52,11 +52,11 @@ static int utf8_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
     pr_signals_handle();
 
     /* Solaris/FreeBSD's iconv(3) takes a const char ** for the input buffer,
-     * whereas Linux/Mac OSX iconv(3) use char ** for the input buffer.
+     * whereas Linux/Mac OSX/GNU iconv(3) use char ** for the input buffer.
      */
 #if defined(LINUX) || defined(DARWIN6) || defined(DARWIN7) || \
     defined(DARWIN8) || defined(DARWIN9) || defined(DARWIN10) || \
-    defined(DARWIN11) || defined(DARWIN12)
+    defined(DARWIN11) || defined(DARWIN12) || defined(GNU)
 
     nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
 #else

--- a/src/encode.c
+++ b/src/encode.c
@@ -60,11 +60,11 @@ static int str_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
     pr_signals_handle();
 
     /* Solaris/FreeBSD's iconv(3) takes a const char ** for the input buffer,
-     * whereas Linux/Mac OSX iconv(3) use char ** for the input buffer.
+     * whereas Linux/Mac OSX/GNU iconv(3) use char ** for the input buffer.
      */
 #if defined(LINUX) || defined(DARWIN6) || defined(DARWIN7) || \
     defined(DARWIN8) || defined(DARWIN9) || defined(DARWIN10) || \
-    defined(DARWIN11) || defined(DARWIN12)
+    defined(DARWIN11) || defined(DARWIN12) || defined(GNU)
 
     nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
 #else


### PR DESCRIPTION
GNU/Hurd uses the same glibc as Linux, and as such also follows posix by making the 2nd parameter of iconv() a char**.