### PR TITLE
fix C23, functions unprototyped

### DIFF
--- a/lib/pr_fnmatch.c
+++ b/lib/pr_fnmatch.c
@@ -355,10 +355,7 @@ is_char_class (const wchar_t *wcs)
 
 
 int
-pr_fnmatch (pattern, string, flags)
-     const char *pattern;
-     const char *string;
-     int flags;
+pr_fnmatch (const char *pattern, const char *string, int flags)
 {
 # if HANDLE_MULTIBYTE
   if (__builtin_expect (MB_CUR_MAX, 1) != 1)

--- a/lib/pr_fnmatch_loop.c
+++ b/lib/pr_fnmatch_loop.c
@@ -62,13 +62,8 @@ __mempcpy (void *dest, const void *src, size_t n)
 
 static int
 internal_function
-FCT (pattern, string, string_end, no_leading_period, flags, ends)
-     const CHAR *pattern;
-     const CHAR *string;
-     const CHAR *string_end;
-     int no_leading_period;
-     int flags;
-     struct STRUCT *ends;
+FCT (const CHAR *pattern, const CHAR *string, const CHAR *string_end,
+	int no_leading_period, int flags, struct STRUCT *ends)
 {
   register const CHAR *p = pattern, *n = string;
   register UCHAR c;

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -325,7 +325,7 @@ static int mcache_ping_servers(pr_memcache_t *mcache) {
 
   alive_server_list = NULL;
   for (i = 0; i < server_count; i++) {
-    memcached_server_instance_st server;
+    const memcached_instance_st * server;
 
     server = memcached_server_instance_by_position(clone, i);
 
@@ -448,7 +448,7 @@ static int mcache_stat_servers(pr_memcache_t *mcache) {
           case MEMCACHED_SOME_ERRORS:
           case MEMCACHED_SERVER_MARKED_DEAD:
           case MEMCACHED_CONNECTION_FAILURE: {
-            memcached_server_instance_st server;
+            const memcached_instance_st * server;
 
             server = memcached_server_get_last_disconnect(mcache->mc);
             if (server != NULL) {
@@ -988,7 +988,7 @@ int pr_memcache_kadd(pr_memcache_t *mcache, module *m, const char *key,
 
     case MEMCACHED_SERVER_MARKED_DEAD:
     case MEMCACHED_CONNECTION_FAILURE: {
-      memcached_server_instance_st server;
+      const memcached_instance_st * server;
 
       server = memcached_server_get_last_disconnect(mcache->mc);
       if (server != NULL) {
@@ -1058,7 +1058,7 @@ int pr_memcache_kdecr(pr_memcache_t *mcache, module *m, const char *key,
 
     case MEMCACHED_SERVER_MARKED_DEAD:
     case MEMCACHED_CONNECTION_FAILURE: {
-      memcached_server_instance_st server;
+      const memcached_instance_st * server;
 
       server = memcached_server_get_last_disconnect(mcache->mc);
       if (server != NULL) {
@@ -1131,7 +1131,7 @@ void *pr_memcache_kget(pr_memcache_t *mcache, module *m, const char *key,
 
       case MEMCACHED_SERVER_MARKED_DEAD:
       case MEMCACHED_CONNECTION_FAILURE: {
-        memcached_server_instance_st server;
+        const memcached_instance_st * server;
 
         server = memcached_server_get_last_disconnect(mcache->mc);
         if (server != NULL) {
@@ -1213,7 +1213,7 @@ char *pr_memcache_kget_str(pr_memcache_t *mcache, module *m, const char *key,
 
       case MEMCACHED_SERVER_MARKED_DEAD:
       case MEMCACHED_CONNECTION_FAILURE: {
-        memcached_server_instance_st server;
+        const memcached_instance_st * server;
 
         server = memcached_server_get_last_disconnect(mcache->mc);
         if (server != NULL) {
@@ -1303,7 +1303,7 @@ int pr_memcache_kincr(pr_memcache_t *mcache, module *m, const char *key,
 
     case MEMCACHED_SERVER_MARKED_DEAD:
     case MEMCACHED_CONNECTION_FAILURE: {
-      memcached_server_instance_st server;
+      const memcached_instance_st * server;
 
       server = memcached_server_get_last_disconnect(mcache->mc);
       if (server != NULL) {
@@ -1368,7 +1368,7 @@ int pr_memcache_kremove(pr_memcache_t *mcache, module *m, const char *key,
 
     case MEMCACHED_SERVER_MARKED_DEAD:
     case MEMCACHED_CONNECTION_FAILURE: {
-      memcached_server_instance_st server;
+      const memcached_instance_st * server;
 
       server = memcached_server_get_last_disconnect(mcache->mc);
       if (server != NULL) {
@@ -1437,7 +1437,7 @@ int pr_memcache_kset(pr_memcache_t *mcache, module *m, const char *key,
 
     case MEMCACHED_SERVER_MARKED_DEAD:
     case MEMCACHED_CONNECTION_FAILURE: {
-      memcached_server_instance_st server;
+      const memcached_instance_st * server;
 
       server = memcached_server_get_last_disconnect(mcache->mc);
       if (server != NULL) {


### PR DESCRIPTION
>./pr_fnmatch_loop.c:65:1: error:
>a function definition without a prototype is deprecated in all versions of C and
>      is not supported in C23 [-Werror,-Wdeprecated-non-prototype]
>   65 | FCT (pattern, string, string_end, no_leading_period, flags, ends)
>      | ^
>pr_fnmatch.c:241:14: note: expanded from macro 'FCT'
>  241 | # define FCT    internal_fnmatch
>In file included from mod_core.c:29:
>pr_fnmatch.c:358:1: error:
>a function definition without a prototype is deprecated in all versions of C and is not
>      supported in C23 [-Werror,-Wdeprecated-non-prototype]

>memcache.c:330:12: error:
>assigning to 'memcached_server_instance_st' (aka 'struct memcached_instance_st *') from
>      'const memcached_instance_st *' (aka 'const struct memcached_instance_st *') discards qualifiers
>      [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
>  330 |     server = memcached_server_instance_by_position(clone, i);
>      |            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~