### PR TITLE
(Fix_1977) Inconsistency Between proftpd and RFC 959: Violation of Telnet String Requirement in Argument Field

### DIFF
--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -2469,6 +2469,10 @@ MODRET auth_user(cmd_rec *cmd) {
 
   user = cmd->arg;
 
+  if (strchr(user, '\r') != NULL || strchr(user, '\n') != NULL) {
+    return PR_ERROR_MSG(cmd, R_501, _("Syntax error, parameters or arguments contain invalid characters"));
+  }
+
   (void) pr_table_remove(session.notes, "mod_auth.orig-user", NULL);
   (void) pr_table_remove(session.notes, "mod_auth.anon-passwd", NULL);
 
@@ -2665,12 +2669,17 @@ MODRET auth_pass(cmd_rec *cmd) {
     return PR_ERROR_MSG(cmd, R_503, _("You are already logged in"));
   }
 
+
   user = pr_table_get(session.notes, "mod_auth.orig-user", NULL);
   if (user == NULL) {
     (void) pr_table_remove(session.notes, "mod_auth.orig-user", NULL);
     (void) pr_table_remove(session.notes, "mod_auth.anon-passwd", NULL);
 
     return PR_ERROR_MSG(cmd, R_503, _("Login with USER first"));
+  }
+
+  if (strchr(cmd->arg, '\r') != NULL || strchr(cmd->arg, '\n') != NULL) {
+    return PR_ERROR_MSG(cmd, R_501, _("Syntax error, parameters or arguments contain invalid characters"));
   }
 
   /* Clear any potentially cached directory config */


### PR DESCRIPTION
- Fix: #1977 
- To address this issue, we implemented checks for the argument field in the relevant functions to handle and report violations of the Telnet String Requirement. (`USER` and `PASS`)