### PR TITLE
(Fix_1976) Inconsistency Between proftpd and RFC 959: Violation of state transition between USER and PASS commands.

### DIFF
--- a/contrib/mod_copy.c
+++ b/contrib/mod_copy.c
@@ -557,6 +557,7 @@ MODRET set_copyoptions(cmd_rec *cmd) {
  */
 
 MODRET copy_copy(cmd_rec *cmd) {
+  access_username = FALSE;
   if (copy_engine == FALSE) {
     return PR_DECLINED(cmd);
   }
@@ -664,6 +665,7 @@ MODRET copy_copy(cmd_rec *cmd) {
 }
 
 MODRET copy_cpfr(cmd_rec *cmd) {
+  access_username = FALSE;
   register unsigned int i;
   int res;
   char *cmd_name, *path = "";
@@ -782,6 +784,7 @@ MODRET copy_cpfr(cmd_rec *cmd) {
 }
 
 MODRET copy_cpto(cmd_rec *cmd) {
+  access_username = FALSE;
   register unsigned int i;
   const char *from, *to = "";
   char *cmd_name;

--- a/contrib/mod_quotatab.c
+++ b/contrib/mod_quotatab.c
@@ -4196,6 +4196,7 @@ MODRET quotatab_pre_site(cmd_rec *cmd) {
 }
 
 MODRET quotatab_site(cmd_rec *cmd) {
+  access_username = FALSE;
 
   /* Make sure it's a valid SITE QUOTA command */
   if (cmd->argc < 2) {

--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -564,6 +564,7 @@ MODRET set_sitemiscengine(cmd_rec *cmd) {
  */
 
 MODRET site_misc_mkdir(cmd_rec *cmd) {
+  access_username = FALSE;
   if (!site_misc_engine) {
     return PR_DECLINED(cmd);
   }
@@ -675,6 +676,7 @@ MODRET site_misc_mkdir(cmd_rec *cmd) {
 }
 
 MODRET site_misc_rmdir(cmd_rec *cmd) {
+  access_username = FALSE;
   if (!site_misc_engine) {
     return PR_DECLINED(cmd);
   }
@@ -774,6 +776,7 @@ MODRET site_misc_rmdir(cmd_rec *cmd) {
 }
 
 MODRET site_misc_symlink(cmd_rec *cmd) {
+  access_username = FALSE;
   if (!site_misc_engine) {
     return PR_DECLINED(cmd);
   }
@@ -1244,6 +1247,7 @@ MODRET site_misc_utime_atime_mtime_ctime(cmd_rec *cmd) {
 }
 
 MODRET site_misc_utime(cmd_rec *cmd) {
+  access_username = FALSE;
   if (!site_misc_engine) {
     return PR_DECLINED(cmd);
   }

--- a/include/conf.h
+++ b/include/conf.h
@@ -121,6 +121,8 @@
 #include "memcache.h"
 #include "redis.h"
 
+extern int access_username;
+
 # ifdef HAVE_SETPASSENT
 #  define setpwent()	setpassent(1)
 # endif /* HAVE_SETPASSENT */

--- a/modules/mod_site.c
+++ b/modules/mod_site.c
@@ -550,6 +550,7 @@ static cmdtable site_commands[] = {
 
 modret_t *site_dispatch(cmd_rec *cmd) {
   register unsigned int i = 0;
+  access_username = FALSE;
 
   if (!cmd->argc) {
     pr_response_add_err(R_500, _("'SITE' requires parameters"));

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -1310,6 +1310,7 @@ static int get_hidden_store_path(cmd_rec *cmd, const char *path,
 }
 
 MODRET xfer_opts_rest(cmd_rec *cmd) {
+  access_username = FALSE;
   register unsigned int i;
   char *method, *xfer_cmd;
   unsigned char *authenticated;


### PR DESCRIPTION
- Fix: #1976 

- To address this issue, we:
    1. Introduce a new state flag `access_username`  in `./include/conf.h`;
    2. Update the `access_username` state whenever other commands are issued between the USER and PASS commands;
    3. Add an additional check within the `auth_pass` function to verify whether USER immediately followed by PASS (./modules/mod_auth.c).

If there are aspects that need adjustment, I would be more than happy to assist.

Thank you for your attention, and I look forward to your response.