### PR TITLE
Issue #2009: The MaxLoginAttemptsFromUser ban event from SFTP session…

### DIFF
--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp/ban.pm
@@ -29,6 +29,11 @@ my $TESTS = {
     test_class => [qw(bug forking mod_ban sftp ssh2)],
   },
 
+  sftp_ban_max_login_attempts_per_user_issue2009 => {
+    order => ++$order,
+    test_class => [qw(bug forking mod_ban sftp ssh2)],
+  },
+
 };
 
 sub new {
@@ -80,40 +85,9 @@ sub set_up {
 sub sftp_ban_max_login_attempts {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
-
-  my $config_file = "$tmpdir/sftp.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/sftp.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/sftp.scoreboard");
-
-  my $log_file = test_get_logfile();
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/sftp.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/sftp.group");
+  my $setup = test_setup($tmpdir, 'sftp-ban');
 
   my $ban_tab = File::Spec->rel2abs("$tmpdir/sftp-ban.tab");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $group = 'ftpd';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, $group, $gid, $user);
 
   my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
   my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
@@ -121,14 +95,14 @@ sub sftp_ban_max_login_attempts {
   my $rsa_priv_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key');  my $rsa_pub_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key.pub');
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
-    TraceLog => $log_file,
-    Trace => 'DEFAULT:10 ssh2:20 sftp:20 scp:20',
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'DEFAULT:10 ban:20 ssh2:20 sftp:20',
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     MaxLoginAttempts => 1,
@@ -136,7 +110,7 @@ sub sftp_ban_max_login_attempts {
     IfModules => {
       'mod_ban.c' => {
         BanEngine => 'on',
-        BanLog => $log_file,
+        BanLog => $setup->{log_file},
 
         # This says to ban a client which exceeds the MaxLoginAttempts
         # limit once within the last 1 minute will be banned for 10 secs
@@ -151,14 +125,15 @@ sub sftp_ban_max_login_attempts {
 
       'mod_sftp.c' => [
         "SFTPEngine on",
-        "SFTPLog $log_file",
+        "SFTPLog $setup->{log_file}",
         "SFTPHostKey $rsa_host_key",
         "SFTPHostKey $dsa_host_key",
       ],
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -186,7 +161,7 @@ sub sftp_ban_max_login_attempts {
         die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
       }
 
-      if ($ssh2->auth_password($user, 'foo')) {
+      if ($ssh2->auth_password($setup->{user}, 'foo')) {
         die("Password auth (wrong password) succeeded unexpectedly");
       }
 
@@ -202,7 +177,6 @@ sub sftp_ban_max_login_attempts {
         die("Connecting to SSH2 server succeeded unexpectedly");
       }
     };
-
     if ($@) {
       $ex = $@;
     }
@@ -211,7 +185,7 @@ sub sftp_ban_max_login_attempts {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -221,18 +195,10 @@ sub sftp_ban_max_login_attempts {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    test_append_logfile($log_file, $ex);
-    unlink($log_file);
-
-    die($ex);
-  }
-
-  unlink($log_file);
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub sftp_ban_maxcmdrate_exceeded {
@@ -413,6 +379,133 @@ sub sftp_ban_maxcmdrate_exceeded {
   }
 
   unlink($log_file);
+}
+
+sub sftp_ban_max_login_attempts_per_user_issue2009 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'sftp-ban');
+
+  my $ban_tab = File::Spec->rel2abs("$tmpdir/sftp-ban.tab");
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/ssh_host_dsa_key');
+
+  my $rsa_priv_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key');  my $rsa_pub_key = File::Spec->rel2abs('t/etc/modules/mod_sftp/test_rsa_key.pub');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'DEFAULT:10 ban:20 ssh2:20 sftp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    MaxLoginAttempts => 1,
+
+    IfModules => {
+      'mod_ban.c' => {
+        BanEngine => 'on',
+        BanLog => $setup->{log_file},
+
+        # This says to ban a user which exceeds the MaxLoginAttempts
+        # limit once within the last 1 minute will be banned for 10 secs
+        BanOnEvent => 'MaxLoginAttemptsFromUser 1/00:01:00 00:00:10',
+
+        BanTable => $ban_tab,
+      },
+
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  require Net::SSH2;
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $ssh2 = Net::SSH2->new();
+
+      sleep(1);
+
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      if ($ssh2->auth_password($setup->{user}, 'foo')) {
+        die("Password auth (wrong password) succeeded unexpectedly");
+      }
+
+      $ssh2->disconnect();
+
+      # Now try the correct password for authentication, which would succeed --
+      # except that mod_ban should now have a ban in place, and prevent us
+      # from doing this.  Note that we need to create a new connection to test
+      # the mod_ban rules.
+
+      $ssh2 = Net::SSH2->new();
+
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      if ($ssh2->auth_password($setup->{user}, $setup->{passwd})) {
+        die("Password auth (wrong password) succeeded unexpectedly");
+      }
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 1;


### PR DESCRIPTION
…s was not being properly honored due to unexpected (but necessary) cleanup happening in the core modules.

The mod_sftp module now deals with such core module cleanups properly, restoring proper implementation of this ban event for SFTP sessions.