### PR TITLE
`doc/contrib/mod_tls.html`: Fix typo "TLSEC[A]CertificateFile"

### DIFF
--- a/doc/contrib/mod_tls.html
+++ b/doc/contrib/mod_tls.html
@@ -57,7 +57,7 @@ is based.  His module can be found here:
   <li><a href="#TLSDHParamFile">TLSDHParamFile</a>
   <li><a href="#TLSDSACertificateFile">TLSDSACertificateFile</a>
   <li><a href="#TLSDSACertificateKeyFile">TLSDSACertificateKeyFile</a>
-  <li><a href="#TLSECCertificateFile">TLSECACertificateFile</a>
+  <li><a href="#TLSECCertificateFile">TLSECCertificateFile</a>
   <li><a href="#TLSECCertificateKeyFile">TLSECCertificateKeyFile</a>
   <li><a href="#TLSECDHCurve">TLSECDHCurve</a>
   <li><a href="#TLSEngine">TLSEngine</a>


### PR DESCRIPTION
.. in section "Directives" as can be seen at http://www.proftpd.org/docs/contrib/mod_tls.html :

<img width="280" height="393" alt="directives" src="https://github.com/user-attachments/assets/9748d531-2454-42be-9a43-b1b3105d6eac" />

CC @Castaglia
