### PR TITLE
`src/encode.c`: Fix call to `iconv` to fix the CI

### DIFF
--- a/contrib/mod_sftp/utf8.c
+++ b/contrib/mod_sftp/utf8.c
@@ -51,17 +51,7 @@ static int utf8_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
 
     pr_signals_handle();
 
-    /* Solaris/FreeBSD's iconv(3) takes a const char ** for the input buffer,
-     * whereas Linux/Mac OSX/GNU iconv(3) use char ** for the input buffer.
-     */
-#if defined(LINUX) || defined(DARWIN6) || defined(DARWIN7) || \
-    defined(DARWIN8) || defined(DARWIN9) || defined(DARWIN10) || \
-    defined(DARWIN11) || defined(DARWIN12) || defined(GNU)
-
     nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
-#else
-    nconv = iconv(conv, &inbuf, inbuflen, &outbuf, outbuflen);
-#endif
 
     if (nconv == (size_t) -1) {
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -59,17 +59,7 @@ static int str_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
 
     pr_signals_handle();
 
-    /* Solaris/FreeBSD's iconv(3) takes a const char ** for the input buffer,
-     * whereas Linux/Mac OSX/GNU iconv(3) use char ** for the input buffer.
-     */
-#if defined(LINUX) || defined(DARWIN6) || defined(DARWIN7) || \
-    defined(DARWIN8) || defined(DARWIN9) || defined(DARWIN10) || \
-    defined(DARWIN11) || defined(DARWIN12) || defined(GNU)
-
     nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
-#else
-    nconv = iconv(conv, &inbuf, inbuflen, &outbuf, outbuflen);
-#endif
 
     if (nconv == (size_t) -1) {
 

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -50,7 +50,7 @@ static int utf8_convert(iconv_t conv, char *inbuf, size_t *inbuflen,
 
     pr_signals_handle();
 
-    nconv = iconv(conv, &inbuf, inbuflen, &outbuf, outbuflen);
+    nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
     if (nconv == (size_t) -1) {
       if (errno == EINVAL) {
         memmove(start, inbuf, *inbuflen);


### PR DESCRIPTION
Neither latest FreeBSD nor latest Solaris want `const char **` input.

On FreeBSD, [the symptom](https://github.com/proftpd/proftpd/runs/60830959156) was:
```
encode.c: In function 'str_convert':
encode.c:71:25: error: passing argument 2 of 'libiconv' from incompatible pointer type [-Wincompatible-pointer-types]
   71 |     nconv = iconv(conv, &inbuf, inbuflen, &outbuf, outbuflen);
      |                         ^~~~~~
      |                         |
      |                         const char **
In file included from encode.c:32:
/usr/local/include/iconv.h:84:43: note: expected 'char **' but argument is of type 'const char **'
   84 | extern size_t iconv (iconv_t cd,  char* * inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
      |                                   ~~~~~~~~^~~~~
```

CC @Castaglia
