### PR TITLE
mod_tls: allow build with OpenSSL 4.x

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -805,7 +805,7 @@ static void tls_setup_notes(pool *p, SSL *ssl);
 static int tls_verify_cb(int ok, X509_STORE_CTX *ctx);
 static int tls_verify_crl(int ok, X509_STORE_CTX *ctx);
 static int tls_verify_ocsp(int ok, X509_STORE_CTX *ctx);
-static char *tls_x509_name_oneline(X509_NAME *x509_name);
+static char *tls_x509_name_oneline(const X509_NAME *x509_name);
 
 static int tls_readmore(int fd);
 static int tls_writemore(int fd);
@@ -2984,9 +2984,9 @@ static int tls_cert_match_ip_san(pool *p, X509 *cert, const char *ipstr) {
 
 static char *tls_get_cert_cn(pool *p, X509 *cert) {
   int idx = -1;
-  X509_NAME *subj_name = NULL;
-  X509_NAME_ENTRY *cn_entry = NULL;
-  ASN1_STRING *cn_asn1 = NULL;
+  const X509_NAME *subj_name = NULL;
+  const X509_NAME_ENTRY *cn_entry = NULL;
+  const ASN1_STRING *cn_asn1 = NULL;
   char *cn_str = NULL;
   size_t cn_len = 0;
 
@@ -6427,7 +6427,7 @@ static int ocsp_add_cached_response(pool *p, const char *fingerprint,
   return res;
 }
 
-static int tls_feature_cmp(ASN1_STRING *str, void *feat_data,
+static int tls_feature_cmp(const ASN1_STRING *str, void *feat_data,
     size_t feat_datasz) {
   int is_feat = FALSE, res;
   ASN1_STRING *feat;
@@ -6471,8 +6471,8 @@ static int tls_cert_must_staple(X509 *cert, int *v2) {
 
   for (i = 0; i < ext_count; i++) {
     char buf[1024];
-    X509_EXTENSION *ext;
-    ASN1_OBJECT *obj;
+    const X509_EXTENSION *ext;
+    const ASN1_OBJECT *obj;
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(HAVE_LIBRESSL)) || \
     (defined(HAVE_LIBRESSL) && LIBRESSL_VERSION_NUMBER >= 0x3050000L)
@@ -6488,7 +6488,7 @@ static int tls_cert_must_staple(X509 *cert, int *v2) {
     /* Double-check that the OID is that of the "TLS Feature" extension. */
     if (strcmp(buf, TLS_X509V3_TLS_FEAT_OID_TEXT) == 0) {
       char status_request[] = TLS_X509V3_TLS_FEAT_STATUS_REQUEST;
-      ASN1_OCTET_STRING *value;
+      const ASN1_OCTET_STRING *value;
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(HAVE_LIBRESSL)) || \
     (defined(HAVE_LIBRESSL) && LIBRESSL_VERSION_NUMBER >= 0x3050000L)
@@ -9699,14 +9699,14 @@ static int tls_cert_to_user(const char *user_name, const char *field_name) {
   }
 
   if (strcmp(field_name, "CommonName") == 0) {
-    X509_NAME *name;
+    const X509_NAME *name;
     int pos = -1;
 
     name = X509_get_subject_name(client_cert);
 
     while (TRUE) {
-      X509_NAME_ENTRY *entry;
-      ASN1_STRING *data;
+      const X509_NAME_ENTRY *entry;
+      const ASN1_STRING *data;
       int data_len;
       const unsigned char *data_str = NULL;
 
@@ -9817,8 +9817,8 @@ static int tls_cert_to_user(const char *user_name, const char *field_name) {
       register int i;
 
       for (i = 0; i < nexts; i++) {
-        X509_EXTENSION *ext = NULL;
-        ASN1_OBJECT *asn_object = NULL;
+        const X509_EXTENSION *ext = NULL;
+        const ASN1_OBJECT *asn_object = NULL;
         char oid[PR_TUNABLE_PATH_MAX];
 
         pr_signals_handle();
@@ -9830,7 +9830,7 @@ static int tls_cert_to_user(const char *user_name, const char *field_name) {
         memset(oid, '\0', sizeof(oid));
         if (OBJ_obj2txt(oid, sizeof(oid)-1, asn_object, 1) > 0) {
           if (strcmp(oid, field_name) == 0) {
-            ASN1_OCTET_STRING *asn_data = NULL;
+            const ASN1_OCTET_STRING *asn_data = NULL;
             const unsigned char *asn_datastr = NULL;
             int asn_datalen;
 
@@ -10127,7 +10127,7 @@ static void tls_setup_cert_ext_environ(const char *env_prefix, X509 *cert) {
  *   email                   Email         NID_pkcs9_emailAddress
  */
 
-static void tls_setup_cert_dn_environ(const char *env_prefix, X509_NAME *name) {
+static void tls_setup_cert_dn_environ(const char *env_prefix, const X509_NAME *name) {
   register int i;
   int nentries;
   char *k, *v;
@@ -10139,7 +10139,7 @@ static void tls_setup_cert_dn_environ(const char *env_prefix, X509_NAME *name) {
 #endif /* OpenSSL-1.1.x and later */
 
   for (i = 0; i < nentries; i++) {
-    X509_NAME_ENTRY *entry;
+    const X509_NAME_ENTRY *entry;
     const unsigned char *entry_data;
     int nid, entry_len;
 
@@ -10256,7 +10256,7 @@ static void tls_setup_cert_environ(pool *p, const char *env_prefix,
     char buf[80] = {'\0'};
     ASN1_INTEGER *serial = X509_get_serialNumber(cert);
     const X509_ALGOR *algo = NULL;
-    X509_PUBKEY *pubkey = NULL;
+    const X509_PUBKEY *pubkey = NULL;
 
     memset(buf, '\0', sizeof(buf));
     pr_snprintf(buf, sizeof(buf) - 1, "%lu", X509_get_version(cert) + 1);
@@ -10266,7 +10266,7 @@ static void tls_setup_cert_environ(pool *p, const char *env_prefix,
     v = pstrdup(p, buf);
     pr_env_set(p, k, v);
 
-    if (serial->length < 4) {
+    if (ASN1_STRING_length(serial) < 4) {
       memset(buf, '\0', sizeof(buf));
       pr_snprintf(buf, sizeof(buf) - 1, "%lu", ASN1_INTEGER_get(serial));
       buf[sizeof(buf)-1] = '\0';
@@ -10546,7 +10546,7 @@ static void tls_setup_notes(pool *p, SSL *ssl) {
   client_cert = SSL_get_peer_certificate(ssl);
   if (client_cert != NULL) {
     const X509_ALGOR *algo = NULL;
-    X509_PUBKEY *pubkey = NULL;
+    const X509_PUBKEY *pubkey = NULL;
     BIO *bio = NULL;
     char *data = NULL;
     long datalen = 0;
@@ -10702,7 +10702,7 @@ static int tls_verify_cb(int ok, X509_STORE_CTX *ctx) {
 
 static int tls_verify_crl(int ok, X509_STORE_CTX *ctx) {
   register unsigned int i = 0;
-  X509_NAME *subject = NULL, *issuer = NULL;
+  const X509_NAME *subject = NULL, *issuer = NULL;
   X509 *xs = NULL;
   STACK_OF(X509_CRL) *crls = NULL;
   int res, verify_error;
@@ -10880,7 +10880,7 @@ static int tls_verify_ocsp_url(X509_STORE_CTX *ctx, X509 *cert,
     const char *url) {
   BIO *conn;
   X509 *issuing_cert = NULL;
-  X509_NAME *subj = NULL;
+  const X509_NAME *subj = NULL;
   X509_STORE *store = NULL;
   const char *subj_name;
   char *host = NULL, *port = NULL, *uri = NULL;
@@ -11298,8 +11298,14 @@ static int tls_verify_ocsp(int ok, X509_STORE_CTX *ctx) {
         ocsp_urls = make_array(tmp_pool, 1, sizeof(char *));
       }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+    !defined(HAVE_LIBRESSL)
       *((char **) push_array(ocsp_urls)) = pstrdup(tmp_pool,
-        (char *) desc->location->d.uniformResourceIdentifier->data);
+        (char *) ASN1_STRING_get0_data(desc->location->d.uniformResourceIdentifier));
+#else
+      *((char **) push_array(ocsp_urls)) = pstrdup(tmp_pool,
+        (char *) ASN1_STRING_data(desc->location->d.uniformResourceIdentifier));
+#endif /* OpenSSL 1.1.x and later */
     }
   }
 
@@ -11367,7 +11373,7 @@ static ssize_t tls_write(SSL *ssl, const void *buf, size_t len) {
   return count;
 }
 
-static char *tls_x509_name_oneline(X509_NAME *x509_name) {
+static char *tls_x509_name_oneline(const X509_NAME *x509_name) {
   static char buf[1024] = {'\0'};
 
   /* If we are using OpenSSL 0.9.6 or newer, we want to use


### PR DESCRIPTION
ASN1_STRING are now opaque types — the internal data and length fields are no longer directly accessible. Use the accessor API instead. Accessors have been available since OpenSSL 1.1.0

Signatures of numerous API functions, including those that are related to X509 processing, are changed to include const qualifiers for argument and return types, where suitable. Add const qualifer to variables.

fixes:
```c

mod_tls.c: In function 'tls_get_cert_cn':
mod_tls.c:2768:13: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2768 |   subj_name = X509_get_subject_name(cert);
      |             ^
mod_tls.c:2780:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2780 |   cn_entry = X509_NAME_get_entry(subj_name, idx);
      |            ^
mod_tls.c:2787:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2787 |   cn_asn1 = X509_NAME_ENTRY_get_data(cn_entry);
      |           ^
mod_tls.c: In function 'tls_cert_must_staple':
mod_tls.c:6234:9: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 6234 |     ext = X509_get_ext(cert, i);
      |         ^
mod_tls.c:6239:9: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 6239 |     obj = X509_EXTENSION_get_object(ext);
      |         ^
mod_tls.c:6250:13: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 6250 |       value = X509_EXTENSION_get_data(ext);
      |             ^
mod_tls.c: In function 'tls_get_subj_name':
mod_tls.c:9178:40: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9178 |     char *name = tls_x509_name_oneline(X509_get_subject_name(cert));
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c: In function 'tls_cert_to_user':
mod_tls.c:9417:10: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9417 |     name = X509_get_subject_name(client_cert);
      |          ^
mod_tls.c:9432:13: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9432 |       entry = X509_NAME_get_entry(name, pos);
      |             ^
mod_tls.c:9433:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9433 |       data = X509_NAME_ENTRY_get_data(entry);
      |            ^
mod_tls.c:9538:13: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9538 |         ext = X509_get_ext(client_cert, i);
      |             ^
mod_tls.c:9539:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9539 |         asn_object = X509_EXTENSION_get_object(ext);
      |                    ^
mod_tls.c:9549:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9549 |             asn_data = X509_EXTENSION_get_data(ext);
      |                      ^
mod_tls.c: In function 'tls_setup_cert_dn_environ':
mod_tls.c:9861:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9861 |     entry = X509_NAME_get_entry(name, i);
      |           ^
mod_tls.c: In function 'tls_setup_cert_environ':
mod_tls.c:9981:15: error: invalid use of incomplete typedef 'ASN1_INTEGER' {aka 'struct asn1_string_st'}
 9981 |     if (serial->length < 4) {
      |               ^~
mod_tls.c:9999:42: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 9999 |     v = pstrdup(p, tls_x509_name_oneline(X509_get_subject_name(cert)));
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c:10003:14: warning: passing argument 2 of 'tls_setup_cert_dn_environ' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10003 |       NULL), X509_get_subject_name(cert));
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:9842:74: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
 9842 | static void tls_setup_cert_dn_environ(const char *env_prefix, X509_NAME *name) {
      |                                                               ~~~~~~~~~~~^~~~
mod_tls.c:10006:42: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10006 |     v = pstrdup(p, tls_x509_name_oneline(X509_get_issuer_name(cert)));
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c:10010:7: warning: passing argument 2 of 'tls_setup_cert_dn_environ' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10010 |       X509_get_issuer_name(cert));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:9842:74: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
 9842 | static void tls_setup_cert_dn_environ(const char *env_prefix, X509_NAME *name) {
      |                                                               ~~~~~~~~~~~^~~~
mod_tls.c:10066:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10066 |     pubkey = X509_get_X509_PUBKEY(cert);
      |            ^
mod_tls.c: In function 'tls_setup_notes':
mod_tls.c:10275:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10275 |     pubkey = X509_get_X509_PUBKEY(client_cert);
      |            ^
mod_tls.c: In function 'tls_verify_cb':
mod_tls.c:10407:7: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10407 |       X509_get_subject_name(cert)));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c:10409:7: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10409 |       X509_get_issuer_name(cert)));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c: In function 'tls_verify_crl':
mod_tls.c:10497:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10497 |   subject = X509_get_subject_name(xs);
      |           ^
mod_tls.c:10501:10: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10501 |   issuer = X509_get_issuer_name(xs);
      |          ^
mod_tls.c: In function 'tls_verify_ocsp_url':
mod_tls.c:10734:8: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
10734 |   subj = X509_get_subject_name(cert);
      |        ^
mod_tls.c: In function 'tls_verify_ocsp':
mod_tls.c:11109:32: warning: passing argument 1 of 'tls_x509_name_oneline' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
11109 |   subj = tls_x509_name_oneline(X509_get_subject_name(cert));
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
mod_tls.c:803:36: note: expected 'X509_NAME *' {aka 'struct X509_name_st *'} but argument is of type 'const X509_NAME *' {aka 'const struct X509_name_st *'}
  803 | static char *tls_x509_name_oneline(X509_NAME *);
      |                                    ^~~~~~~~~~~
mod_tls.c:11137:61: error: invalid use of incomplete typedef 'ASN1_IA5STRING' {aka 'struct asn1_string_st'}
11137 |         (char *) desc->location->d.uniformResourceIdentifier->data);
      |                                                             ^~

``` 