### PR TITLE
Issue #2047: Use CLOCK_MONOTONIC in alarm handler

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -394,6 +394,12 @@
 #undef HAVE_GETPRPWENT
 
 /* Define if you have the gettimeofday function.  */
+#undef HAVE_CLOCK_GETTIME
+
+/* Define if you have the CLOCK_MONOTONIC macro.  */
+#undef HAVE_DECL_CLOCK_MONOTONIC
+
+/* Define if you have the gettimeofday function.  */
 #undef HAVE_GETTIMEOFDAY
 
 /* Define if you have the gmtime_r function.  */

--- a/configure
+++ b/configure
@@ -21704,7 +21704,7 @@ _ACEOF
 fi
 done
 
-for ac_func in gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups
+for ac_func in clock_gettime gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -21715,6 +21715,14 @@ _ACEOF
 
 fi
 done
+
+ac_fn_c_check_decl "$LINENO" "CLOCK_MONOTONIC" "ac_cv_have_decl_clock_monotonic" "#include <time.h>
+"
+if test "x$ac_cv_have_decl_clock_monotonic" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_CLOCK_MONOTONIC 1
+_ACEOF
+fi
 
 for ac_func in loginrestrictions
 do :

--- a/src/timers.c
+++ b/src/timers.c
@@ -231,8 +231,12 @@ static RETSIGTYPE sig_alarm(int signo) {
   /* Reset the alarm */
   total_time += current_timeout;
   if (current_timeout) {
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_DECL_CLOCK_MONOTONIC)
     clock_gettime(CLOCK_MONOTONIC, &ts);
     alarmed_time = ts.tv_sec;
+#else
+    alarmed_time = time(NULL);
+#endif /* HAVE_CLOCK_GETTIME && HAVE_DECL_CLOCK_MONOTONIC*/
     alarm(current_timeout);
   }
 }
@@ -291,8 +295,12 @@ void handle_alarm(void) {
       alarm(0);
 
       /* Determine how much time has elapsed since we last processed timers. */
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_DECL_CLOCK_MONOTONIC)
       clock_gettime(CLOCK_MONOTONIC, &ts);
       now = ts.tv_sec;
+#else
+      time(&now);
+#endif /* HAVE_CLOCK_GETTIME && HAVE_DECL_CLOCK_MONOTONIC*/
       alarm_elapsed = alarmed_time > 0 ? (int) (now - alarmed_time) : 0;
 
       new_timeout = total_time + alarm_elapsed;

--- a/src/timers.c
+++ b/src/timers.c
@@ -198,6 +198,7 @@ static int process_timers(int elapsed) {
 static RETSIGTYPE sig_alarm(int signo) {
 #if defined(HAVE_SIGACTION)
   struct sigaction act;
+  struct timespec ts;
 
   act.sa_handler = sig_alarm;
   sigemptyset(&act.sa_mask);
@@ -230,7 +231,8 @@ static RETSIGTYPE sig_alarm(int signo) {
   /* Reset the alarm */
   total_time += current_timeout;
   if (current_timeout) {
-    alarmed_time = time(NULL);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    alarmed_time = ts.tv_sec;
     alarm(current_timeout);
   }
 }
@@ -282,13 +284,15 @@ void handle_alarm(void) {
 
     if (!alarms_blocked) {
       int alarm_elapsed, new_timeout;
+      struct timespec ts;
       time_t now;
 
       /* Clear any pending ALRM signals. */
       alarm(0);
 
       /* Determine how much time has elapsed since we last processed timers. */
-      time(&now);
+      clock_gettime(CLOCK_MONOTONIC, &ts);
+      now = ts.tv_sec;
       alarm_elapsed = alarmed_time > 0 ? (int) (now - alarmed_time) : 0;
 
       new_timeout = total_time + alarm_elapsed;


### PR DESCRIPTION
FTP session can get get closed when there's simultaneous system time update via PTP or NTP.
Unlike the standard "wall clock" time (CLOCK_REALTIME), which can jump forwards or backwards if the user changes the system time or if an PTP/NTP synchronizes it, CLOCK_MONOTONIC is guaranteed to only move forward.
Fixes issue #2047.