### PR TITLE
Issue #2047: Use `clock_gettime(3)` and `CLOCK_MONOTONIC` for better …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,8 @@
 - Issue 2058 - Scoreboard wlock_entry() function uses F_UNLCK instead of
   F_WRLCK.
 - Issue 2057 - SQL Injection in mod_wrap2_sql via reverse DNS hostname.
+- Issue 2047 - FTP sessions could be prematurely closed during updates of
+  system time/date.
 
 1.3.9 - Released 14-Mar-2025
 --------------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,6 +6,12 @@ This file contains a description of the major changes to ProFTPD for the
 releases.  More information on these changes can be found in the NEWS and
 ChangeLog files.
 
+1.3.10rc2
+----------
+
+  + Use `CLOCK_MONOTONIC` for more accurate timer support (Issue #2047)
+
+
 1.3.10rc1
 ----------
 

--- a/config.h.in
+++ b/config.h.in
@@ -282,6 +282,12 @@
 /* Define if you have the bcopy function.  */
 #undef HAVE_BCOPY
 
+/* Define if you have the clock_gettime function.  */
+#undef HAVE_CLOCK_GETTIME
+
+/* Define if your clock_gettime(3) supports CLOCK_MONOTONIC.  */
+#undef HAVE_CLOCK_MONOTONIC
+
 /* Define if you have the crypt function.  */
 #undef HAVE_CRYPT
 

--- a/configure
+++ b/configure
@@ -21692,7 +21692,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-for ac_func in getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo
+for ac_func in clock_gettime getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -21827,6 +21827,41 @@ _ACEOF
 fi
 done
 
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for CLOCK_MONOTONIC" >&5
+$as_echo_n "checking for CLOCK_MONOTONIC... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  #include <sys/types.h>
+  #include <time.h>
+
+int
+main ()
+{
+
+  struct timespec ts;
+  (void) clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CLOCK_MONOTONIC 1" >>confdefs.h
+
+
+else
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 ac_fn_c_check_func "$LINENO" "setpassent" "ac_cv_func_setpassent"
 if test "x$ac_cv_func_setpassent" = xyes; then :

--- a/configure.in
+++ b/configure.in
@@ -2238,7 +2238,7 @@ AC_TRY_LINK(
   ]
 )
 
-AC_CHECK_FUNCS(getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo)
+AC_CHECK_FUNCS(clock_gettime getcwd getenv getgrouplist getgroups getgrset gethostbyname2 gethostname getnameinfo)
 AC_CHECK_FUNCS(gettimeofday hstrerror inet_aton inet_ntop inet_pton initgroups)
 AC_CHECK_FUNCS(loginrestrictions)
 AC_CHECK_FUNCS(explicit_bzero memcpy mempcpy memset_s mkdir mkstemp mlock mlockall munlock munlockall)
@@ -2253,6 +2253,21 @@ then
 fi
 AC_CHECK_FUNCS(setsid setgroupent seteuid setegid setenv setpgid sigaction siginterrupt)
 AC_CHECK_FUNCS(tzset uname unsetenv)
+
+dnl Determine whether clock_gettime(3), if present, supports CLOCK_MONOTONIC
+AC_MSG_CHECKING([for CLOCK_MONOTONIC])
+AC_TRY_COMPILE([
+  #include <sys/types.h>
+  #include <time.h>
+], [
+  struct timespec ts;
+  (void) clock_gettime(CLOCK_MONOTONIC, &ts);
+], [
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_CLOCK_MONOTONIC, 1, [Define if you have CLOCK_MONOTONIC])
+], [
+  AC_MSG_RESULT(no)
+])
 
 AC_CHECK_FUNC(setpassent,
 [case "$target_os:$enable_force_setpassent" in

--- a/src/timers.c
+++ b/src/timers.c
@@ -195,6 +195,31 @@ static int process_timers(int elapsed) {
   return res;
 }
 
+static time_t get_current_time(void) {
+  time_t now;
+  int use_fallback = TRUE;
+
+#if defined(HAVE_CLOCK_GETTIME) && \
+    defined(HAVE_CLOCK_MONOTONIC)
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) < 0) {
+    pr_trace_msg(trace_channel, 1,
+      "clock_gettime(3) error: %s, falling back to time(3)", strerror(errno));
+
+  } else {
+    now = ts.tv_sec;
+    use_fallback = FALSE;
+  }
+#endif /* HAVE_CLOCK_GETTIME and HAVE_CLOCK_MONOTONIC */
+
+  if (use_fallback == TRUE) {
+    time(&now);
+  }
+
+  return now;
+}
+
 static RETSIGTYPE sig_alarm(int signo) {
 #if defined(HAVE_SIGACTION)
   struct sigaction act;
@@ -230,7 +255,7 @@ static RETSIGTYPE sig_alarm(int signo) {
   /* Reset the alarm */
   total_time += current_timeout;
   if (current_timeout) {
-    alarmed_time = time(NULL);
+    alarmed_time = get_current_time();
     alarm(current_timeout);
   }
 }
@@ -288,7 +313,7 @@ void handle_alarm(void) {
       alarm(0);
 
       /* Determine how much time has elapsed since we last processed timers. */
-      time(&now);
+      now = get_current_time();
       alarm_elapsed = alarmed_time > 0 ? (int) (now - alarmed_time) : 0;
 
       new_timeout = total_time + alarm_elapsed;


### PR DESCRIPTION
…timer support in the face of changing system date/times, as when changed by NTP/PTP.