### PR TITLE
The mod_copy module was not properly detecting when the destination p…

### DIFF
--- a/contrib/mod_copy.c
+++ b/contrib/mod_copy.c
@@ -339,7 +339,7 @@ static int copy_dir(pool *p, const char *src_dir, const char *dst_dir,
 }
 
 static int copy_paths(pool *p, const char *from, const char *to) {
-  struct stat st;
+  struct stat from_st, to_st;
   int res, flags = 0;
   xaset_t *set;
 
@@ -365,7 +365,7 @@ static int copy_paths(pool *p, const char *from, const char *to) {
   /* Check whether from is a file, a directory, a symlink, or something
    * unsupported.
    */
-  res = pr_fsio_lstat(from, &st);
+  res = pr_fsio_lstat(from, &from_st);
   if (res < 0) {
     int xerrno = errno;
 
@@ -380,11 +380,11 @@ static int copy_paths(pool *p, const char *from, const char *to) {
     flags |= PR_FSIO_COPY_FILE_FL_NO_DELETE_ON_FAILURE;
   }
 
-  if (S_ISREG(st.st_mode)) {
+  if (S_ISREG(from_st.st_mode)) {
     char *abs_path;
 
     pr_fs_clear_cache2(to);
-    res = pr_fsio_stat(to, &st);
+    res = pr_fsio_lstat(to, &to_st);
     if (res == 0) {
       unsigned char *allow_overwrite;
 
@@ -396,6 +396,10 @@ static int copy_paths(pool *p, const char *from, const char *to) {
         errno = EACCES;
         return -1;
       }
+
+    } else {
+      pr_trace_msg(trace_channel, 19,
+        "lstat(2) error for destination path '%s': %s", to, strerror(errno));
     }
 
     res = pr_fs_copy_file2(from, to, flags, NULL);
@@ -410,26 +414,26 @@ static int copy_paths(pool *p, const char *from, const char *to) {
     }
 
     pr_fs_clear_cache2(to);
-    if (pr_fsio_stat(to, &st) < 0) {
+    if (pr_fsio_stat(to, &to_st) < 0) {
       pr_trace_msg(trace_channel, 3,
-        "error stat'ing '%s': %s", to, strerror(errno));
+        "stat(2) error on destination path '%s': %s", to, strerror(errno));
     }
 
     /* Write a TransferLog entry as well. */
     abs_path = dir_abs_path(p, to, TRUE);
 
     if (session.sf_flags & SF_ANON) {
-      xferlog_write(0, session.c->remote_name, st.st_size, abs_path,
+      xferlog_write(0, session.c->remote_name, to_st.st_size, abs_path,
         (session.sf_flags & SF_ASCII ? 'a' : 'b'), 'd', 'a',
         session.anon_user, 'c', "_");
 
     } else {
-      xferlog_write(0, session.c->remote_name, st.st_size, abs_path,
+      xferlog_write(0, session.c->remote_name, to_st.st_size, abs_path,
         (session.sf_flags & SF_ASCII ? 'a' : 'b'), 'd', 'r',
         session.user, 'c', "_");
     }
 
-  } else if (S_ISDIR(st.st_mode)) {
+  } else if (S_ISDIR(from_st.st_mode)) {
     res = create_path(p, to);
     if (res < 0) {
       int xerrno = errno;
@@ -453,9 +457,9 @@ static int copy_paths(pool *p, const char *from, const char *to) {
       return -1;
     }
 
-  } else if (S_ISLNK(st.st_mode)) {
+  } else if (S_ISLNK(from_st.st_mode)) {
     pr_fs_clear_cache2(to);
-    res = pr_fsio_stat(to, &st);
+    res = pr_fsio_lstat(to, &to_st);
     if (res == 0) {
       unsigned char *allow_overwrite;
 
@@ -468,6 +472,9 @@ static int copy_paths(pool *p, const char *from, const char *to) {
         errno = EACCES;
         return -1;
       }
+    } else {
+      pr_trace_msg(trace_channel, 19,
+        "lstat(2) error for destination path '%s': %s", to, strerror(errno));
     }
 
     res = copy_symlink(p, from, to, flags);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_copy.pm
@@ -46,9 +46,14 @@ my $TESTS = {
     test_class => [qw(forking)],
   },
 
-  copy_config_allowoverwrite => {
+  copy_config_allowoverwrite_file => {
     order => ++$order,
     test_class => [qw(forking)],
+  },
+
+  copy_config_allowoverwrite_dangling_symlink => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
   },
 
   copy_config_limit => {
@@ -1099,42 +1104,12 @@ EOC
   unlink($log_file);
 }
 
-sub copy_config_allowoverwrite {
+sub copy_config_allowoverwrite_file {
   my $self = shift;
   my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'copy');
 
-  my $config_file = "$tmpdir/copy.conf";
-  my $pid_file = File::Spec->rel2abs("$tmpdir/copy.pid");
-  my $scoreboard_file = File::Spec->rel2abs("$tmpdir/copy.scoreboard");
-
-  my $log_file = File::Spec->rel2abs('tests.log');
-
-  my $auth_user_file = File::Spec->rel2abs("$tmpdir/copy.passwd");
-  my $auth_group_file = File::Spec->rel2abs("$tmpdir/copy.group");
-
-  my $user = 'proftpd';
-  my $passwd = 'test';
-  my $home_dir = File::Spec->rel2abs($tmpdir);
-  my $uid = 500;
-  my $gid = 500;
-
-  # Make sure that, if we're running as root, that the home directory has
-  # permissions/privs set for the account we create
-  if ($< == 0) {
-    unless (chmod(0755, $home_dir)) {
-      die("Can't set perms on $home_dir to 0755: $!");
-    }
-
-    unless (chown($uid, $gid, $home_dir)) {
-      die("Can't set owner of $home_dir to $uid/$gid: $!");
-    }
-  }
-
-  auth_user_write($auth_user_file, $user, $passwd, $uid, $gid, $home_dir,
-    '/bin/bash');
-  auth_group_write($auth_group_file, 'ftpd', $gid, $user);
-
-  my $src_file = File::Spec->rel2abs("$home_dir/foo.txt");
+  my $src_file = File::Spec->rel2abs("$setup->{home_dir}/foo.txt");
   if (open(my $fh, "> $src_file")) {
     print $fh "Hello, World!\n";
     unless (close($fh)) {
@@ -1145,7 +1120,7 @@ sub copy_config_allowoverwrite {
     die("Can't open $src_file: $!");
   }
 
-  my $dst_file = File::Spec->rel2abs("$home_dir/bar.txt");
+  my $dst_file = File::Spec->rel2abs("$setup->{home_dir}/bar.txt");
   if (open(my $fh, "> $dst_file")) {
     print $fh "Farwell, World!\n";
     unless (close($fh)) {
@@ -1157,12 +1132,12 @@ sub copy_config_allowoverwrite {
   }
 
   my $config = {
-    PidFile => $pid_file,
-    ScoreboardFile => $scoreboard_file,
-    SystemLog => $log_file,
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
 
-    AuthUserFile => $auth_user_file,
-    AuthGroupFile => $auth_group_file,
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
     AuthOrder => 'mod_auth_file.c',
 
     IfModules => {
@@ -1172,7 +1147,8 @@ sub copy_config_allowoverwrite {
     },
   };
 
-  my ($port, $config_user, $config_group) = config_write($config_file, $config);
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
 
   # Open pipes, for use between the parent and child processes.  Specifically,
   # the child will indicate when it's done with its test by writing a message
@@ -1190,27 +1166,26 @@ sub copy_config_allowoverwrite {
   if ($pid) {
     eval {
       my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
-      $client->login($user, $passwd);
+      $client->login($setup->{user}, $setup->{passwd});
 
-      my ($resp_code, $resp_msg);
       eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
       unless ($@) {
         die("SITE COPY succeeded unexpectedly");
       }
 
-      $resp_code = $client->response_code();
-      $resp_msg = $client->response_msg();
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
 
-      my $expected;
-      $expected = 550;
+      my $expected = 550;
       $self->assert($expected == $resp_code,
-        test_msg("Expected $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = "COPY: Permission denied";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected '$expected', got '$resp_msg'"));
-    };
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
+      $client->quit();
+    };
     if ($@) {
       $ex = $@;
     }
@@ -1219,7 +1194,7 @@ sub copy_config_allowoverwrite {
     $wfh->flush();
 
   } else {
-    eval { server_wait($config_file, $rfh) };
+    eval { server_wait($setup->{config_file}, $rfh) };
     if ($@) {
       warn($@);
       exit 1;
@@ -1229,15 +1204,114 @@ sub copy_config_allowoverwrite {
   }
 
   # Stop server
-  server_stop($pid_file);
-
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
-  if ($ex) {
-    die($ex);
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub copy_config_allowoverwrite_dangling_symlink {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'copy');
+
+  my $src_file = File::Spec->rel2abs("$setup->{home_dir}/foo.txt");
+  if (open(my $fh, "> $src_file")) {
+    print $fh "Hello, World!\n";
+    unless (close($fh)) {
+      die("Can't write $src_file: $!");
+    }
+
+  } else {
+    die("Can't open $src_file: $!");
   }
 
-  unlink($log_file);
+  # For this, we create a dangling symlink as the destination.
+
+  my $dst_file = File::Spec->rel2abs("$setup->{home_dir}/bar.txt");
+  unless (symlink('/foo/bar/baz', $dst_file)) {
+    die("Can't symlink $dst_file to nonexistent file: $!");
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'copy:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      eval { $client->site('COPY', 'foo.txt', 'bar.txt') };
+      unless ($@) {
+        die("SITE COPY succeeded unexpectedly");
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+
+      my $expected = 550;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "COPY: Permission denied";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
 }
 
 sub copy_config_pathdenyfilter {


### PR DESCRIPTION
…ath is a dangling symlink, and thus was not enforcing the "AllowOverwrite off" configuration for such cases.

Thanks to skove for reporting this issue.