### PR TITLE
Issue #2093: Check for a null `ctrl_ssl` pointer, as is already done …

### DIFF
--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -9073,6 +9073,7 @@ static void tls_end_sess(SSL *ssl, conn_t *conn, int flags) {
   }
 
   if (ssl != ctrl_ssl &&
+      ctrl_ssl != NULL &&
       SSL_get_session(ssl) == SSL_get_session(ctrl_ssl)) {
     /* Uh-oh; our two SSL objects are pointing at the same SSL_SESSION object.
      * This can happen when the SSL_SESSION is resumed, enabled by session


### PR DESCRIPTION
…in the master branch, before calling OpenSSL APIs on it and triggering a null pointer dereference crash.

Note that this is a regression in the 1.3.9 branch, caused by changes for addressing Issue #1963.