### PR TITLE
If IPv6 support is disabled, do not cause a parse-time error with the…

### DIFF
--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -672,7 +672,6 @@ MODRET set_serveradmin(cmd_rec *cmd) {
 
 /* usage: UseIPv6 on|off */
 MODRET set_useipv6(cmd_rec *cmd) {
-#if defined(PR_USE_IPV6)
   int use_ipv6 = -1;
 
   CHECK_ARGS(cmd, 1);
@@ -688,14 +687,15 @@ MODRET set_useipv6(cmd_rec *cmd) {
     pr_netaddr_disable_ipv6();
 
   } else {
+#if defined(PR_USE_IPV6)
     pr_netaddr_enable_ipv6();
+# else
+  CONF_ERROR(cmd,
+    "Use of 'UseIPv6 on' configurations requires IPv6 support (--enable-ipv6)");
+#endif /* PR_USE_IPV6 */
   }
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd,
-    "Use of the UseIPv6 directive requires IPv6 support (--enable-ipv6)");
-#endif /* PR_USE_IPV6 */
 }
 
 MODRET set_usereversedns(cmd_rec *cmd) {


### PR DESCRIPTION
… `UseIPv6` configuration directive.

Instead, only raise the parse-time error if the configuration uses "UseIPv6 on" when IPv6 support is disabled.  Otherwise, it's a benign issue to request "UseIPv6 off" in a build where IPv6 support is not enabled.