### PR TITLE
Align usage of handle_kex_sntrup761 with its definition

### DIFF
--- a/contrib/mod_sftp/kex.c
+++ b/contrib/mod_sftp/kex.c
@@ -6486,12 +6486,12 @@ int sftp_kex_handle(struct ssh2_packet *pkt) {
 
         } else
 #endif /* HAVE_MLKEM768_OPENSSL and HAVE_SHA256_OPENSSL */
-#if defined(HAVE_SHA512_OPENSSL)
+#if defined(HAVE_X25519_OPENSSL) && defined(HAVE_SHA512_OPENSSL)
         if (kex->use_sntrup761) {
           res = handle_kex_sntrup761(pkt, kex);
 
         } else
-#endif /* HAVE_SHA512_OPENSSL */
+#endif /* HAVE_X25519_OPENSSL and HAVE_SHA512_OPENSSL */
 #if defined(PR_USE_OPENSSL_ECC)
         if (kex->use_ecdh) {
           res = handle_kex_ecdh(pkt, kex);


### PR DESCRIPTION
The declaration of handle_kex_sntrup761 in mod_sftp/kex.c is guarded by
```
#if defined(HAVE_X25519_OPENSSL) && defined(HAVE_SHA512_OPENSSL)
  ...
#endif
```

However, its usage later in the file is guarded only by
```
#if defined(HAVE_SHA512_OPENSSL)
  ...
#endif
```

This can lead to attempts to use an undefined function when `HAVE_X25519_OPENSSL` is not defined.

Curiously, I found that the error (I use  `-Werror=implicit-function-declaration`) that results from this:
```
kex.c: In function 'sftp_kex_handle':
kex.c:6491:17: error: implicit declaration of function 'handle_kex_sntrup761'; did you mean 'handle_kex_rsa'? [-Werror=implicit-function-declaration]
           res = handle_kex_sntrup761(pkt, kex);
                 ^~~~~~~~~~~~~~~~~~~~
                 handle_kex_rsa
cc1: some warnings being treated as errors 
make[2]: *** [Makefile:50: kex.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
```
did not terminate the build of proftpd as a whole, and I only noticed it because `mod_sftp.so` didn't get installed.