### PR TITLE
configure.in: fix %llu detection for cross-compilation

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3205,19 +3205,18 @@ AC_TRY_LINK(
   ]
 )
 
-dnl Run a small test program to see if the host's printf(3) family can
-dnl actually handle the %llu format.
-AC_MSG_CHECKING([whether printf supports %llu format]);
-AC_TRY_RUN(
-  [ #include <stdio.h>
-    int main(int argc, char *argv[]) {
-      return (fprintf(stderr, "%llu\n", (unsigned long long) 1) == 2 ? 0 : 1);
-    }
-  ],
-  AC_MSG_RESULT(yes); AC_DEFINE(HAVE_LLU, 1, [Define if you have %llu support]),
-  AC_MSG_RESULT(no); AC_DEFINE(HAVE_LU, 1, [Define if you have %lu support]),
-  AC_MSG_RESULT(cross-compiling); AC_DEFINE(HAVE_LU, 1, [Define if you have %lu support])
-)
+dnl Determine whether printf(3) supports the %llu format specifier.
+dnl Use the already-known sizeof(long long) rather than a runtime test so
+dnl that cross-compilation produces the correct result.  Any C99-compliant
+dnl platform with an 8-byte long long is guaranteed to support %llu.
+AC_MSG_CHECKING([whether printf supports %llu format])
+if test "$ac_cv_sizeof_long_long" -ge 8; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_LLU, 1, [Define if you have %llu support])
+else
+  AC_MSG_RESULT(no)
+  AC_DEFINE(HAVE_LU, 1, [Define if you have %lu support])
+fi
 
 dnl Run a small test program to see if the host's listen(2) function can
 dnl handle a negative backlog (Issue #1636).


### PR DESCRIPTION
AC_TRY_RUN cannot execute test binaries when cross-compiling, so the cross-compile fallback unconditionally defined HAVE_LU instead of HAVE_LLU.  This caused pr_off_t to be defined as unsigned long (32-bit on ARM) even when _FILE_OFFSET_BITS=64 made off_t 64-bit, breaking display and transfer of files larger than 2 GB on 32-bit ARM targets.

sizeof(long long) is already determined at configure time via AC_CHECK_SIZEOF and is available in ac_cv_sizeof_long_long.  Replace the runtime AC_TRY_RUN with a compile-time check against that value.  Any C99-compliant platform with an 8-byte long long is guaranteed to support %llu, so the result is correct for both native and cross builds.