### PR TITLE
The `pr_set_scoreboard()` function constructs the default `Scoreboard…

### DIFF
--- a/src/scoreboard.c
+++ b/src/scoreboard.c
@@ -790,8 +790,8 @@ int pr_set_scoreboard(const char *path) {
   /* For best operability, automatically set the ScoreboardMutex file to
    * be the same as the ScoreboardFile with a ".lck" suffix.
    */
-  sstrncpy(scoreboard_mutex, path, sizeof(scoreboard_file));
-  strncat(scoreboard_mutex, ".lck", sizeof(scoreboard_mutex)-strlen(path)-1);
+  sstrncpy(scoreboard_mutex, path, sizeof(scoreboard_mutex));
+  sstrcat(scoreboard_mutex, ".lck", sizeof(scoreboard_mutex));
 
   return 0;
 }


### PR DESCRIPTION
…Mutex` path based on the provided `ScoreboardFile` path; an overlong path could trigger a buffer overflow.

For this to occur, the site admin would need to configure an overlong `ScoreboardFile` path in the config file; this is thus a "don't shoot yourself in the foot" kind of situation/trigger.

Thanks to Kamil Leoniak and Delphos Labs for discovering and reporting this issue.