### PR TITLE
Issue #2163: The `config` and `get` action handlers need to properly …

### DIFF
--- a/contrib/mod_ctrls_admin.c
+++ b/contrib/mod_ctrls_admin.c
@@ -367,6 +367,14 @@ static int ctrls_handle_config_remove(pr_ctrls_t *ctrl, int reqargc,
 static int ctrls_handle_config(pr_ctrls_t *ctrl, int reqargc,
     char **reqargv) {
 
+  /* Check the config ACL */
+  if (pr_ctrls_check_acl(ctrl, ctrls_admin_acttab, "config") != TRUE) {
+
+    /* Access denied */
+    pr_ctrls_add_response(ctrl, "access denied");
+    return PR_CTRLS_STATUS_ACCESS_DENIED;
+  }
+
   /* Sanity check */
   if (reqargc == 0 ||
       reqargv == NULL) {
@@ -376,8 +384,9 @@ static int ctrls_handle_config(pr_ctrls_t *ctrl, int reqargc,
 
   if (strcmp(reqargv[0], "set") == 0) {
     return ctrls_handle_config_set(ctrl, --reqargc, ++reqargv);
+  }
 
-  } else if (strcmp(reqargv[0], "remove") == 0) {
+  if (strcmp(reqargv[0], "remove") == 0) {
     return ctrls_handle_config_remove(ctrl, --reqargc, ++reqargv);
   }
 
@@ -391,6 +400,7 @@ static int ctrls_handle_debug(pr_ctrls_t *ctrl, int reqargc,
 
   /* Check the debug ACL */
   if (pr_ctrls_check_acl(ctrl, ctrls_admin_acttab, "debug") != TRUE) {
+
     /* Access denied */
     pr_ctrls_add_response(ctrl, "access denied");
     return PR_CTRLS_STATUS_ACCESS_DENIED;
@@ -552,6 +562,7 @@ static int ctrls_handle_down(pr_ctrls_t *ctrl, int reqargc,
 
   /* Check the 'down' ACL */
   if (pr_ctrls_check_acl(ctrl, ctrls_admin_acttab, "down") != TRUE) {
+
     /* Access denied */
     pr_ctrls_add_response(ctrl, "access denied");
     return PR_CTRLS_STATUS_ACCESS_DENIED;
@@ -607,6 +618,14 @@ static int ctrls_handle_down(pr_ctrls_t *ctrl, int reqargc,
 
 static int ctrls_handle_get(pr_ctrls_t *ctrl, int reqargc,
     char **reqargv) {
+
+  /* Check the get ACL */
+  if (pr_ctrls_check_acl(ctrl, ctrls_admin_acttab, "get") != TRUE) {
+
+    /* Access denied */
+    pr_ctrls_add_response(ctrl, "access denied");
+    return PR_CTRLS_STATUS_ACCESS_DENIED;
+  }
 
   /* Sanity check */
   if (reqargc == 0 ||


### PR DESCRIPTION
…check for configured ACLs that allow/deny the requesting client.