### PR TITLE
If the non-default (and undocumented) "xattr" SFTP extensions are ena…

### DIFF
--- a/contrib/mod_sftp/fxp.c
+++ b/contrib/mod_sftp/fxp.c
@@ -6351,8 +6351,6 @@ static int fxp_handle_ext_flistxattr(struct fxp_packet *fxp,
     sftp_msg_write_string(&buf, &buflen, name);
   }
 
-  sftp_msg_write_data(&buf, &buflen, (const unsigned char *) names, res, TRUE);
-
   resp = fxp_packet_create(fxp->pool, fxp->channel_id);
   resp->payload = ptr;
   resp->payload_sz = (bufsz - buflen);


### PR DESCRIPTION
…bled, the "flistxattr" extension can return heap memory to the unsuspecting client.

Thanks to Fabian Wahle of Hap Security for reporting this issue.