### PR TITLE
If the `NLST` command uses globs without recursion (`-R`), and one of…

### DIFF
--- a/modules/mod_ls.c
+++ b/modules/mod_ls.c
@@ -3242,7 +3242,9 @@ MODRET ls_nlst(cmd_rec *cmd) {
 
     /* Iterate through each matching entry */
     path = g.gl_pathv;
-    while (path && *path && res >= 0) {
+    while (path != NULL &&
+           *path &&
+           res >= 0) {
       struct stat st;
 
       pr_signals_handle();
@@ -3260,11 +3262,18 @@ MODRET ls_nlst(cmd_rec *cmd) {
 
           } else {
             /*...otherwise, just list the name. */
-            res = nlstfile(cmd, p);
+            if (ls_perms(cmd->tmp_pool, cmd, p, &hidden)) {
+              /* Don't display hidden files. */
+              if (hidden) {
+                continue;
+              }
+
+              res = nlstfile(cmd, p);
+            }
           }
 
         } else if (S_ISREG(st.st_mode) &&
-            ls_perms(cmd->tmp_pool, cmd, p, &hidden)) {
+                   ls_perms(cmd->tmp_pool, cmd, p, &hidden)) {
           /* Don't display hidden files */
           if (hidden) {
             continue;

--- a/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
+++ b/tests/t/lib/ProFTPD/Tests/Commands/NLST.pm
@@ -67,6 +67,11 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  nlst_ok_glob_limited_dir => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
   nlst_fails_login_required => {
     order => ++$order,
     test_class => [qw(forking)],
@@ -1309,6 +1314,151 @@ sub nlst_ok_glob_dir_with_recursion_bug4084 {
         'cmds.passwd' => 1,
         'cmds.conf' => 1,
         'test.d/test.dat' => 1,
+      };
+
+      my $ok = 1;
+      my $mismatch;
+      foreach my $name (keys(%$res)) {
+        unless (defined($expected->{$name})) {
+          $mismatch = $name;
+          $ok = 0;
+          last;
+        }
+      }
+
+      unless ($ok) {
+        die("Unexpected name '$mismatch' appeared in NLST data")
+      }
+    };
+
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+
+  $self->assert_child_ok($pid);
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub nlst_ok_glob_limited_dir {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'cmds');
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/test.d");
+  mkpath($sub_dir);
+
+  my $sub_file = File::Spec->rel2abs("$sub_dir/test.dat");
+  if (open(my $fh, "> $sub_file")) {
+    close($fh);
+
+  } else {
+    die("Can't open $sub_file: $!");
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+  if (open(my $fh, ">> $setup->{config_file}")) {
+    my $config_dir = $sub_dir;
+
+    if ($^O eq 'darwin') {
+      # MacOSX-specific hack
+      $config_dir = '/private' . $config_dir;
+    }
+
+    print $fh <<EOC;
+<Directory $config_dir>
+  <Limit NLST>
+    DenyAll
+  </Limit>
+</Directory>
+EOC
+    unless (close($fh)) {
+      die("Can't write $setup->{config_file}: $!");
+    }
+
+  } else {
+    die("Can't open $setup->{config_file}: $!");
+  }
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $conn = $client->nlst_raw("*");
+      unless ($conn) {
+        die("NLST failed: " . $client->response_code() . " " .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 25);
+      eval { $conn->close() };
+
+      $client->quit();
+
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# data:\n$buf";
+      }
+
+      my $res = {};
+      my $names = [split(/\n/, $buf)];
+      foreach my $name (@$names) {
+        $res->{$name} = 1;
+      }
+
+      my $expected = {
+        'cmds.pid' => 1,
+        'cmds.scoreboard' => 1,
+        'cmds.scoreboard.lck' => 1,
+        'cmds.group' => 1,
+        'cmds.passwd' => 1,
+        'cmds.conf' => 1,
       };
 
       my $ok = 1;


### PR DESCRIPTION
… the globbed paths is a directory, then any policy limits on that path are not being honored properly.

Thanks to Fabian Wahle of Hap Security for reporting this issue.