### PR TITLE
If the undocumented `UserDirRoot` directive is used for anonymous log…

### DIFF
--- a/doc/directives/index.html
+++ b/doc/directives/index.html
@@ -479,7 +479,6 @@ by the core <i>and</i> contrib modules in the ProFTPD source distribution.
   <li><a href="../modules/mod_xfer.html#UseSendfile">UseSendfile</a>
   <li><a href="../modules/mod_core.html#User">User</a>
   <li><a href="../modules/mod_auth.html#UserAlias">UserAlias</a>
-  <li><a href="../modules/mod_auth.html#UserDirRoot">UserDirRoot</a>
   <li><a href="../modules/mod_core.html#UserOwner">UserOwner</a>
   <li><a href="../modules/mod_auth.html#UserPassword">UserPassword</a>
   <li><a href="../contrib/mod_wrap2.html#WrapAllowMsg">WrapAllowMsg</a>
@@ -497,7 +496,7 @@ by the core <i>and</i> contrib modules in the ProFTPD source distribution.
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2022 The ProFTPD Project<br>
+&copy; Copyright 2022-2026 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -1445,9 +1445,21 @@ static int setup_env(pool *p, cmd_rec *cmd, const char *user, char *pass) {
 
     PRIVS_SETUP(pw->pw_uid, pw->pw_gid)
 
-    if ((add_userdir && *add_userdir == TRUE) &&
+    if ((add_userdir != NULL &&
+         *add_userdir == TRUE) &&
         strcmp(u, user) != 0) {
-      chroot_dir = pdircat(p, c->name, u, NULL);
+      char sanitized_user[PR_TUNABLE_PATH_MAX + 1];
+
+      /* Sanitize the provided USER name first. */
+      memset(sanitized_user, '\0', sizeof(sanitized_user));
+      pr_fs_clean_path2(u, sanitized_user, sizeof(sanitized_user)-1, 0);
+
+      if (strcmp(u, sanitized_user) != 0) {
+        pr_trace_msg("auth", 9,
+          "UserDirRoot: sanitized USER '%s' to '%s'", u, sanitized_user);
+      }
+
+      chroot_dir = pdircat(p, c->name, sanitized_user, NULL);
 
     } else {
       chroot_dir = c->name;

--- a/tests/t/config/userdirroot.t
+++ b/tests/t/config/userdirroot.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use lib qw(t/lib);
+use strict;
+
+use Test::Unit::HarnessUnit;
+
+$| = 1;
+
+my $r = Test::Unit::HarnessUnit->new();
+$r->start("ProFTPD::Tests::Config::UserDirRoot");

--- a/tests/t/lib/ProFTPD/Tests/Config/UserDirRoot.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/UserDirRoot.pm
@@ -1,0 +1,301 @@
+package ProFTPD::Tests::Config::UserDirRoot;
+
+use lib qw(t/lib);
+use base qw(ProFTPD::TestSuite::Child);
+use strict;
+
+use File::Path qw(mkpath);
+use File::Spec;
+use IO::Handle;
+
+use ProFTPD::TestSuite::FTP;
+use ProFTPD::TestSuite::Utils qw(:auth :config :running :test :testsuite);
+
+$| = 1;
+
+my $order = 0;
+
+my $TESTS = {
+  userdirroot_ok => {
+    order => ++$order,
+    test_class => [qw(forking rootprivs)],
+  },
+
+  userdirroot_sanitized_ok => {
+    order => ++$order,
+    test_class => [qw(forking rootprivs)],
+  },
+
+};
+
+sub new {
+  return shift()->SUPER::new(@_);
+}
+
+sub list_tests {
+  return testsuite_get_runnable_tests($TESTS);
+}
+
+sub userdirroot_ok {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my $alias = 'ftp';
+  my $test_dir = File::Spec->rel2abs("$tmpdir/$alias");
+  mkpath($test_dir);
+
+  if ($< == 0) {
+    unless (chmod(0755, $test_dir)) {
+      die("Can't set perms on $test_dir to 0755: $!");
+    }
+
+    unless (chown($setup->{uid}, $setup->{gid}, $test_dir)) {
+      die("Can't set owner of $test_dir to $setup->{uid}/$setup->{gid}: $!");
+    }
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'auth:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    Anonymous => {
+      $setup->{home_dir} => {
+        User => $setup->{user},
+        Group => $setup->{group},
+        UserAlias => "$alias $setup->{user}",
+        UserDirRoot => 'on',
+      },
+    },
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($alias, 'NoPasswordNeededHereForAnon');
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $ok = 0;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /Preparing to chroot to directory '(.*)?'/) {
+          my $chroot_path = $1;
+
+          my $expected = $test_dir;
+          if ($^O eq 'darwin') {
+            # MacOSX-specific hack
+            $expected = '/private' . $expected;
+          }
+
+          if ($chroot_path eq $expected) {
+            $ok = 1;
+            last;
+          }
+        }
+      }
+
+      close($fh);
+      $self->assert($ok, test_msg("Did not see expected chroot directory path"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub userdirroot_sanitized_ok {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'config');
+
+  my $test_dir = File::Spec->rel2abs("$tmpdir/ftp");
+  mkpath($test_dir);
+
+  if ($< == 0) {
+    unless (chmod(0755, $test_dir)) {
+      die("Can't set perms on $test_dir to 0755: $!");
+    }
+
+    unless (chown($setup->{uid}, $setup->{gid}, $test_dir)) {
+      die("Can't set owner of $test_dir to $setup->{uid}/$setup->{gid}: $!");
+    }
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'auth:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c',
+
+    Anonymous => {
+      $setup->{home_dir} => {
+        User => $setup->{user},
+        Group => $setup->{group},
+
+        # NOTE: In general, using a wildcard UserAlias is a Very Bad Idea.
+        UserAlias => "* $setup->{user}",
+
+        UserDirRoot => 'on',
+      },
+    },
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login('../../././/./../ftp', 'NoPasswordNeededHereForAnon');
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $ok = 0;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /Preparing to chroot to directory '(.*)?'/) {
+          my $chroot_path = $1;
+
+          my $expected = $test_dir;
+          if ($^O eq 'darwin') {
+            # MacOSX-specific hack
+            $expected = '/private' . $expected;
+          }
+
+          if ($chroot_path eq $expected) {
+            $ok = 1;
+            last;
+          }
+        }
+      }
+
+      close($fh);
+      $self->assert($ok, test_msg("Did not see expected chroot directory path"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+1;

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -198,6 +198,7 @@ if (scalar(@ARGV) > 0) {
     t/config/useftpusers.t
     t/config/useglobbing.t
     t/config/useralias.t
+    t/config/userdirroot.t
     t/config/userowner.t
     t/config/userpassword.t
     t/config/usesendfile.t


### PR DESCRIPTION
…ins, _and_ `UserAlias` is unwisely used with a wildcard matching, the constructed `chroot(2)` path for the login could be surprisingly different than expected.

Sanitize the client-provided `USER` name in such situations, to ensure that the constructed path is under the configured `<Anonymous>` chroot path.

Thanks to Fabian Wahle of Hap Security for reporting this issue.