### PR TITLE
Now that ASAN support is more common, spruce up `--enable-devel=sanit…

### DIFF
--- a/configure
+++ b/configure
@@ -17887,6 +17887,7 @@ fi
 
 
 pr_devel_cflags="-g3 -O0 -Wcast-align -Wchar-subscripts -Winline -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -Wpointer-arith -Wshadow -Wundef"
+pr_devel_ldflags=""
 pr_devel_libs=""
 
 # Check whether --enable-devel was given.
@@ -18049,45 +18050,8 @@ $as_echo "no" >&6; }
       fi
 
       if test `echo $enableval | grep -c sanitize` = "1" ; then
-        pr_devel_cflags="-fsanitize=address $pr_devel_cflags"
-        pr_devel_libs="-fsanitize=address $pr_devel_libs"
-
-        # Determine whether we need to link with libasan (gcc) or not (clang)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -lasan" >&5
-$as_echo_n "checking whether the C compiler accepts -lasan... " >&6; }
-        saved_ldflags=$LDFLAGS
-        LDFLAGS="-lasan $LDFLAGS"
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-            int i;
-            i = 7;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-            pr_devel_libs="-lasan $pr_devel_libs"
-
-else
-
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-        LDFLAGS=$saved_ldflags
+        pr_devel_cflags="-DPR_DEVEL_ASAN -DPR_DEVEL_NO_POOL_FREELIST -fsanitize=address,undefined $pr_devel_cflags"
+        pr_devel_ldflags="-fsanitize=address,undefined $pr_devel_ldflags"
       fi
 
 
@@ -26101,6 +26065,7 @@ $as_echo "#define PR_USE_DEVEL 1" >>confdefs.h
 
     CFLAGS=`echo "$CFLAGS" | sed -e 's/\-O2//'`
   CFLAGS="$CFLAGS $pr_devel_cflags"
+  LDFLAGS="$LDFLAGS $pr_devel_ldflags"
   LIBS="$LIBS $pr_devel_libs"
 
   if test x"$GCC" = xyes; then

--- a/configure.in
+++ b/configure.in
@@ -1196,6 +1196,7 @@ AC_ARG_ENABLE(xattr,
 
 dnl Enable developer code
 pr_devel_cflags="-g3 -O0 -Wcast-align -Wchar-subscripts -Winline -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -Wpointer-arith -Wshadow -Wundef"
+pr_devel_ldflags=""
 pr_devel_libs=""
 
 AC_ARG_ENABLE(devel,
@@ -1254,33 +1255,12 @@ AC_ARG_ENABLE(devel,
       fi
 
       if test `echo $enableval | grep -c sanitize` = "1" ; then
-        pr_devel_cflags="-fsanitize=address $pr_devel_cflags"
-        pr_devel_libs="-fsanitize=address $pr_devel_libs"
-
-        # Determine whether we need to link with libasan (gcc) or not (clang)
-        AC_MSG_CHECKING([whether the C compiler accepts -lasan])
-        saved_ldflags=$LDFLAGS
-        LDFLAGS="-lasan $LDFLAGS"
-        AC_TRY_LINK(
-          [
-          ],
-          [
-            int i;
-            i = 7;
-          ],
-          [
-            AC_MSG_RESULT(yes)
-            pr_devel_libs="-lasan $pr_devel_libs"
-          ],
-          [
-            AC_MSG_RESULT(no)
-          ]
-        )
-        LDFLAGS=$saved_ldflags
+        pr_devel_cflags="-DPR_DEVEL_ASAN -DPR_DEVEL_NO_POOL_FREELIST -fsanitize=address,undefined $pr_devel_cflags"
+        pr_devel_ldflags="-fsanitize=address,undefined $pr_devel_ldflags"
       fi
 
       dnl Here is where we WOULD check for the stacktrace developer option.
-      dnl However, as of Issue 276, stacktraces are now enabled by default.
+      dnl However, as of Issue #276, stacktraces are now enabled by default.
 
       if test `echo $enableval | grep -c timing` = "1"; then
         pr_devel_cflags="-DPR_DEVEL_TIMING $pr_devel_cflags"
@@ -4502,6 +4482,7 @@ if test x"$devel" = xyes ; then
   dnl Remove optimization flags from CFLAGS
   CFLAGS=`echo "$CFLAGS" | sed -e 's/\-O2//'`
   CFLAGS="$CFLAGS $pr_devel_cflags"
+  LDFLAGS="$LDFLAGS $pr_devel_ldflags"
   LIBS="$LIBS $pr_devel_libs"
 
   if test x"$GCC" = xyes; then

--- a/contrib/mod_auth_otp/Makefile.in
+++ b/contrib/mod_auth_otp/Makefile.in
@@ -17,6 +17,7 @@ MODULE_NAME=mod_auth_otp
 MODULE_OBJS=mod_auth_otp.o base32.o otp.o crypto.o db.o
 SHARED_MODULE_OBJS=mod_auth_otp.lo base32.lo otp.lo crypto.lo db.lo
 UTILS_LIBS=@UTILS_LIBS@
+UTILS_LDFLAGS=-L../../lib
 UTILS_OBJS=utils/base32.o utils/otp.o utils/crypto.o auth-otp.o
 UTILS_API_OBJS=../../src/pool.o \
   ../../src/str.o \
@@ -25,7 +26,6 @@ UTILS_API_OBJS=../../src/pool.o \
 # Necessary redefinitions
 INCLUDES=-I. -I../.. -I../../include -I$(top_srcdir)/../../include @INCLUDES@
 CPPFLAGS=$(ADDL_CPPFLAGS) -DHAVE_CONFIG_H $(DEFAULT_PATHS) $(PLATFORM) $(INCLUDES)
-LDFLAGS=-L../../lib @LDFLAGS@
 
 .c.o:
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
@@ -45,7 +45,7 @@ static: $(MODULE_OBJS) auth-otp$(EXEEXT)
 	$(RANLIB) $(MODULE_NAME).a
 
 auth-otp$(EXEEXT): $(UTILS_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(UTILS_OBJS) $(UTILS_API_OBJS) $(UTILS_LIBS)
+	$(CC) $(LDFLAGS) $(UTILS_LDFLAGS) -o $@ $(UTILS_OBJS) $(UTILS_API_OBJS) $(UTILS_LIBS)
 
 install: install-headers install-man install-utils
 	if [ -f $(MODULE_NAME).la ] ; then \
@@ -70,7 +70,7 @@ install-utils: $(DESTDIR)$(sbindir)
 	$(INSTALL_BIN) auth-otp$(EXEEXT) $(DESTDIR)$(sbindir)/auth-otp$(EXEEXT)
 
 clean:
-	$(LIBTOOL) --mode=clean $(RM) $(MODULE_NAME).a $(MODULE_NAME).la *.o *.lo .libs/*.o
+	$(LIBTOOL) --mode=clean $(RM) $(MODULE_NAME).a $(MODULE_NAME).la *.o *.gcda *.gcno *.lo .libs/*.o
 	-$(RM) auth-otp$(EXEEXT)
 	-$(RM) -r utils/
 

--- a/src/main.c
+++ b/src/main.c
@@ -2217,7 +2217,11 @@ static void show_settings(void) {
 #endif /* PR_USE_CURSES and HAVE_LIBCURSES */
 
 #if defined(PR_USE_DEVEL)
+# if defined(PR_DEVEL_ASAN)
+  printf("%s", "    + Developer support (ASAN)\n");
+# else
   printf("%s", "    + Developer support\n");
+# endif /* PR_DEVEL_ASAN */
 #else
   printf("%s", "    - Developer support\n");
 #endif /* PR_USE_DEVEL */

--- a/src/session.c
+++ b/src/session.c
@@ -172,15 +172,19 @@ void pr_session_end(int flags) {
   }
 #endif /* PR_USE_DEVEL */
 
-#if defined(PR_DEVEL_PROFILE)
+#if defined(PR_DEVEL_ASAN) || \
+    defined(PR_DEVEL_PROFILE)
   /* Populating the gmon.out gprof file requires that the process exit
    * via exit(3) or by returning from main().  Using _exit(2) doesn't allow
    * the process the time to write its profile data out.
+   *
+   * Similarly, tools like ASAN have exit(3) hooks for reporting their
+   * findings.
    */
   exit(exitcode);
 #else
   _exit(exitcode);
-#endif /* PR_DEVEL_PROFILE */
+#endif /* PR_DEVEL_ASAN or PR_DEVEL_PROFILE */
 }
 
 const char *pr_session_get_disconnect_reason(const char **details) {


### PR DESCRIPTION
…ize` so that it can be used as shorthand for creating an ASAN build of ProFTPD.

This will make it easier to start writing regression tests, running under ASAN, for exercising larger swaths of code and using more modules.