### PR TITLE
Issue #2188: Make sure that `mod_sql` escapes the client-provided gro…

### DIFF
--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -2278,7 +2278,7 @@ static struct group *sql_getgroup(cmd_rec *cmd, struct group *g) {
     sql_log(DEBUG_AUTH, "cache hit for group '%s'", grp->gr_name);
 
     /* Check for negatively cached groups, which will have NULL gr_mem. */
-    if (!grp->gr_mem) {
+    if (grp->gr_mem == NULL) {
       sql_log(DEBUG_AUTH, "negative cache entry for group '%s'", grp->gr_name);
       return NULL;
     }
@@ -2287,7 +2287,17 @@ static struct group *sql_getgroup(cmd_rec *cmd, struct group *g) {
   }
 
   if (g->gr_name != NULL) {
-    groupname = g->gr_name;
+    char *realname;
+
+    realname = g->gr_name;
+
+    mr = sql_dispatch(sql_make_cmd(cmd->tmp_pool, 2, MOD_SQL_DEF_CONN_NAME,
+      realname), "sql_escapestring");
+    if (check_response(mr, 0) < 0) {
+      return NULL;
+    }
+
+    groupname = (char *) mr->data;
     sql_log(DEBUG_WARN, "cache miss for group '%s'", groupname);
 
   } else {
@@ -2354,6 +2364,10 @@ static struct group *sql_getgroup(cmd_rec *cmd, struct group *g) {
 
     groupname = sd->data[0];
   }
+
+  /* The groupname has been escaped according to the backend database' rules
+   * at this point.
+   */
 
   if (!cmap.groupcustombyname) {
     grpwhere = pstrcat(cmd->tmp_pool, cmap.grpfield, " = '", groupname, "'",

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -472,6 +472,11 @@ my $TESTS = {
     order => ++$order,
     test_class => [qw(forking bug rootprivs)],
   },
+
+  sql_site_chgrp_sql_injection_issue2188 => {
+    order => ++$order,
+    test_class => [qw(forking bug)],
+  },
 };
 
 sub new {
@@ -15976,6 +15981,180 @@ EOS
   };
   if ($@) {
     $ex = $@ unless $ex;
+  }
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub sql_site_chgrp_sql_injection_issue2188 {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'sqlite');
+
+  my $test_file = File::Spec->rel2abs("$tmpdir/test.dat");
+  if (open(my $fh, "> $test_file")) {
+    close($fh);
+
+  } else {
+    die("Can't open $test_file: $!");
+  }
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create users, groups tables and populate them
+  my $db_script = File::Spec->rel2abs("$tmpdir/proftpd.sql");
+
+  if (open(my $fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE users (
+  userid TEXT,
+  passwd TEXT,
+  uid INTEGER,
+  gid INTEGER,
+  homedir TEXT,
+  shell TEXT
+);
+INSERT INTO users (userid, passwd, uid, gid, homedir, shell) VALUES ('$setup->{user}', '$setup->{passwd}', $setup->{uid}, $setup->{gid}, '$setup->{home_dir}', '/bin/bash');
+
+CREATE TABLE groups (
+  groupname TEXT,
+  gid INTEGER,
+  members TEXT
+);
+INSERT INTO groups (groupname, gid, members) VALUES ('$setup->{group}', $setup->{gid}, '$setup->{user}');
+EOS
+
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script);
+
+  # Make sure that, if we're running as root, the database file has
+  # the permissions/privs set for use by proftpd
+  if ($< == 0) {
+    unless (chmod(0666, $db_file)) {
+      die("Can't set perms on $db_file to 0666: $!");
+    }
+  }
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'sql:20',
+
+    # Needed to generate the expected log message for verification
+    DebugLevel => 9,
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_sql.c' => {
+        SQLAuthTypes => 'plaintext',
+        SQLBackend => 'sqlite3',
+        SQLConnectInfo => $db_file,
+        SQLLogFile => $setup->{log_file},
+        AuthOrder => 'mod_sql.c',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $bad_group = "');INSERT||UNION%%SELECT%%999|--'";
+      eval { $client->site('CHGRP', $bad_group, 'test.dat') };
+      unless ($@) {
+        die("SITE CHGRP succeeded unexpectedly");
+      }
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+
+      my $expected = 550;
+      $self->assert($expected == $resp_code,
+        test_msg("Expected response code $expected, got $resp_code"));
+
+      $expected = "test.dat: Invalid argument";
+      $self->assert($expected eq $resp_msg,
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
+
+      $client->quit();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  eval {
+    if (open(my $fh, "< $setup->{log_file}")) {
+      my $ok = 0;
+
+      while (my $line = <$fh>) {
+        chomp($line);
+
+        if ($ENV{TEST_VERBOSE}) {
+          print STDERR "# $line\n";
+        }
+
+        if ($line =~ /Unable to resolve group name/) {
+          $ok = 1;
+          last;
+        }
+      }
+
+      close($fh);
+      $self->assert($ok, test_msg("Did not see expected log message"));
+
+    } else {
+      die("Can't read $setup->{log_file}: $!");
+    }
+  };
+  if ($@) {
+    $ex = $@;
   }
 
   test_cleanup($setup->{log_file}, $ex);


### PR DESCRIPTION
…up name for name-to-GID lookups, to prevent SQL injections.