### PR TITLE
Issue #2210: Ensure that the default Controls socket ACLs, if not exp…

### DIFF
--- a/modules/mod_ctrls.c
+++ b/modules/mod_ctrls.c
@@ -1337,8 +1337,7 @@ static int ctrls_init(void) {
   }
 
   /* Make certain the socket ACL is initialized. */
-  memset(&ctrls_sock_acl, '\0', sizeof(ctrls_acl_t));
-  ctrls_sock_acl.acl_users.allow = ctrls_sock_acl.acl_groups.allow = FALSE;
+  pr_ctrls_init_acl(&ctrls_sock_acl);
 
   pr_event_register(&ctrls_module, "core.restart", ctrls_restart_ev, NULL);
   pr_event_register(&ctrls_module, "core.shutdown", ctrls_shutdown_ev, NULL);


### PR DESCRIPTION
…licitly configured, properly implement the intended deny-by-default behavior.