### PR TITLE
Ideally, the `pr_ctrls_check_acl()` function should implement fail-cl…

### DIFF
--- a/src/ctrls.c
+++ b/src/ctrls.c
@@ -2028,6 +2028,7 @@ int pr_ctrls_check_user_acl(uid_t cl_uid, const ctrls_user_acl_t *user_acl) {
 int pr_ctrls_check_acl(const pr_ctrls_t *ctrl,
     const ctrls_acttab_t *acttab, const char *action) {
   register unsigned int i = 0;
+  int unknown_action = TRUE;
 
   if (ctrl == NULL ||
       ctrl->ctrls_cl == NULL ||
@@ -2041,18 +2042,38 @@ int pr_ctrls_check_acl(const pr_ctrls_t *ctrl,
     if (strcmp(acttab[i].act_action, action) == 0) {
       int user_check = FALSE, group_check = FALSE;
 
+      unknown_action = FALSE;
+
       if (acttab[i].act_acl != NULL) {
         user_check = pr_ctrls_check_user_acl(ctrl->ctrls_cl->cl_uid,
           &(acttab[i].act_acl->acl_users));
+        pr_trace_msg(trace_channel, 19,
+          "checking user ACL for action '%s' with UID %lu returned %s", action,
+          (unsigned long) ctrl->ctrls_cl->cl_uid,
+          user_check ? "true" : "false");
+
         group_check = pr_ctrls_check_group_acl(ctrl->ctrls_cl->cl_gid,
           &(acttab[i].act_acl->acl_groups));
+        pr_trace_msg(trace_channel, 19,
+          "checking group ACL for action '%s' with GID %lu returned %s", action,
+          (unsigned long) ctrl->ctrls_cl->cl_gid,
+          group_check ? "true" : "false");
       }
 
       if (user_check != TRUE &&
           group_check != TRUE) {
+        /* Known action is explicitly denied for user and group by this ACL. */
         return FALSE;
       }
     }
+  }
+
+  if (unknown_action == TRUE) {
+    pr_trace_msg(trace_channel, 19,
+      "checked ACL for unknown/unmatched action '%s', returning false", action);
+
+    /* Fail-close by returning false here for unmatched actions. */
+    return FALSE;
   }
 
   return TRUE;

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -1604,7 +1604,7 @@ START_TEST (ctrls_check_acl_test) {
   mark_point();
   action = "foobar";
   res = pr_ctrls_check_acl(ctrl, acttab, action);
-  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   mark_point();
   action = "test";
@@ -1623,6 +1623,7 @@ START_TEST (ctrls_check_acl_test) {
   res = pr_ctrls_check_acl(ctrl, acttab, action);
   ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
+  mark_point();
   acl->acl_users.nuids = 1;
   res = pr_ctrls_check_acl(ctrl, acttab, action);
   ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ctrls.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ctrls.pm
@@ -45,6 +45,11 @@ my $TESTS = {
     test_class => [qw(bug forking)],
   },
 
+  ctrls_unknown_action_failed => {
+    order => ++$order,
+    test_class => [qw(forking)],
+  },
+
 };
 
 sub new {
@@ -636,6 +641,88 @@ sub ctrls_intvl_timeoutlogin_bug4298 {
   server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
+  test_cleanup($setup, $ex);
+}
+
+sub ctrls_unknown_action_failed {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'ctrls');
+
+  my $ctrls_sock = File::Spec->rel2abs("$tmpdir/ctrls.sock");
+
+  my ($user, $group) = config_get_identity();
+  my $poll_interval = 2;
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'ctrls:20 event:10',
+
+    IfModules => {
+      'mod_ctrls.c' => {
+        ControlsEngine => 'on',
+        ControlsLog => $setup->{log_file},
+        ControlsSocket => $ctrls_sock,
+        ControlsACLs => "all allow user *",
+        ControlsSocketACL => "allow user *",
+        ControlsInterval => $poll_interval,
+      },
+
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  my $ex;
+
+  # Start server
+  server_start($setup->{config_file});
+  sleep(2);
+
+  eval {
+    my ($exit_status, $lines) = ftpdctl($ctrls_sock, 'foobar', $poll_interval);
+    if ($ENV{TEST_VERBOSE}) {
+      print STDERR "# ftpdctl: (exit status $exit_status)\n";
+      foreach my $line (@$lines) {
+        chomp($line);
+        print STDERR "#  $line\n";
+      }
+    }
+
+    my $expected = 7;
+    $self->assert($exit_status == $expected,
+      test_msg("Expected exit status $expected, got $exit_status"));
+
+    $lines = [grep { /unsupported/ } @$lines];
+
+    $expected = 1;
+    my $matches = scalar(@$lines);
+    $self->assert($expected == $matches,
+      test_msg("Expected line count $expected, got $matches"));
+
+    my $actions = '';
+    foreach my $line (@$lines) {
+      if ($line =~ /^ftpdctl: (.*?)$/) {
+        $actions .= "$1";
+      }
+    }
+
+    $expected = 'unsupported action requested';
+    $self->assert($expected eq $actions,
+      test_msg("Expected '$expected', got '$actions'"));
+  };
+  if ($@) {
+    $ex = $@;
+  }
+
+  server_stop($setup->{pid_file});
   test_cleanup($setup, $ex);
 }
 


### PR DESCRIPTION
…ose behavior by returning false for unknown actions.

This is mostly defensive programming issue; all existing callers of `pr_ctrls_check_acl()` do so using action names that are present in their respective action tables.  Thus there is no change in existing behavior with this change.

Thanks to Fabian Wahle of Hap Security for reporting this issue.