### PR TITLE
Try to mitigate symlink attacks in `pr_ctrls_connect()` where we `unl…

### DIFF
--- a/src/ctrls.c
+++ b/src/ctrls.c
@@ -1243,8 +1243,10 @@ int pr_set_registered_actions(module *mod, const char *action,
   return 0;
 }
 
-#if !defined(SO_PEERCRED) && !defined(HAVE_GETPEEREID) && \
-    !defined(HAVE_GETPEERUCRED) && defined(LOCAL_CREDS)
+#if !defined(SO_PEERCRED) && \
+    !defined(HAVE_GETPEEREID) && \
+    !defined(HAVE_GETPEERUCRED) && \
+    defined(LOCAL_CREDS)
 static int ctrls_connect_local_creds(int fd) {
   char buf[1] = {'\0'};
   int res;
@@ -1276,6 +1278,7 @@ static int ctrls_connect_local_creds(int fd) {
 int pr_ctrls_connect(const char *socket_file) {
   int fd = -1, len = 0;
   struct sockaddr_un cl_sock, ctrl_sock;
+  struct stat st;
 
   if (socket_file == NULL) {
     errno = EINVAL;
@@ -1321,7 +1324,23 @@ int pr_ctrls_connect(const char *socket_file) {
     "/tmp/ftp.cl", (unsigned int) getpid());
   len = sizeof(cl_sock);
 
-  /* Make sure the file doesn't already exist */
+  /* Make sure the file doesn't already exist.  If it does exist AND is
+   * a file or socket, we can remove it.
+   */
+  if (lstat(cl_sock.sun_path, &st) == 0) {
+    if (S_ISDIR(st.st_mode) ||
+        S_ISLNK(st.st_mode)) {
+      pr_trace_msg(trace_channel, 6,
+        "client path '%s' exists and is not a socket", cl_sock.sun_path);
+
+      (void) close(fd);
+      pr_signals_unblock();
+
+      errno = EEXIST;
+      return -1;
+    }
+  }
+
   (void) unlink(cl_sock.sun_path);
 
   /* Make it a socket */
@@ -1372,8 +1391,10 @@ int pr_ctrls_connect(const char *socket_file) {
     return -1;
   }
 
-#if !defined(SO_PEERCRED) && !defined(HAVE_GETPEEREID) && \
-    !defined(HAVE_GETPEERUCRED) && defined(LOCAL_CREDS)
+#if !defined(SO_PEERCRED) && \
+    !defined(HAVE_GETPEEREID) && \
+    !defined(HAVE_GETPEERUCRED) && \
+    defined(LOCAL_CREDS)
   if (ctrls_connect_local_creds(fd) < 0) {
     int xerrno = errno;
 

--- a/tests/api/ctrls.c
+++ b/tests/api/ctrls.c
@@ -1417,6 +1417,74 @@ START_TEST (ctrls_accept_test) {
 }
 END_TEST
 
+START_TEST (ctrls_connect_eexist_directory_test) {
+  int res;
+  const char socket_path[1024];
+
+  mark_point();
+  res = pr_ctrls_connect(NULL);
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+
+  mark_point();
+  memset(socket_path, '\0', sizeof(socket_path));
+  snprintf(socket_path, sizeof(socket_path)-1, "/tmp/ftp.cl%05u",
+    (unsigned int) getpid());
+  res = pr_ctrls_connect(socket_path);
+  ck_assert_msg(res < 0, "Failed to handle nonexistent socket path");
+  ck_assert_msg(errno == ECONNREFUSED || errno == ENOENT,
+    "Expected ECONNREFUSED (%d) or ENOENT (%d), got %s (%d)", ECONNREFUSED,
+    ENOENT, strerror(errno), errno);
+
+  mark_point();
+  if (mkdir(socket_path, 0777) < 0) {
+    return;
+  }
+
+  res = pr_ctrls_connect(socket_path);
+  ck_assert_msg(res < 0, "Failed to handle directory socket path");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)",
+    EEXIST, strerror(errno), errno);
+
+  (void) rmdir(socket_path);
+}
+END_TEST
+
+START_TEST (ctrls_connect_eexist_symlink_test) {
+  int res;
+  const char socket_path[1024];
+
+  mark_point();
+  res = pr_ctrls_connect(NULL);
+  ck_assert_msg(res < 0, "Failed to handle null path");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    strerror(errno), errno);
+
+  mark_point();
+  memset(socket_path, '\0', sizeof(socket_path));
+  snprintf(socket_path, sizeof(socket_path)-1, "/tmp/ftp.cl%05u",
+    (unsigned int) getpid());
+  res = pr_ctrls_connect(socket_path);
+  ck_assert_msg(res < 0, "Failed to handle nonexistent socket path");
+  ck_assert_msg(errno == ECONNREFUSED || errno == ENOENT,
+    "Expected ECONNREFUSED (%d) or ENOENT (%d), got %s (%d)", ECONNREFUSED,
+    ENOENT, strerror(errno), errno);
+
+  mark_point();
+  if (symlink(socket_path, "/foo/bar/baz") < 0) {
+    return;
+  }
+
+  res = pr_ctrls_connect(socket_path);
+  ck_assert_msg(res < 0, "Failed to handle symlink socket path");
+  ck_assert_msg(errno == EEXIST, "Expected EEXIST (%d), got %s (%d)",
+    EEXIST, strerror(errno), errno);
+
+  (void) unlink(socket_path);
+}
+END_TEST
+
 START_TEST (ctrls_connect_test) {
   int fd, res;
   const char *socket_path;
@@ -2159,6 +2227,8 @@ Suite *tests_get_ctrls_suite(void) {
   tcase_add_test(testcase, ctrls_run_ctrls_test);
   tcase_add_test(testcase, ctrls_reset_ctrls_test);
   tcase_add_test(testcase, ctrls_accept_test);
+  tcase_add_test(testcase, ctrls_connect_eexist_directory_test);
+  tcase_add_test(testcase, ctrls_connect_eexist_symlink_test);
   tcase_add_test(testcase, ctrls_connect_test);
 
   /* mod_ctrls */


### PR DESCRIPTION
…ink(2)` a predicatable path.

Thanks to Fabian Wahle of Hap Security for reporting this issue.