### PR TITLE
Make sure that the mod_quotatab limit/tally records' name fields are …

### DIFF
--- a/contrib/mod_quotatab.h
+++ b/contrib/mod_quotatab.h
@@ -57,7 +57,7 @@ typedef enum {
 
 /* Quota objects */
 typedef struct {
-  char name[81];
+  char name[PR_TUNABLE_LOGIN_MAX+1];
 
   /* name refers to user, group, or class */
   quota_type_t quota_type;
@@ -83,7 +83,7 @@ typedef struct {
 } quota_limit_t;
 
 typedef struct {
-  char name[81];
+  char name[PR_TUNABLE_LOGIN_MAX+1];
 
   quota_type_t quota_type;
 


### PR DESCRIPTION
…sized to match the maximum allowed user name length.

Thanks to Fabian Wahle of Hap Security for reporting this issue.