### PR TITLE
AIX: avoid ip_len macro collision with external headers

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -158,6 +158,10 @@ char *strchr(),*strrchr();
 # include <netinet/ip.h>
 #endif
 
+#if defined(ip_len) && defined(_AIX)
+# undef ip_len
+#endif
+
 #ifdef HAVE_NETINET_TCP_H
 # include <netinet/tcp.h>
 #endif


### PR DESCRIPTION
Hi All,

AIX's netinet/ip.h defines ip_len as a macro:   `#define ip_len ip_ff.ip_flen`

Because `include/os.h` includes `netinet/ip.h`, This macro leaks into translation units including os.h and causes
conflicts with external headers such as libsodium, which declares functions using ip_len as a parameter name.

For example, libsodium's sodium_ip2bin() declaration:
    int sodium_ip2bin(..., size_t ip_len)

is expanded by the preprocessor into invalid C:
    int sodium_ip2bin(..., size_t ip_ff.ip_flen)
    
   ```
 libtool: compile:  /opt/freeware/bin/gcc -g -DHAVE_CONFIG_H -DAIX7_1_5_0 -DAIX7 -I.. -I../include -I../include -c ../modules/mod_sql_passwd.c  -DPIC -o .libs/mod_sql_passwd.o
In file included from ../include/os.h:159,
                 from ../include/conf.h:32,
                 from ../modules/mod_sql_passwd.c:28:
/opt/freeware/include/sodium/utils.h:96:65: error: expected ';', ',' or ')' before '.' token
   96 | int sodium_ip2bin(unsigned char bin[16], const char *ip, size_t ip_len)
      |                                                                 ^~~~~~
gmake[1]: *** [Makefile:34: mod_sql_passwd.la] Error 1
gmake[1]: Leaving directory '/home/buildusr/rpmbuild/BUILD/proftpd-1.3.9b/modules'
gmake: *** [Makefile:58: modules] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.TB3qab (%build)
```

**Proposed Fix:**

Undefine the AIX `ip_len` macro immediately after including`netinet/ip.h` in `include/os.h`.

This prevents system-header macros from leaking into application and third-party headers.