### PR TITLE
When resolving UID/GID to names, mod_ldap currently uses the `permane…

### DIFF
--- a/contrib/mod_ldap.c
+++ b/contrib/mod_ldap.c
@@ -2294,7 +2294,7 @@ MODRET ldap_auth_uid2name(cmd_rec *cmd) {
     return PR_DECLINED(cmd);
   }
 
-  return mod_create_data(cmd, pstrdup(permanent_pool, pw->pw_name));
+  return mod_create_data(cmd, pstrdup(cmd->pool, pw->pw_name));
 }
 
 MODRET ldap_auth_gid2name(cmd_rec *cmd) {
@@ -2310,7 +2310,7 @@ MODRET ldap_auth_gid2name(cmd_rec *cmd) {
     return PR_DECLINED(cmd);
   }
 
-  return mod_create_data(cmd, pstrdup(permanent_pool, gr->gr_name));
+  return mod_create_data(cmd, pstrdup(cmd->pool, gr->gr_name));
 }
 
 MODRET ldap_auth_name2uid(cmd_rec *cmd) {


### PR DESCRIPTION
…nt_pool` for duplicating the returned name, which effectively leaks memory for long-lasting sessions.

Instead, it should use `cmd->pool` for the name duplication, as done by `mod_sql` and others.