### PR TITLE
When populating the names of the quotatab limit/tally tables, use our…

### DIFF
--- a/contrib/mod_quotatab.c
+++ b/contrib/mod_quotatab.c
@@ -1012,7 +1012,7 @@ unsigned char quotatab_lookup_default(quota_tabtype_t tab_type, void *ptr,
      *  files_{in,out,xfer}_avail
      */
 
-    memmove(limit->name, name, strlen(name) + 1);
+    sstrncpy(limit->name, name, sizeof(limit->name)-1);
     limit->quota_type = quota_type;
 
     limit->quota_per_session = pr_str_is_boolean(c->argv[1]);
@@ -4832,6 +4832,8 @@ static int quotatab_sess_init(void) {
     }
   }
 
+  memset(&sess_limit, 0, sizeof(sess_limit));
+  memset(&sess_tally, 0, sizeof(sess_tally));
   return 0;
 }
 

--- a/contrib/mod_quotatab_ldap.c
+++ b/contrib/mod_quotatab_ldap.c
@@ -107,7 +107,7 @@ static unsigned char ldaptab_lookup(quota_table_t *ldaptab, void *ptr,
    *  files_{in,out,xfer}_avail
    */
 
-  memmove(limit->name, values[0], strlen(values[0]) + 1);
+  sstrncpy(limit->name, values[0], sizeof(limit->name)-1);
   limit->quota_type = USER_QUOTA;
 
   if (strcasecmp(values[1], "false") == 0) {

--- a/contrib/mod_quotatab_radius.c
+++ b/contrib/mod_quotatab_radius.c
@@ -92,7 +92,7 @@ static unsigned char radiustab_lookup(quota_table_t *radiustab, void *ptr,
    *  files_{in,out,xfer}_avail
    */
 
-  memmove(limit->name, values[0], strlen(values[0]) + 1);
+  sstrncpy(limit->name, values[0], sizeof(limit->name)-1);
   limit->quota_type = USER_QUOTA;
 
   if (strcasecmp(values[1], "false") == 0) {

--- a/contrib/mod_quotatab_sql.c
+++ b/contrib/mod_quotatab_sql.c
@@ -279,7 +279,7 @@ static unsigned char sqltab_lookup(quota_table_t *sqltab, void *ptr,
     }
 
     /* Process each element returned. */
-    memmove(tally->name, values[0], sizeof(tally->name));
+    sstrncpy(tally->name, values[0], sizeof(tally->name)-1);
 
     if (strcasecmp(values[1], "user") == 0) {
       tally->quota_type = USER_QUOTA;
@@ -379,7 +379,7 @@ static unsigned char sqltab_lookup(quota_table_t *sqltab, void *ptr,
     }
 
     /* Process each element returned. */
-    memmove(limit->name, values[0], sizeof(limit->name));
+    sstrncpy(limit->name, values[0], sizeof(limit->name)-1);
 
     if (strcasecmp(values[1], "user") == 0) {
       limit->quota_type = USER_QUOTA;


### PR DESCRIPTION
… own `sstrncpy()` function.