### PR TITLE
Make sure we properly honor the maximum ExtendedLog buffer size when …

### DIFF
--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -748,6 +748,10 @@ static int resolve_on_other(pool *p, pr_jot_ctx_t *jot_ctx,
 
   log = jot_ctx->log;
   if (log->buflen > 0) {
+    if (text_len > log->buflen) {
+      text_len = log->buflen;
+    }
+
     pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
       (int) text_len, text, (unsigned long) text_len);
     memcpy(log->buf, text, text_len);


### PR DESCRIPTION
…resolving "other" text.

This is analogous to https://github.com/proftpd/proftpd/commit/809779ff117f33322b8fdec73b52c4adb72f7021