### PR TITLE
Avoid zero-length `memcpy(3)` calls in Jot resolvers when handling (p…

### DIFF
--- a/contrib/mod_exec.c
+++ b/contrib/mod_exec.c
@@ -990,6 +990,11 @@ static void exec_jot_append_text(struct exec_jot_buffer *log, const char *text,
 
   pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
     (int) text_len, text, (unsigned long) text_len);
+
+  if (text_len == 0) {
+    return;
+  }
+
   memcpy(log->buf, text, text_len);
   log->buf += text_len;
   log->buflen -= text_len;

--- a/contrib/mod_sql.c
+++ b/contrib/mod_sql.c
@@ -808,6 +808,11 @@ static int sql_resolved_append_text(pool *p, struct sql_resolved *resolved,
 
   pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
     (int) new_textlen, new_text, (unsigned long) new_textlen);
+
+  if (new_textlen == 0) {
+    return 0;
+  }
+
   memcpy(resolved->buf, new_text, new_textlen);
   resolved->buf += new_textlen;
   resolved->buflen -= new_textlen;

--- a/modules/mod_log.c
+++ b/modules/mod_log.c
@@ -488,6 +488,11 @@ static void extlog_buffer_append(struct extlog_buffer *log, const char *text,
 
   pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
     (int) text_len, text, (unsigned long) text_len);
+
+  if (text_len == 0) {
+    return;
+  }
+
   memcpy(log->buf, text, text_len);
   log->buf += text_len;
   log->buflen -= text_len;

--- a/modules/mod_redis.c
+++ b/modules/mod_redis.c
@@ -77,6 +77,11 @@ static void redis_buffer_append_text(struct redis_buffer *log, const char *text,
 
   pr_trace_msg(trace_channel, 19, "appending text '%.*s' (%lu) to buffer",
     (int) text_len, text, (unsigned long) text_len);
+
+  if (text_len == 0) {
+    return;
+  }
+
   memcpy(log->buf, text, text_len);
   log->buf += text_len;
   log->buflen -= text_len;

--- a/src/jot.c
+++ b/src/jot.c
@@ -2851,6 +2851,10 @@ static void jot_parsed_append_text(pr_jot_parsed_t *parsed, const char *text,
   pr_trace_msg(trace_channel, 19, "appending text '%.*s' to format",
     (int) text_len, text);
 
+  if (text_len == 0) {
+    return;
+  }
+
   for (i = 0; i < text_len; i++) {
     *(parsed->buf++) = (unsigned char) text[i];
   }


### PR DESCRIPTION
…ossibly truncated) zero length text.