### PR TITLE
Coverity rightly identified that the `now` timestamp was not being pr…

### DIFF
--- a/contrib/mod_ctrls_admin.c
+++ b/contrib/mod_ctrls_admin.c
@@ -1175,7 +1175,6 @@ static int ctrls_handle_shutdown(pr_ctrls_t *ctrl, int reqargc,
       }
 
       timeout = client_timeout;
-      time(&now);
 
       pr_ctrls_log(MOD_CTRLS_ADMIN_VERSION,
         "shutdown: waiting %u seconds before shutting down", timeout);
@@ -1197,6 +1196,8 @@ static int ctrls_handle_shutdown(pr_ctrls_t *ctrl, int reqargc,
      */
 
     nkids = child_count();
+    time(&now);
+
     while (nkids > 0) {
       if (timeout &&
           time(NULL) - now > timeout) {


### PR DESCRIPTION
…operly initialized in all cases of `ftpdctl shutdown`.