### PR TITLE
If `SFTPAuthPublicKeys` has explicitly configured a list of allowed p…

### DIFF
--- a/contrib/mod_sftp/kex.c
+++ b/contrib/mod_sftp/kex.c
@@ -3176,37 +3176,54 @@ static int write_newkeys_reply(struct ssh2_packet *pkt) {
 static int write_ext_info_server_sig_algs(struct ssh2_packet *pkt,
     unsigned char **buf, uint32_t *buflen) {
   char *sig_algs = "";
+  config_rec *c;
 
+  c = find_config(main_server->conf, CONF_PARAM, "SFTPAuthPublicKeys", FALSE);
+  if (c != NULL) {
+    register unsigned int i;
+
+    for (i = 0; i < c->argc; i++) {
+      const char *algo;
+
+      algo = c->argv[i];
+      sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", algo, NULL);
+    }
+
+  } else {
+    /* No explicit list of publickey algorithms configured; provide the full
+     * list of supported algorithms.
+     */
 #if defined(HAVE_X448_OPENSSL)
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-ed448",
-    NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-ed448",
+      NULL);
 #endif /* HAVE_X448_OPENSSL */
 
 #if defined(PR_USE_SODIUM)
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-ed25519",
-    NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-ed25519",
+      NULL);
 #endif /* PR_USE_SODIUM */
 
 #if defined(HAVE_SHA256_OPENSSL)
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "rsa-sha2-256",
-    NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "",
+      "rsa-sha2-256", NULL);
 #endif /* HAVE_SHA256_OPENSSL */
 
 #if defined(HAVE_SHA512_OPENSSL)
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "rsa-sha2-512",
-    NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "",
+      "rsa-sha2-512", NULL);
 #endif /* HAVE_SHA512_OPENSSL */
 
 #if defined(PR_USE_OPENSSL_ECC)
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "",
-    "ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521", NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "",
+      "ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521", NULL);
 #endif /* PR_USE_OPENSSL_ECC */
 
-  sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-rsa",
-    NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, *sig_algs ? "," : "", "ssh-rsa",
+      NULL);
 #if !defined(OPENSSL_NO_DSA)
-  sig_algs = pstrcat(pkt->pool, sig_algs, ",", "ssh-dss", NULL);
+    sig_algs = pstrcat(pkt->pool, sig_algs, ",", "ssh-dss", NULL);
 #endif /* OPENSSL_NO_DSA */
+  }
 
   pr_trace_msg(trace_channel, 11,
     "writing 'server-sig-algs' EXT_INFO extension: %s", sig_algs);

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sftp.pm
@@ -33337,6 +33337,8 @@ sub sftp_config_auth_public_keys_issue1806 {
     die("Can't copy $dsa_rfc4716_key to $authorized_keys: $!");
   }
 
+  my $pubkey_algs = 'ssh-rsa';
+
   my $config = {
     PidFile => $setup->{pid_file},
     ScoreboardFile => $setup->{scoreboard_file},
@@ -33362,7 +33364,7 @@ sub sftp_config_auth_public_keys_issue1806 {
         "SFTPAuthorizedUserKeys file:~/.authorized_keys",
 
         # The user has an authorized DSA public key, but we only allow RSA keys.
-        "SFTPAuthPublicKeys ssh-rsa",
+        "SFTPAuthPublicKeys $pubkey_algs",
       ],
     },
   };
@@ -33429,7 +33431,8 @@ sub sftp_config_auth_public_keys_issue1806 {
 
   eval {
     if (open(my $fh, "< $setup->{log_file}")) {
-      my $saw_expected_msg = 0;
+      my $serversigalgs_msg = 0;
+      my $authpubkeys_msg = 0;
 
       while (my $line = <$fh>) {
         chomp($line);
@@ -33438,15 +33441,26 @@ sub sftp_config_auth_public_keys_issue1806 {
           print STDERR "# $line\n";
         }
 
+        if ($line =~ /writing 'server\-sig\-algs' EXT_INFO extension: (.*)?/) {
+          my $algs = $1;
+
+          if ($algs eq $pubkey_algs) {
+            $serversigalgs_msg = 1;
+          }
+        }
+
         if ($line =~ /public key algorithm (\S+)? disabled by SFTPAuthPublicKeys, rejecting request/) {
-          $saw_expected_msg = 1;
+          $authpubkeys_msg = 1;
           last;
         }
       }
 
       close($fh);
-      $self->assert($saw_expected_msg,
-        test_msg("Did not see expected message during authentication"));
+
+      $self->assert($serversigalgs_msg,
+        test_msg("Did not see expected server-sig-algs message during authentication"));
+      $self->assert($authpubkeys_msg,
+        test_msg("Did not see expected SFTPLog message during authentication"));
 
     } else {
       die("Can't read $setup->{log_file}: $!");


### PR DESCRIPTION
…ublickey algorithms, then that list should be honored in the `server-sig-algs` extension provided to the client.