### PR TITLE
Issue #2275: If the password field being compared is the empty string…

### DIFF
--- a/contrib/mod_sql_passwd.c
+++ b/contrib/mod_sql_passwd.c
@@ -492,7 +492,7 @@ static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
   const EVP_MD *md;
   unsigned char *hash = NULL, *data = NULL, *prefix = NULL, *suffix = NULL;
   size_t data_len = 0, prefix_len = 0, suffix_len = 0;
-  unsigned int hash_len = 0;
+  unsigned int cmp_len = 0, copytext_len = 0, hash_len = 0;
 
   /* Temporary copy of the ciphertext string */
   char *copytext;
@@ -504,6 +504,13 @@ static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle %s SQLAuthType", digest);
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   md = EVP_get_digestbyname(digest);
@@ -728,7 +735,14 @@ static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
     }
   }
 
-  if (pr_timingsafe_bcmp(encodedtext, copytext, strlen(copytext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(encodedtext);
+  copytext_len = strlen(copytext);
+  if (copytext_len > cmp_len) {
+    cmp_len = copytext_len;
+  }
+
+  if (pr_timingsafe_bcmp(encodedtext, copytext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -743,7 +757,7 @@ static modret_t *sql_passwd_auth(cmd_rec *cmd, const char *plaintext,
 static modret_t *sql_passwd_bcrypt(cmd_rec *cmd, const char *plaintext,
     const char *ciphertext) {
   char *hashed;
-  size_t hashed_len = 0;
+  size_t ciphertext_len = 0, cmp_len = 0, hashed_len = 0;
 
   if (sql_passwd_engine == FALSE) {
     pr_log_pri(PR_LOG_INFO, MOD_SQL_PASSWD_VERSION
@@ -751,6 +765,13 @@ static modret_t *sql_passwd_bcrypt(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle bcrypt SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   /* OpenSSL does not implement the bcrypt algorithm, so we handle it
@@ -763,7 +784,14 @@ static modret_t *sql_passwd_bcrypt(cmd_rec *cmd, const char *plaintext,
     return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
-  if (pr_timingsafe_bcmp(hashed, ciphertext, strlen(ciphertext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(hashed);
+  ciphertext_len = strlen(ciphertext);
+  if (ciphertext_len > cmp_len) {
+    cmp_len = ciphertext_len;
+  }
+
+  if (pr_timingsafe_bcmp(hashed, ciphertext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -803,7 +831,7 @@ static modret_t *sql_passwd_ssha(cmd_rec *cmd, const char *plaintext,
   const EVP_MD *md;
   unsigned char *hash = NULL, *data = NULL, *decoded_data = NULL, *salt = NULL;
   size_t data_len = 0, decoded_datalen = 0, salt_len = 0;
-  unsigned int hash_len = 0;
+  unsigned int cmp_len = 0, copytext_len = 0, hash_len = 0;
 
   /* Temporary copy of the ciphertext string */
   char *copytext;
@@ -815,6 +843,13 @@ static modret_t *sql_passwd_ssha(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle SSHA SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   /* Verify that the provided ciphertext has the required "{SSHA}" prefix. */
@@ -883,7 +918,14 @@ static modret_t *sql_passwd_ssha(cmd_rec *cmd, const char *plaintext,
   encodedtext = sql_passwd_encode(cmd->tmp_pool, SQL_PASSWD_ENC_USE_BASE64,
     hash, hash_len);
 
-  if (pr_timingsafe_bcmp(encodedtext, copytext, strlen(copytext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(encodedtext);
+  copytext_len = strlen(copytext);
+  if (copytext_len > cmp_len) {
+    cmp_len = copytext_len;
+  }
+
+  if (pr_timingsafe_bcmp(encodedtext, copytext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -900,7 +942,7 @@ static modret_t *sql_passwd_pbkdf2(cmd_rec *cmd, const char *plaintext,
   unsigned char *derived_key;
   const char *encodedtext;
   char *pbkdf2_salt = NULL;
-  size_t pbkdf2_salt_len = 0;
+  size_t ciphertext_len = 0, cmp_len = 0, pbkdf2_salt_len = 0;
   int res;
 
   if (sql_passwd_engine == FALSE) {
@@ -909,6 +951,13 @@ static modret_t *sql_passwd_pbkdf2(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle PBKDF2 SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   if (sql_passwd_pbkdf2_digest == NULL) {
@@ -966,7 +1015,14 @@ static modret_t *sql_passwd_pbkdf2(cmd_rec *cmd, const char *plaintext,
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
   }
 
-  if (pr_timingsafe_bcmp(encodedtext, ciphertext, strlen(ciphertext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(encodedtext);
+  ciphertext_len = strlen(ciphertext);
+  if (ciphertext_len > cmp_len) {
+    cmp_len = ciphertext_len;
+  }
+
+  if (pr_timingsafe_bcmp(encodedtext, ciphertext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -986,6 +1042,7 @@ static modret_t *sql_passwd_scrypt(cmd_rec *cmd, const char *plaintext,
   unsigned int hash_len = 0;
   const char *encodedtext;
   const unsigned char *scrypt_salt;
+  size_t ciphertext_len = 0, cmp_len = 0;
   size_t ops_limit, mem_limit, plaintext_len, scrypt_salt_len;
 
   if (sql_passwd_engine == FALSE) {
@@ -994,6 +1051,13 @@ static modret_t *sql_passwd_scrypt(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle scrypt SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   /* scrypt requires a salt; if no salt is configured, it is an error. */
@@ -1059,7 +1123,14 @@ static modret_t *sql_passwd_scrypt(cmd_rec *cmd, const char *plaintext,
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
   }
 
-  if (pr_timingsafe_bcmp(encodedtext, ciphertext, strlen(ciphertext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(encodedtext);
+  ciphertext_len = strlen(ciphertext);
+  if (ciphertext_len > cmp_len) {
+    cmp_len = ciphertext_len;
+  }
+
+  if (pr_timingsafe_bcmp(encodedtext, ciphertext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -1079,6 +1150,7 @@ static modret_t *sql_passwd_argon2(cmd_rec *cmd, const char *plaintext,
   unsigned int hash_len = 0;
   const char *encodedtext;
   const unsigned char *argon2_salt;
+  size_t ciphertext_len = 0, cmp_len = 0;
   size_t ops_limit, mem_limit, plaintext_len, argon2_salt_len;
 
   if (sql_passwd_engine == FALSE) {
@@ -1087,6 +1159,13 @@ static modret_t *sql_passwd_argon2(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle argon2 SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   /* argon2 requires a salt; if no salt is configured, it is an error. */
@@ -1154,7 +1233,14 @@ static modret_t *sql_passwd_argon2(cmd_rec *cmd, const char *plaintext,
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
   }
 
-  if (pr_timingsafe_bcmp(encodedtext, ciphertext, strlen(ciphertext)) == 0) {
+  /* Use the longer of the two texts for comparison length. */
+  cmp_len = strlen(encodedtext);
+  ciphertext_len = strlen(ciphertext);
+  if (ciphertext_len > cmp_len) {
+    cmp_len = ciphertext_len;
+  }
+
+  if (pr_timingsafe_bcmp(encodedtext, ciphertext, cmp_len) == 0) {
     return PR_HANDLED(cmd);
   }
 
@@ -1183,6 +1269,13 @@ static modret_t *sql_passwd_sodium(cmd_rec *cmd, const char *plaintext,
     sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
       ": SQLPasswordEngine disabled; unable to handle Sodium SQLAuthType");
     return PR_ERROR_INT(cmd, PR_AUTH_ERROR);
+  }
+
+  /* Reject stored empty password fields (Issue #2275). */
+  if (*ciphertext == '\0') {
+    sql_log(DEBUG_WARN, MOD_SQL_PASSWD_VERSION
+      ": ignoring empty password field");
+    return PR_ERROR_INT(cmd, PR_AUTH_BADPWD);
   }
 
   res = crypto_pwhash_str_verify(ciphertext, plaintext, strlen(plaintext));


### PR DESCRIPTION
…, automatically reject it.

In addition, when comparing the computed _vs_ stored texts, do the comparison using the longer of the two texts' lengths, to further guard against unexpectedly truncated/shorter texts.