### PR TITLE
As fallout from Issue #2279, we can remove a now-redundant "is the te…

### DIFF
--- a/modules/mod_auth_file.c
+++ b/modules/mod_auth_file.c
@@ -1600,9 +1600,9 @@ MODRET authfile_chkpass(cmd_rec *cmd) {
     pr_log_debug(DEBUG0, MOD_AUTH_FILE_VERSION
       ": error using crypt(3) for user '%s': %s", user, strerror(xerrno));
 
-    if (ciphertxt_passlen > 0 &&
-        (xerrno == EINVAL ||
-         xerrno == EPERM)) {
+    if (xerrno == EINVAL ||
+        xerrno == EPERM) {
+      ciphertxt_passlen = strlen(ciphertxt_pass);
       check_unsupported_algo(user, ciphertxt_pass, ciphertxt_passlen);
     }
 


### PR DESCRIPTION
…xt length greater than zero" check, as now it is guaranteed to be a non-empty string.