### PR TITLE
Issue #2282: When checking for any `<Limit>` policies on a given path…

### DIFF
--- a/contrib/mod_sftp/auth.c
+++ b/contrib/mod_sftp/auth.c
@@ -702,7 +702,7 @@ static int setup_env(pool *p, const char *user) {
   }
 
   if (pr_fsio_stat(session.cwd, &st) != -1) {
-    build_dyn_config(p, session.cwd, &st, TRUE);
+    build_dyn_config2(p, session.cwd, &st);
   }
 
   pr_scoreboard_entry_update(session.pid,

--- a/include/dirtree.h
+++ b/include/dirtree.h
@@ -217,7 +217,11 @@ int pr_config_get_xfer_bufsz2(int);
 int pr_config_get_server_xfer_bufsz(int);
 
 config_rec *dir_match_path(pool *, char *);
-void build_dyn_config(pool *, const char *, struct stat *, unsigned char);
+
+void build_dyn_config(pool *p, const char *path, struct stat *st,
+  unsigned char recurse);
+void build_dyn_config2(pool *p, const char *path, struct stat *st);
+
 unsigned char dir_hide_file(const char *);
 int dir_check_full(pool *, cmd_rec *, const char *, const char *, int *);
 int dir_check_limits(cmd_rec *, config_rec *, const char *, int);

--- a/modules/mod_auth.c
+++ b/modules/mod_auth.c
@@ -593,7 +593,7 @@ MODRET auth_post_pass(cmd_rec *cmd) {
    * or denied .ftpaccess-parsing separately from the containing server.
    */
   if (pr_fsio_stat(session.cwd, &st) != -1) {
-    build_dyn_config(cmd->tmp_pool, session.cwd, &st, TRUE);
+    build_dyn_config2(cmd->tmp_pool, session.cwd, &st);
   }
 
   have_user_timeout = have_group_timeout = have_class_timeout =

--- a/src/dirtree.c
+++ b/src/dirtree.c
@@ -1758,6 +1758,10 @@ void build_dyn_config(pool *p, const char *_path, struct stat *stp,
   }
 }
 
+void build_dyn_config2(pool *p, const char *path, struct stat *st) {
+  build_dyn_config(p, path, st, TRUE);
+}
+
 /* dir_check_full() fully recurses the path passed
  * returns 1 if operation is allowed on current path,
  * or 0 if not.
@@ -1807,7 +1811,7 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     memset(&st, '\0', sizeof(st));
   }
 
-  build_dyn_config(p, path, &st, TRUE);
+  build_dyn_config2(p, path, &st);
 
   /* Check to see if this path is hidden by HideFiles. */
   regex_hidden = dir_hide_file(path);
@@ -1939,11 +1943,32 @@ int dir_check_full(pool *pp, cmd_rec *cmd, const char *group, const char *path,
   return res;
 }
 
+/* Returns TRUE if the given ancestor path is indeed an ancestor, by path
+ * prefix, of the path, FALSE otherwise.
+ */
+static int is_ancestor_path(const char *ancestor_path, const char *path) {
+  size_t ancestor_pathlen, pathlen;
+
+  ancestor_pathlen = strlen(ancestor_path);
+  pathlen = strlen(path);
+
+  /* By definition, a path than is an ancestor is shorter. */
+  if (ancestor_pathlen >= pathlen) {
+    return FALSE;
+  }
+
+  if (strncmp(ancestor_path, path, ancestor_pathlen) == 0 &&
+      path[ancestor_pathlen] == '/') {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 /* dir_check() checks the current dir configuration against the path,
  * if it matches (partially), a search is done only in the subconfig,
- * otherwise handed off to dir_check_full
+ * otherwise handed off to dir_check_full().
  */
-
 int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     int *hidden) {
   char *fullpath, *owner;
@@ -1972,7 +1997,7 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
         (session.anon_config ? session.anon_config : NULL));
 
   if (c == NULL ||
-      strncmp(c->name, fullpath, strlen(c->name)) != 0) {
+      is_ancestor_path(c->name, fullpath) != TRUE) {
     destroy_pool(p);
     return dir_check_full(pp, cmd, group, path, hidden);
   }
@@ -1983,7 +2008,7 @@ int dir_check(pool *pp, cmd_rec *cmd, const char *group, const char *path,
     memset(&st, 0, sizeof(st));
   }
 
-  build_dyn_config(p, path, &st, FALSE);
+  build_dyn_config2(p, path, &st);
 
   /* Check to see if this path is hidden by HideFiles. */
   regex_hidden = dir_hide_file(path);


### PR DESCRIPTION
…, make sure to _always_ recurse upward through all parents looking for possible `.ftpaccess` files.