### PR TITLE
Make sure we check for NULL pointers before freeing up cipher/MAC res…

### DIFF
--- a/contrib/mod_sftp/cipher.c
+++ b/contrib/mod_sftp/cipher.c
@@ -1583,27 +1583,46 @@ int sftp_cipher_init(void) {
 
 int sftp_cipher_free(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL
-  EVP_CIPHER_CTX_free(read_ctxs[0]);
-  EVP_CIPHER_CTX_free(read_ctxs[1]);
-  EVP_CIPHER_CTX_free(write_ctxs[0]);
-  EVP_CIPHER_CTX_free(write_ctxs[1]);
+  if (read_ctxs[0] != NULL) {
+    EVP_CIPHER_CTX_free(read_ctxs[0]);
+    read_ctxs[0] = NULL;
+  }
+
+  if (read_ctxs[1] != NULL) {
+    EVP_CIPHER_CTX_free(read_ctxs[1]);
+    read_ctxs[1] = NULL;
+  }
+
+  if (write_ctxs[0] != NULL) {
+    EVP_CIPHER_CTX_free(write_ctxs[0]);
+    write_ctxs[0] = NULL;
+  }
+
+  if (write_ctxs[1] != NULL) {
+    EVP_CIPHER_CTX_free(write_ctxs[1]);
+    write_ctxs[1] = NULL;
+  }
 
 # if defined(HAVE_EVP_CHACHA20_OPENSSL) && \
     !defined(HAVE_BROKEN_CHACHA20)
   if (read_header_ctxs[0] != NULL) {
     EVP_CIPHER_CTX_free(read_header_ctxs[0]);
+    read_header_ctxs[0] = NULL;
   }
 
   if (read_header_ctxs[1] != NULL) {
     EVP_CIPHER_CTX_free(read_header_ctxs[1]);
+    read_header_ctxs[1] = NULL;
   }
 
   if (write_header_ctxs[0] != NULL) {
     EVP_CIPHER_CTX_free(write_header_ctxs[0]);
+    write_header_ctxs[0] = NULL;
   }
 
   if (write_header_ctxs[1] != NULL) {
     EVP_CIPHER_CTX_free(write_header_ctxs[1]);
+    write_header_ctxs[1] = NULL;
   }
 # endif /* HAVE_EVP_CHACHA20_OPENSSL and !HAVE_BROKEN_CHACHA20 */
 #endif /* OpenSSL-1.0.0 and later */

--- a/contrib/mod_sftp/mac.c
+++ b/contrib/mod_sftp/mac.c
@@ -1102,10 +1102,25 @@ int sftp_mac_init(void) {
 int sftp_mac_free(void) {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(HAVE_LIBRESSL)) || \
     (defined(HAVE_LIBRESSL) && LIBRESSL_VERSION_NUMBER >= 0x3050000L)
-  HMAC_CTX_free(hmac_read_ctxs[0]);
-  HMAC_CTX_free(hmac_read_ctxs[1]);
-  HMAC_CTX_free(hmac_write_ctxs[0]);
-  HMAC_CTX_free(hmac_write_ctxs[1]);
+  if (hmac_read_ctxs[0] != NULL) {
+    HMAC_CTX_free(hmac_read_ctxs[0]);
+    hmac_read_ctxs[0] = NULL;
+  }
+
+  if (hmac_read_ctxs[1] != NULL) {
+    HMAC_CTX_free(hmac_read_ctxs[1]);
+    hmac_read_ctxs[1] = NULL;
+  }
+
+  if (hmac_write_ctxs[0] != NULL) {
+    HMAC_CTX_free(hmac_write_ctxs[0]);
+    hmac_write_ctxs[0] = NULL;
+  }
+
+  if (hmac_write_ctxs[1] != NULL) {
+    HMAC_CTX_free(hmac_write_ctxs[1]);
+    hmac_write_ctxs[1] = NULL;
+  }
 #endif /* OpenSSL-1.1.0/LibreSSL-3.5.0 and later */
   return 0;
 }


### PR DESCRIPTION
…ources, _and_ that we properly set NULL pointers for those resources once freed.