### PR TITLE
Address some spelling nits about which `codespell` complains.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -331,7 +331,7 @@ Good luck!
 Troubleshooting
 ---------------
 
-This section is far from comprehensive.  See the FAQ and other resourses
+This section is far from comprehensive.  See the FAQ and other resources
 for further assistance.
 
 
@@ -433,7 +433,7 @@ T6. Another diagnostic technique is to monitor the FTP protocol communication
     between the proftpd server and the ftp client.  Many ftp clients have a
     debug or trace option.  Though requiring detailed knowledge of the FTP
     protocol, telnet can be used to connect and directly converse with the
-    proftpd server.  Lastly, the FTP converstation can be traced using a
+    proftpd server.  Lastly, the FTP conversation can be traced using a
     network monitoring tool, such as tcpdump, ethereal, snoop or netsnoop.
 
 

--- a/NEWS
+++ b/NEWS
@@ -133,7 +133,7 @@
 - Issue 1984 - mod_quotatab_ldap interactions can lead to segfault due to
   stale pointer.
 - Issue 2003 - RNTO before authentication leads to out-of-order response codes.
-- Issue 2002 - Enviroment variable substitution for multi-word values not
+- Issue 2002 - Environment variable substitution for multi-word values not
   supported as needed.
 - Issue 2009 - MaxLoginAttemptsFromUser event never triggers in mod_ban for
   SFTP sessions.

--- a/contrib/README.ratio
+++ b/contrib/README.ratio
@@ -24,14 +24,14 @@ users that you wish to have ratios saved. If there is a problem
 accessing the files, ProFTPD will revert back to the old per session
 ratio method (u/l d/l stats will be forgotten on disconnect).
 
-touch and chmod both files to allow r/w from all users whos ratios
+touch and chmod both files to allow r/w from all users whose ratios
 will be saved. Enable ratios, users are added to the ratios file as
 they log in and stat tracking begins.
 
 If you are using DefaultRoot along with this command, the Ratio files
 will need to be stored within the Root directory. One easy way is to
 create a sub-directory off of DefaultRoot that is rwx by all users
-and then restrict ALL access to these directorys within ProFTPD...
+and then restrict ALL access to these directories within ProFTPD...
 
 	<Directory /workdir>
 		<Limit ALL>

--- a/contrib/mod_ratio.c
+++ b/contrib/mod_ratio.c
@@ -46,7 +46,7 @@
    * 1999-10-03: v3.0: Uses generic API to access SQL data at runtime.
      Supports negative ratios (upload X to get 1) by popular demand.
      Added proper SITE command and help.  Various presentation
-     idiosyncracies fixed.
+     idiosyncrasies fixed.
 
    * 1999-06-13: v2.2: fixed ratio display, it was printing ratios in
      reverse order.

--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -8086,7 +8086,7 @@ static int tls_accept(conn_t *conn, unsigned char on_data) {
         /* The error codes in the OpenSSL error queue are "packed"; we need
          * to unpack them to get the reason value.
          *
-         * Try to provide more context for the most commonly ocurring/reported
+         * Try to provide more context for the most commonly occurring/reported
          * handshake errors here.
          */
 
@@ -11008,11 +11008,11 @@ static int tls_verify_ocsp_url(X509_STORE_CTX *ctx, X509 *cert,
   }
 
 # if 0
-  /* XXX ideally we would set the requestor name to the subject name of the
+  /* XXX ideally we would set the requester name to the subject name of the
    * cert configured via TLS{DSA,RSA}CertificateFile here.
    */
   if (OCSP_request_set1_name(req, /* server cert X509_NAME subj name */) != 1) {
-    tls_log("error adding requestor name '%s' to OCSP request: %s",
+    tls_log("error adding requester name '%s' to OCSP request: %s",
       requestor_name, tls_get_errors());
 
     if (ocsp_ssl_ctx != NULL) {

--- a/contrib/mod_wrap2_file.c
+++ b/contrib/mod_wrap2_file.c
@@ -180,7 +180,7 @@ static void filetab_parse_table(wrap2_table_t *filetab) {
       }
 
     } else {
-      wrap2_log("file '%s': skipping irrevelant daemon/service ('%s') line %u",
+      wrap2_log("file '%s': skipping irrelevant daemon/service ('%s') line %u",
         filetab->tab_name, service, lineno);
     }
   }

--- a/doc/contrib/mod_ldap.html
+++ b/doc/contrib/mod_ldap.html
@@ -849,7 +849,7 @@ non-encrypted connections.  Enabling this option causes <code>mod_ldap</code>
 to use an encrypted (TLS/SSL) connection to the LDAP server. If a secure
 connection to the LDAP server fails, <code>mod_ldap</code> will not
 authenticate users; <code>mod_ldap</code> will <b>not</b> fall back to an
-unsecure connection.
+insecure connection.
 
 <p>
 <hr>

--- a/doc/contrib/mod_quotatab_sql.html
+++ b/doc/contrib/mod_quotatab_sql.html
@@ -116,7 +116,7 @@ And, for the <code>QuotaTallyTable</code> directive:
 <p>
 Also note that SQL-based tally tables have an issue with proper synchronization
 of updates, especially when multiple sessions involving the same tally
-are ocurring.  In order to prevent the tally table from becoming out of
+are occurring.  In order to prevent the tally table from becoming out of
 sync, you are <b>strongly</b> encouraged to define a <a href="../contrib/mod_quotatab.html#QuotaLock"><code>QuotaLock</code></a>
 file.
 

--- a/doc/contrib/mod_sftp.html
+++ b/doc/contrib/mod_sftp.html
@@ -2406,11 +2406,11 @@ However, when I telnet to the port on which <code>mod_sftp</code> is listening,
 I see the version banner plus some data which can't be rendered in the terminal.
 What is that extra data?<br>
 <font color=blue>Answer</font>: The short answer is that <code>mod_sftp</code>
-is pre-emptively sending the first key exchange data; it is this data which is
+is preemptively sending the first key exchange data; it is this data which is
 not displayed well.
 
 <p>
-This pre-emptive sending of the first key exchange message is an optimization.
+This preemptive sending of the first key exchange message is an optimization.
 The SSH2 protocol (and many SSH2 servers) start off doing:
 <pre>
  (1) <i>client</i> ------------ connect -------------&gt; <i>server</i>

--- a/doc/contrib/mod_sql.html
+++ b/doc/contrib/mod_sql.html
@@ -255,7 +255,7 @@ The current supported authentication methods are:
   <li><b>OpenSSL</b><br>
     Allows passwords in the database to be of the form
     <code>'{digest-name}hashed-value'</code>, where <code>hashed-value</code>
-    is the base64-encoded digest of the passsword.  Only available if you
+    is the base64-encoded digest of the password.  Only available if you
     define <code>HAVE_OPENSSL</code> when you compile <code>proftpd</code>
     and you link with OpenSSL's <code>libcrypto</code> library; the easiest
     way to handle this is to use the <code>--enable-openssl</code> configure
@@ -1060,7 +1060,7 @@ meta-sequences available to <code>SQLNamedQuery</code> are largely equivalent.
 
 <p>
 The first parameter, <em>name</em>, should be unique across all named queries
-and must not contain spaces.  The result of re-using a name is undefined.
+and must not contain spaces.  The result of reusing a name is undefined.
 
 <p>
 The second parameter, <em>type</em>, is the type of query, either

--- a/doc/contrib/mod_sql_passwd.html
+++ b/doc/contrib/mod_sql_passwd.html
@@ -335,7 +335,7 @@ tells <code>mod_sql_passwd</code> to prepend the salt as a prefix, and:
 <pre>
   SQLPasswordSaltFile /path/to/salt Append
 </pre>
-will cause the salt to be appended as a sufix.  <b>Note</b> that the default
+will cause the salt to be appended as a suffix.  <b>Note</b> that the default
 behavior is to <i>append</i> the salt as a suffix.
 
 <p>
@@ -391,7 +391,7 @@ tells <code>mod_sql_passwd</code> to prepend the salt as a prefix, and:
   SQLPasswordUserSalt name Append
   SQLPasswordUserSalt sql:/get-user-salt Append
 </pre>
-will cause the salt to be appended as a sufix.  <b>Note</b> that the default
+will cause the salt to be appended as a suffix.  <b>Note</b> that the default
 behavior is to <i>append</i> the salt as a suffix.
 
 <hr>
@@ -723,7 +723,7 @@ values can be supported by the <code>mod_sql_passwd</code> module.
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2009-2025 TJ Saunders<br>
+&copy; Copyright 2009-2026 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/contrib/mod_wrap2_sql.html
+++ b/doc/contrib/mod_wrap2_sql.html
@@ -95,7 +95,7 @@ These example SQL statements assume the existence of two tables: a
   SQLNamedQuery get-denied-clients SELECT "denied FROM wrapdeny WHERE name = '%{0}'"
   ...
   SQLNamedQuery get-all-allowed-clients SELECT "allowed FROM wrapallow"
-  SQLNamedQuery get-all-denied-clients SELET "denied FROM wrapdeny"
+  SQLNamedQuery get-all-denied-clients SELECT "denied FROM wrapdeny"
 </pre>
 These define the SQL statements to return the required list of words. The
 <code>%{0}</code> meta sequence will be substituted with the name being looked
@@ -211,7 +211,7 @@ options in a single row, in an appropriately formatted string.
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2000-2017 TJ Saunders<br>
+&copy; Copyright 2000-2026 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/faq.html
+++ b/doc/faq.html
@@ -1582,7 +1582,7 @@ not be limited to.</P
 ></LI
 ><LI
 ><P
->Output fom debug mode</P
+>Output from debug mode</P
 ></LI
 ><LI
 ><P
@@ -4472,7 +4472,7 @@ CLASS="ANSWER"
 ><B
 > </B
 >mod_ldap is currently stable; there were a couple bugs that were
-squashed after release 1.0 of the module.  it is still udner
+squashed after release 1.0 of the module.  it is still under
 development , check the <A
 HREF="http://horde.net/~jwm/software/mod_ldap/"
 TARGET="_top"

--- a/doc/howto/BCP.html
+++ b/doc/howto/BCP.html
@@ -114,7 +114,7 @@ for storing access control rules in SQL tables.
 On systems which support the /proc filesystem, such as Linux and several others,
 it is <b>highly recommended</b> that the /proc filesystem be guarded, especially
 for non-chroot sessions.  Malicious clients can read or write to that filesystem
-and cause quite a bit of damage.  Thus we encourge administrators to use
+and cause quite a bit of damage.  Thus we encourage administrators to use
 the following in their <code>proftpd.conf</code>:
 <pre>
   &lt;Directory /proc&gt;
@@ -296,7 +296,7 @@ description for details).
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2017 The ProFTPD Project<br>
+&copy; Copyright 2017-2026 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/howto/ConnectionACLs.html
+++ b/doc/howto/ConnectionACLs.html
@@ -160,7 +160,7 @@ section to look something like this:
 Why does using classes like this make things faster?  When using classes, the
 label (<i>i.e.</i> the class name in the <code>&lt;Class&gt;</code> section,
 like "blacklist" in the above example) is determined when the client
-<i>first</i> connects to <code>proftpd</code>, before any comands are sent.
+<i>first</i> connects to <code>proftpd</code>, before any commands are sent.
 That is when all of the various netmasks and such are checked -- and
 <i>only</i> at that time.  After that, all of the configuration-based ACLs
 are evaluated just using that label.
@@ -214,7 +214,7 @@ can also appear as:
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2017 The ProFTPD Project<br>
+&copy; Copyright 2017-2026 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/howto/KeepAlives.html
+++ b/doc/howto/KeepAlives.html
@@ -14,7 +14,7 @@
 <b>Overview of KeepAlive</b><br>
 Any discussion of so-called "keep-alive" functionality must start by answering
 the question: "What is does 'keep-alive' mean?"  As one specification
-succintly states:
+succinctly states:
 <pre>
   A "keep-alive" mechanism periodically probes the other end of a connection
   when the connection is otherwise idle, even when there is no data to be sent.
@@ -381,7 +381,7 @@ and NATs.)
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2017 The ProFTPD Project<br>
+&copy; Copyright 2017-2026 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/modules/mod_core.html
+++ b/doc/modules/mod_core.html
@@ -347,7 +347,7 @@ in order to the explicit allow rule to apply.  To evaluate the
 <em>expression</em> as a Boolean <em>OR</em> list, meaning that <b>any</b> of
 the elements must evaluate to logically true (<i>i.e.</i> "this group <b>or</b>
 this group <b>or</b> that group..."), use the optional <em>OR</em> keyword.
-Similarly, to evalulate the <em>expression</em> as a regular expression, use
+Similarly, to evaluate the <em>expression</em> as a regular expression, use
 the <em>regex</em> keyword.
 
 <p>
@@ -414,7 +414,7 @@ the elements must evaluate to logically true (<i>i.e.</i> "this user <b>and</b>
 this user <b>and</b> that user..."), use the optional <em>AND</em> keyword.
 (Note that a single user <b>cannot</b> be "this user <b>and</b> that user" at
 the same time, thus the value of <em>AND</em> lists for users is debatable.)
-Similarly, to evalulate the <em>expression</em> as a regular expression, use
+Similarly, to evaluate the <em>expression</em> as a regular expression, use
 the <em>regex</em> keyword.
 
 <p>
@@ -894,7 +894,7 @@ in order to the explicit deny rule to apply.  To evaluate the
 <em>expression</em> as a Boolean <em>OR</em> list, meaning that <b>any</b> of
 the elements must evaluate to logically true (<i>i.e.</i> "this group <b>or</b>
 this group <b>or</b> that group..."), use the optional <em>OR</em> keyword.
-Similarly, to evalulate the <em>expression</em> as a regular expression, use
+Similarly, to evaluate the <em>expression</em> as a regular expression, use
 the <em>regex</em> keyword.
 
 <p>
@@ -945,7 +945,7 @@ the elements must evaluate to logically true (<i>i.e.</i> "this user <b>and</b>
 this user <b>and</b> that user..."), use the optional <em>AND</em> keyword.
 (Note that a single user <b>cannot</b> be "this user <b>and</b> that user" at
 the same time, thus the value of <em>AND</em> lists for users is debatable.)
-Similarly, to evalulate the <em>expression</em> as a regular expression, use
+Similarly, to evaluate the <em>expression</em> as a regular expression, use
 the <em>regex</em> keyword.
 
 <p>
@@ -3407,7 +3407,7 @@ The solution is to use remove use of the deprecated
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2000-2025 The ProFTPD Project<br>
+&copy; Copyright 2000-2026 The ProFTPD Project<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>

--- a/doc/modules/mod_lang.html
+++ b/doc/modules/mod_lang.html
@@ -81,7 +81,7 @@ module does no localization of responses.
 
 <p>
 <b>Note</b> that setting <code>LangEngine</code> to <em>off</em> also keeps
-<code>proftpd</code> from advertisting "UTF8" in its <code>FEAT</code> response.
+<code>proftpd</code> from advertising "UTF8" in its <code>FEAT</code> response.
 As required by RFC 2640, <code>proftpd</code> can <i>only</i> show "UTF8"
 in response to a <code>FEAT</code> command if the <code>LANG</code> command
 is also supported.  Hence why it is the <code>LangEngine</code> directive,
@@ -337,7 +337,7 @@ Both of these conditions <b>must</b> be true, otherwise you will see the
 
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2006-2017 TJ Saunders<br>
+&copy; Copyright 2006-2026 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 

--- a/doc/platforms/AIX.md
+++ b/doc/platforms/AIX.md
@@ -5,7 +5,7 @@ using the proper configure command lines.
 
 One problem involves the less than optimal default shared object search path
 that the IBM linker inserts into executables.  The second problem is
-compilaton failure stemming from an incompatibility with the `<string.h>`
+compilation failure stemming from an incompatibility with the `<string.h>`
 header file when the IBM compiler attempts to inline some string functions.
 
 Also, a minor usage note: do _not_ use the `--enable-autoshadow` or

--- a/modules/mod_xfer.c
+++ b/modules/mod_xfer.c
@@ -1715,7 +1715,7 @@ MODRET xfer_pre_stou(cmd_rec *cmd) {
 
   /* Some FTP clients are "broken" in that they will send a filename
    * along with STOU.  Technically this violates RFC959, but for now, just
-   * ignore that filename.  Stupid client implementors.
+   * ignore that filename.  Stupid client implementers.
    */
 
   if (cmd->argc > 2) {

--- a/src/auth.c
+++ b/src/auth.c
@@ -1491,7 +1491,7 @@ int pr_auth_getgroups(pool *p, const char *name, array_header **group_ids,
      * always be at least 1, as per getgroups(2) behavior.  This one
      * ID is present because it is the primary group membership set in
      * struct passwd, from /etc/passwd.  This will need to be documented
-     * for the benefit of auth_getgroup() implementors.
+     * for the benefit of auth_getgroup() implementers.
      */
 
     if (group_ids != NULL) {

--- a/src/data.c
+++ b/src/data.c
@@ -487,7 +487,7 @@ void pr_data_reset(void) {
 
   /* Note that we deliberately omit the SF_EPSV_ALL flag from here.  Once that
    * session flag has been requested/set, it persists for the rest of the
-   * session, regardless of data transfer successs or failure (Issue #2255).
+   * session, regardless of data transfer success or failure (Issue #2255).
    */
   session.sf_flags &= (SF_ALL^(SF_ABORT|SF_POST_ABORT|SF_XFER|SF_PASSIVE|SF_ASCII_OVERRIDE));
 }
@@ -1055,7 +1055,7 @@ static void poll_ctrl(void) {
      * marks the ABOR command with the marker.  In that case, a SIGURG signal
      * will have been raised, and the SF_ABORT flag set.  The actual "ABOR"
      * bytes on the control connection will be read only AFTER the data transfer
-     * has been failed.  This leads the proper ordering of multiple responses
+     * has been failed.  This leads to the proper ordering of multiple responses
      * (first for failed transfer, second for successful ABOR) in such cases.
      *
      * Now consider the case where a client does NOT use the TCP OOB mechanism,

--- a/src/redis.c
+++ b/src/redis.c
@@ -5337,7 +5337,7 @@ int pr_redis_sorted_set_kscore(pr_redis_t *redis, module *m, const char *key,
   reply = handle_reply(redis, cmd, reply);
   if (reply == NULL) {
     pr_trace_msg(trace_channel, 2,
-      "error gettin score for key (%lu bytes) using %s: %s",
+      "error getting score for key (%lu bytes) using %s: %s",
       (unsigned long) keysz, cmd, strerror(errno));
     destroy_pool(tmp_pool);
     errno = EIO;

--- a/tests/t/lib/ProFTPD/TestSuite/FTP.pm
+++ b/tests/t/lib/ProFTPD/TestSuite/FTP.pm
@@ -212,7 +212,7 @@ sub set_status {
   my $resp = defined($msg) ? [$msg] : [] unless ref($msg);
 
   # In order to properly accumulate the multiple responses from an aborted
-  # data transfer/session, we only want to ovewrite the any existing
+  # data transfer/session, we only want to overwrite the any existing
   # responses if the previous response code is not a 426.  What an ugly hack.
   my $overwrite_resp = 0;
 

--- a/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
+++ b/tests/t/lib/ProFTPD/Tests/Config/ShowSymlinks.pm
@@ -2407,7 +2407,7 @@ sub showsymlinks_off_mlst_rel_symlinked_file_chrooted {
 
       $expected = 'modify=\d+;perm=adfr(w)?;size=\d+;type=file;unique=\S+;UNIX\.group=\d+;UNIX\.groupname=\S+;UNIX\.mode=\d+;UNIX\.owner=\d+;UNIX\.ownername=\S+; ' . $test_symlink . '$';
       $self->assert(qr/$expected/, $resp_msg,
-        test_msg("Expected respone message '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
     };

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_ban.pm
@@ -2105,7 +2105,7 @@ EOC
 
       $expected = 530;
       $self->assert($expected == $resp_code,
-        test_msg("Expected respones code $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_quotatab_sql.pm
@@ -5378,7 +5378,7 @@ EOS
 
       my $expected = 552;
       $self->assert($expected == $resp_code,
-        test_msg("Expected respones code $expected, got $resp_code"));
+        test_msg("Expected response code $expected, got $resp_code"));
 
       $expected = 'STOR denied: quota exceeded: used \S+ of \S+ upload bytes';
       $self->assert(qr/$expected/, $resp_msg,

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_sql_sqlite.pm
@@ -1717,7 +1717,8 @@ EOS
       },
 
       # Bug#3149 occurred because mod_sql's resolve_short_tag() function
-      # was not able to resolve %V properly (it was deferencing a bad pointer).
+      # was not able to resolve %V properly (it was dereferencing a bad
+      * pointer).
       'mod_sql.c' => {
         SQLAuthTypes => 'plaintext',
         SQLBackend => 'sqlite3',
@@ -14109,7 +14110,7 @@ EOS
     die($ex);
   }
 
-  # Note: We are simply re-using the existing get_locations() function here
+  # Note: We are simply reusing the existing get_locations() function here
   # for convenience/expedience.
   my ($login, $ip_addr, $name) = get_locations($db_file, "user = \'$user\'");
 

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_redis.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_redis.pm
@@ -2717,7 +2717,7 @@ sub wrap2_allow_msg_bug3538 {
 
       $expected = "User $setup->{user} logged in.";
       $self->assert($expected eq $resp_msg,
-        "Expected response meessage '$expected', got '$resp_msg'");
+        "Expected response message '$expected', got '$resp_msg'");
 
       $client->quit();
     };

--- a/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_sql.pm
+++ b/tests/t/lib/ProFTPD/Tests/Modules/mod_wrap2_sql.pm
@@ -3708,7 +3708,7 @@ EOS
 
       $expected = "User $user logged in.";
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response meessage '$expected', got '$resp_msg'"));
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
     };
 
     if ($@) {


### PR DESCRIPTION
No functional change.