### PR TITLE
Issue #2301: Ensure that we have sufficient remaining buffer space fo…

### DIFF
--- a/contrib/mod_snmp/asn1.c
+++ b/contrib/mod_snmp/asn1.c
@@ -223,6 +223,17 @@ static int asn1_read_len(pool *p, unsigned char **buf, size_t *buflen,
       return -1;
     }
 
+    /* Make sure the provided buffer is large enough for the amount of data
+     * received (Issue #2301).
+     */
+    if (byte > *buflen) {
+      (void) pr_log_writefile(snmp_logfd, MOD_SNMP_VERSION,
+        "ASN.1 error: provided ASN1 length value %u exceeds buffer (%lu bytes)",
+        (unsigned int) byte, (unsigned long) *buflen);
+      errno = EINVAL;
+      return -1;
+    }
+
     *asn1_len = 0;
     memmove(asn1_len, *buf, (size_t) byte);
     (*buf) += byte;
@@ -317,6 +328,16 @@ int snmp_asn1_read_int(pool *p, unsigned char **buf, size_t *buflen,
   /* Length */
   res = asn1_read_len(p, buf, buflen, &objlen);
   if (res < 0) {
+    return -1;
+  }
+
+  /* Sanity check on the object length, to make sure it is not absurd. */
+  if (objlen > SNMP_ASN1_MAX_OBJECT_LEN) {
+    pr_trace_msg(trace_channel, 3,
+      "failed reading object integer: object length (%u bytes) is greater "
+      "than max object length (%u bytes)", objlen, SNMP_ASN1_MAX_OBJECT_LEN);
+    pr_log_stacktrace(snmp_logfd, MOD_SNMP_VERSION);
+    errno = EINVAL;
     return -1;
   }
 
@@ -462,6 +483,16 @@ int snmp_asn1_read_oid(pool *p, unsigned char **buf, size_t *buflen,
     return -1;
   }
 
+  /* Sanity check on the object length, to make sure it is not absurd. */
+  if (objlen > SNMP_ASN1_MAX_OBJECT_LEN) {
+    pr_trace_msg(trace_channel, 3,
+      "failed reading object OID: object length (%u bytes) is greater "
+      "than max object length (%u bytes)", objlen, SNMP_ASN1_MAX_OBJECT_LEN);
+    pr_log_stacktrace(snmp_logfd, MOD_SNMP_VERSION);
+    errno = EINVAL;
+    return -1;
+  }
+
   /* Is there enough data remaining in the buffer for the indicated object? */
   if (objlen > *buflen) {
     pr_trace_msg(trace_channel, 3,
@@ -566,6 +597,16 @@ int snmp_asn1_read_string(pool *p, unsigned char **buf, size_t *buflen,
   /* Length */
   res = asn1_read_len(p, buf, buflen, &objlen);
   if (res < 0) {
+    return -1;
+  }
+
+  /* Sanity check on the object length, to make sure it is not absurd. */
+  if (objlen > SNMP_ASN1_MAX_OBJECT_LEN) {
+    pr_trace_msg(trace_channel, 3,
+      "failed reading object string: object length (%u bytes) is greater "
+      "than max object length (%u bytes)", objlen, SNMP_ASN1_MAX_OBJECT_LEN);
+    pr_log_stacktrace(snmp_logfd, MOD_SNMP_VERSION);
+    errno = EINVAL;
     return -1;
   }
 

--- a/contrib/mod_snmp/mib.c
+++ b/contrib/mod_snmp/mib.c
@@ -44,7 +44,7 @@ static struct snmp_mib snmp_mibs[] = {
   /* Miscellaneous non-mod_snmp MIBs */
   { { SNMP_MGMT_SYS_OID_UPTIME, 0 },
     SNMP_MGMT_SYS_OIDLEN_UPTIME + 1,
-    0, TRUE, TRUE,
+    SNMP_DB_NOTIFY_F_SYS_UPTIME, TRUE, TRUE,
     SNMP_MGMT_SYS_MIB_NAME_PREFIX "sysUpTime",
     SNMP_MGMT_SYS_MIB_NAME_PREFIX "sysUpTime.0",
     SNMP_SMI_TIMETICKS },

--- a/contrib/mod_snmp/mod_snmp.c
+++ b/contrib/mod_snmp/mod_snmp.c
@@ -1405,12 +1405,12 @@ static int snmp_agent_handle_packet(int sockfd, pr_netaddr_t *agent_addr) {
     return -1;
   }
 
-  res = snmp_msg_read(pkt->pool, &(pkt->req_data), &(pkt->req_datalen),
-    &(pkt->community), &(pkt->community_len), &(pkt->snmp_version),
-    &(pkt->req_pdu));
+  /* Read the packet fields needed for authentication. */
+  res = snmp_msg_read_header(pkt->pool, &(pkt->req_data), &(pkt->req_datalen),
+    &(pkt->community), &(pkt->community_len), &(pkt->snmp_version));
   if (res < 0) {
     (void) pr_log_writefile(snmp_logfd, MOD_SNMP_VERSION,
-      "error reading SNMP message from UDP packet: %s", strerror(errno));
+      "error reading SNMP message header from UDP packet: %s", strerror(errno));
 
     destroy_pool(pkt->pool);
     errno = EINVAL;
@@ -1423,6 +1423,17 @@ static int snmp_agent_handle_packet(int sockfd, pr_netaddr_t *agent_addr) {
     (void) pr_log_writefile(snmp_logfd, MOD_SNMP_VERSION,
       "%s message does not contain correct authentication info, "
       "ignoring message", snmp_msg_get_versionstr(pkt->snmp_version));
+
+    destroy_pool(pkt->pool);
+    errno = EINVAL;
+    return -1;
+  }
+
+  res = snmp_msg_read_pdu(pkt->pool, &(pkt->req_data), &(pkt->req_datalen),
+    &(pkt->req_pdu), pkt->snmp_version);
+  if (res < 0) {
+    (void) pr_log_writefile(snmp_logfd, MOD_SNMP_VERSION,
+      "error reading SNMP message data from UDP packet: %s", strerror(errno));
 
     destroy_pool(pkt->pool);
     errno = EINVAL;

--- a/contrib/mod_snmp/msg.c
+++ b/contrib/mod_snmp/msg.c
@@ -73,9 +73,8 @@ const char *snmp_msg_get_versionstr(long snmp_version) {
  *    }
  */
 
-int snmp_msg_read(pool *p, unsigned char **buf, size_t *buflen,
-    char **community, unsigned int *community_len, long *snmp_version,
-    struct snmp_pdu **pdu) {
+int snmp_msg_read_header(pool *p, unsigned char **buf, size_t *buflen,
+    char **community, unsigned int *community_len, long *snmp_version) {
   unsigned char asn1_type;
   unsigned int asn1_len;
   int res;
@@ -87,7 +86,7 @@ int snmp_msg_read(pool *p, unsigned char **buf, size_t *buflen,
 
   if (asn1_type != (SNMP_ASN1_TYPE_SEQUENCE|SNMP_ASN1_CONSTRUCT)) {
     pr_trace_msg(trace_channel, 3,
-      "unable to read SNMP message (tag '%s')",
+      "unable to read SNMP message (tag \"%s\")",
       snmp_asn1_get_tagstr(p, asn1_type));
 
     errno = EINVAL;
@@ -129,7 +128,7 @@ int snmp_msg_read(pool *p, unsigned char **buf, size_t *buflen,
   /* Check that asn1_type is a UNIVERSAL/PRIMITIVE/OCTETSTRING. */
   if (!(asn1_type == (SNMP_ASN1_CLASS_UNIVERSAL|SNMP_ASN1_PRIMITIVE|SNMP_ASN1_TYPE_OCTETSTRING))) {
     pr_trace_msg(trace_channel, 3,
-      "unable to read OCTET_STRING (received type '%s')",
+      "unable to read OCTET_STRING (received type \"%s\")",
       snmp_asn1_get_tagstr(p, asn1_type));
     errno = EINVAL;
     return -1;
@@ -139,7 +138,14 @@ int snmp_msg_read(pool *p, unsigned char **buf, size_t *buflen,
     "read %s message: community = '%s'",
     snmp_msg_get_versionstr(*snmp_version), *community);
 
-  res = snmp_pdu_read(p, buf, buflen, pdu, *snmp_version);
+  return 0;
+}
+
+int snmp_msg_read_pdu(pool *p, unsigned char **buf, size_t *buflen,
+    struct snmp_pdu **pdu, long snmp_version) {
+  int res;
+
+  res = snmp_pdu_read(p, buf, buflen, pdu, snmp_version);
   if (res < 0) {
     return -1;
   }

--- a/contrib/mod_snmp/msg.h
+++ b/contrib/mod_snmp/msg.h
@@ -29,9 +29,10 @@
 
 const char *snmp_msg_get_versionstr(long snmp_version);
 
-int snmp_msg_read(pool *p, unsigned char **buf, size_t *buflen,
-  char **community, unsigned int *community_len, long *snmp_version,
-  struct snmp_pdu **pdu);
+int snmp_msg_read_header(pool *p, unsigned char **buf, size_t *buflen,
+  char **community, unsigned int *community_len, long *snmp_version);
+int snmp_msg_read_pdu(pool *p, unsigned char **buf, size_t *buflen,
+  struct snmp_pdu **pdu, long snmp_version);
 int snmp_msg_write(pool *p, unsigned char **buf, size_t *buflen,
   char *community, unsigned int community_len, long snmp_version,
   struct snmp_pdu *pdu);


### PR DESCRIPTION
…r copying data when reading the ASN.1 length fields in an SNMP message.

In addition, we now delay reading the SNMP message PDU (the "payload") bytes until after the message has been authenticated, and additionally enforce our maximum message size when reading other fields (e.g. text strings, integer, OIDs).