### PR TITLE
There is an unintentional one-byte out-of-bounds read when constructi…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -876,6 +876,13 @@ static cmd_rec *make_ftp_cmd(pool *p, char *buf, size_t buflen, int flags) {
    * it does the proper handling of CRNUL sequences itself.
    */
   arg_len = buflen - strlen(wrd);
+  if (arg_len > 0) {
+    /* This additional -1 is for the whitespace character, after the `wrd`
+     * token, consumed by pr_str_get_word().
+     */
+    arg_len -= 1;
+  }
+
   arg = pcalloc(cmd->pool, arg_len + 1);
 
   /* Remember that ptr here is advanced past the first word. */


### PR DESCRIPTION
…ng FTP commands.

Note that under normal operations, this is not an issue since the buffer containing the bytes being read has had the CRLF (mandated by FTP) bytes overwritten with NUL characters prior to this parsing; the one-byte out-of-bounds read thus references these existing overwritten bytes in most cases.

Thanks to k3rn3lbr3ach3r of Team kBxAc for reporting this issue.