### PR TITLE
Remove redundant `closedir(3)` call that inadvertently leads to a dou…

### DIFF
--- a/contrib/mod_site_misc.c
+++ b/contrib/mod_site_misc.c
@@ -254,8 +254,6 @@ static int site_misc_delete_dir(pool *p, const char *dir) {
       xerrno = errno;
 
       if (res < 0) {
-        pr_fsio_closedir(dirh);
-
         pr_cmd_dispatch_phase(cmd, POST_CMD_ERR, 0);
         pr_cmd_dispatch_phase(cmd, LOG_CMD_ERR, 0);
         pr_response_clear(&resp_err_list);


### PR DESCRIPTION
…ble `closedir(3)`.

Thanks to Bruno Henc for reporting this issue.