### PR TITLE
Address warnings emitted when `-Wimplicit-fallthrough` is enabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           # The modules to build are distro-specific
           echo "PROFTPD_MODULES=mod_sql:mod_sql_mysql:mod_sql_odbc:mod_sql_postgres:mod_sql_sqlite:mod_sql_passwd:mod_sftp:mod_sftp_sql:mod_sftp_pam:mod_tls:mod_tls_fscache:mod_tls_shmcache:mod_tls_memcache:mod_tls_redis:mod_ban:mod_copy:mod_ctrls_admin:mod_deflate:mod_dnsbl:mod_dynmasq:mod_exec:mod_facl:mod_geoip:mod_ifversion:mod_ldap:mod_load:mod_log_forensic:mod_qos:mod_quotatab:mod_quotatab_file:mod_quotatab_ldap:mod_quotatab_radius:mod_quotatab_sql:mod_radius:mod_readme:mod_rewrite:mod_shaper:mod_site_misc:mod_snmp:mod_wrap2:mod_wrap2_file:mod_wrap2_redis:mod_wrap2_sql:mod_digest:mod_auth_otp:mod_statcache:mod_unique_id:mod_ifsession" >> $GITHUB_ENV
 
-      - name: Install AlmaLinux 10 RPM packages
+      - name: Install AlmaLinux 10 packages
         if: ${{ matrix.container == 'almalinux:10' }}
         run: |
           # Need to add other repos for e.g. libsodium

--- a/contrib/mod_dnsbl/mod_dnsbl.c
+++ b/contrib/mod_dnsbl/mod_dnsbl.c
@@ -405,7 +405,7 @@ static void dnsbl_sess_reinit_ev(const void *event_data, void *user_data) {
 }
 
 static int dnsbl_sess_init(void) {
-  int res, xerrno = 0;
+  int res = 0, xerrno = 0;
   config_rec *c;
 
   pr_event_register(&dnsbl_module, "core.session-reinit", dnsbl_sess_reinit_ev,

--- a/contrib/mod_ifversion.c
+++ b/contrib/mod_ifversion.c
@@ -299,7 +299,7 @@ static int compare_version(pool *p, char *version_str, char **error) {
 }
 
 static int match_version(pool *p, const char *pattern_str, char **error) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   pr_regex_t *pre;
   int res;
 
@@ -331,7 +331,7 @@ static int match_version(pool *p, const char *pattern_str, char **error) {
 #else
   *error = pstrdup(p, "system does not support POSIX regular expressions");
   return 0;
-#endif /* regex support */
+#endif /* PR_USE_REGEX */
 }
 
 /* Configuration handlers
@@ -395,6 +395,7 @@ MODRET start_ifversion(cmd_rec *cmd) {
        */
       version_str[strlen(version_str)-1] = '\0';
       version_str++;
+      /* FALLTHROUGH */
 
     case '~':
       /* Regular expression */

--- a/contrib/mod_sftp/kex.c
+++ b/contrib/mod_sftp/kex.c
@@ -6019,6 +6019,7 @@ static struct ssh2_packet *read_kex_packet(pool *p, struct sftp_kex *kex,
           pkt = NULL;
           break;
         }
+        /* FALLTHROUGH */
 
       case SFTP_SSH2_MSG_IGNORE:
         if (use_strict_kex == FALSE) {
@@ -6027,6 +6028,7 @@ static struct ssh2_packet *read_kex_packet(pool *p, struct sftp_kex *kex,
           pkt = NULL;
           break;
         }
+        /* FALLTHROUGH */
 
       case SFTP_SSH2_MSG_UNIMPLEMENTED:
         if (use_strict_kex == FALSE) {
@@ -6035,6 +6037,7 @@ static struct ssh2_packet *read_kex_packet(pool *p, struct sftp_kex *kex,
           pkt = NULL;
           break;
         }
+        /* FALLTHROUGH */
 
       default:
         /* For any other message type, it's considered a protocol error. */

--- a/contrib/mod_sql_odbc.c
+++ b/contrib/mod_sql_odbc.c
@@ -232,20 +232,20 @@ static const char *sqlodbc_typestr(SQLSMALLINT type) {
     case SQL_LONGVARCHAR:
       return "SQL_LONGVARCHAR";
 
-#ifdef SQL_WCHAR
+#if defined(SQL_WCHAR)
     case SQL_WCHAR:
       return "SQL_WCHAR";
-#endif
+#endif /* SQL_WCHAR */
 
-#ifdef SQL_WVARCHAR
+#if defined(SQL_WVARCHAR)
     case SQL_WVARCHAR:
       return "SQL_WVARCHAR";
-#endif
+#endif /* SQL_WVARCHAR */
 
-#ifdef SQL_WLONGVARCHAR
+#if defined(SQL_WLONGVARCHAR)
     case SQL_WLONGVARCHAR:
       return "SQL_WLONGVARCHAR";
-#endif
+#endif /* SQL_WLONGVARCHAR */
 
     case SQL_DECIMAL:
       return "SQL_DECIMAL";
@@ -310,10 +310,10 @@ static const char *sqlodbc_strerror(SQLSMALLINT odbc_error) {
     case SQL_SUCCESS_WITH_INFO:
       return "Success with info";
 
-#ifdef SQL_NO_DATA
+#if defined(SQL_NO_DATA)
     case SQL_NO_DATA:
       return "No data";
-#endif
+#endif /* SQL_NO_DATA */
 
     case SQL_ERROR:
       return "Error";
@@ -346,10 +346,10 @@ static modret_t *sqlodbc_get_error(cmd_rec *cmd, SQLSMALLINT handle_type,
   res = SQLGetDiagRec(handle_type, handle, recno++, state, &odbc_errno,
     errstr, sizeof(errstr), &errlen);
   while (res != SQL_NO_DATA
-#ifdef SQL_ERROR
+#if defined(SQL_ERROR)
          && res != SQL_ERROR
 #endif /* SQL_ERROR */
-#ifdef SQL_INVALID_HANDLE
+#if defined(SQL_INVALID_HANDLE)
          && res != SQL_INVALID_HANDLE
 #endif /* SQL_INVALID_HANDLE */
         ) {
@@ -421,9 +421,9 @@ static modret_t *sqlodbc_get_data(cmd_rec *cmd, db_conn_t *conn) {
         break;
 
       case SQL_SUCCESS_WITH_INFO:
-        /* Note: this deliberately falls through to the SQL_SUCCESS case. */
         sql_log(DEBUG_WARN, "fetching row %lu: %s", sd->rnum + 1,
           sqlodbc_errstr(SQL_HANDLE_STMT, conn->sth, NULL));
+        /* FALLTHROUGH */
 
       case SQL_SUCCESS:
         sd->rnum++;
@@ -446,9 +446,9 @@ static modret_t *sqlodbc_get_data(cmd_rec *cmd, db_conn_t *conn) {
               case SQL_CHAR:
               case SQL_LONGVARCHAR:
               case SQL_VARCHAR:
-#ifdef SQL_WVARCHAR
+#if defined(SQL_WVARCHAR)
               case SQL_WVARCHAR:
-#endif
+#endif /* SQL_WVARCHAR */
                 col_ctype = SQL_C_CHAR;
 
                 if (col_size) {

--- a/contrib/mod_tls.c
+++ b/contrib/mod_tls.c
@@ -38,9 +38,9 @@
 #include "privs.h"
 #include "mod_tls.h"
 
-#ifdef PR_USE_CTRLS
+#if defined(PR_USE_CTRLS)
 # include "mod_ctrls.h"
-#endif
+#endif /* PR_USE_CTRLS */
 
 /* Define if you have the LibreSSL library.
  *
@@ -69,10 +69,10 @@
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 #if OPENSSL_VERSION_NUMBER > 0x000907000L
-# ifdef PR_USE_OPENSSL_ENGINE
+# if defined(PR_USE_OPENSSL_ENGINE)
 #  include <openssl/engine.h>
 # endif /* PR_USE_OPENSSL_ENGINE */
-# ifdef PR_USE_OPENSSL_OCSP
+# if defined(PR_USE_OPENSSL_OCSP)
 #  include <openssl/ocsp.h>
 # endif /* PR_USE_OPENSSL_OCSP */
 # if defined(PR_USE_OPENSSL_OSSL_PROVIDER_LOAD)
@@ -80,14 +80,14 @@
 #  include <openssl/store.h>
 # endif /* PR_USE_OPENSSL_OSSL_PROVIDER_LOAD */
 #endif /* OpenSSL-0.9.7 and later */
-#ifdef PR_USE_OPENSSL_ECC
+#if defined(PR_USE_OPENSSL_ECC)
 # include <openssl/ec.h>
 # include <openssl/ecdh.h>
 #endif /* PR_USE_OPENSSL_ECC */
 
-#ifdef HAVE_MLOCK
+#if defined(HAVE_MLOCK)
 # include <sys/mman.h>
-#endif
+#endif /* HAVE_MLOCK */
 
 #define MOD_TLS_VERSION		"mod_tls/2.9.3"
 
@@ -611,14 +611,14 @@ static unsigned int tls_protocol = TLS_PROTO_DEFAULT;
 /* This is used for e.g. "TLSProtocol ALL -SSLv3 ...". */
 #define TLS_PROTO_ALL			(TLS_PROTO_SSL_V3|TLS_PROTO_TLS_V1|TLS_PROTO_TLS_V1_1|TLS_PROTO_TLS_V1_2|TLS_PROTO_TLS_V1_3)
 
-#ifdef SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
+#if defined(SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS)
 static int tls_ssl_opts = (SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_SINGLE_DH_USE)^SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 #else
 /* OpenSSL-0.9.6 and earlier (yes, it appears people still have these versions
  * installed) does not define the DONT_INSERT_EMPTY_FRAGMENTS option.
  */
 static int tls_ssl_opts = SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_SINGLE_DH_USE;
-#endif
+#endif /* SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS */
 
 static int tls_required_on_auth = 0;
 static int tls_required_on_ctrl = 0;
@@ -1144,7 +1144,7 @@ static const char *get_pkey_typestr(int pkey_type) {
       str = "DSA";
       break;
 
-#ifdef PR_USE_OPENSSL_ECC
+#if defined(PR_USE_OPENSSL_ECC)
     case EVP_PKEY_EC:
       str = "EC";
       break;
@@ -1354,11 +1354,11 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
 
     ssl_state = SSL_get_state(ssl);
     switch (ssl_state) {
-#ifdef SSL_ST_BEFORE
+#if defined(SSL_ST_BEFORE)
       case SSL_ST_BEFORE:
         str = "before";
         break;
-#endif
+#endif /* SSL_ST_BEFORE */
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
@@ -1369,11 +1369,11 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
         str = "ok";
         break;
 
-#ifdef SSL_ST_RENEGOTIATE
+#if defined(SSL_ST_RENEGOTIATE)
       case SSL_ST_RENEGOTIATE:
         str = "renegotiating";
         break;
-#endif
+#endif /* SSL_ST_RENEGOTIATE */
 
       default:
         break;
@@ -2192,7 +2192,7 @@ static void tls_print_server_hello(int io_flag, int version, int content_type,
   BIO_puts(bio, "\nServerHello:\n");
   tls_print_ssl_version(bio, "server_version", &buf, &buflen, &server_version);
 
-#ifdef TLS1_3_VERSION
+#if defined(TLS1_3_VERSION)
   if (server_version == TLS1_3_VERSION) {
     print_session_id = FALSE;
     print_compressions = FALSE;
@@ -2243,7 +2243,7 @@ static void tls_print_server_hello(int io_flag, int version, int content_type,
   BIO_free(bio);
 }
 
-#ifdef SSL3_MT_NEWSESSION_TICKET
+#if defined(SSL3_MT_NEWSESSION_TICKET)
 static void tls_print_ticket(int io_flag, int version, int content_type,
     const unsigned char *buf, size_t buflen, SSL *ssl, void *arg) {
   BIO *bio;
@@ -2344,7 +2344,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
 # endif /* TLS1_3_VERSION */
 
     default:
-#ifdef SSL3_RT_HEADER
+#if defined(SSL3_RT_HEADER)
       /* OpenSSL calls this callback for SSL records received; filter those
        * from true "unknowns".
        */
@@ -2355,7 +2355,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
       }
 #else
       tls_log("[msg] unknown/unsupported version: %d", version);
-#endif
+#endif /* SSL3_RT_HEADER */
       break;
   }
 
@@ -2442,7 +2442,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
                 (unsigned int) buflen, bytes_str);
               break;
 
-#ifdef SSL3_AD_NO_CERTIFICATE
+#if defined(SSL3_AD_NO_CERTIFICATE)
             case SSL3_AD_NO_CERTIFICATE:
               tls_log("[msg] %s %s %s 'no_certificate' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2450,7 +2450,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_NO_CERTIFICATE */
 
-#ifdef SSL3_AD_BAD_CERTIFICATE
+#if defined(SSL3_AD_BAD_CERTIFICATE)
             case SSL3_AD_BAD_CERTIFICATE:
               tls_log("[msg] %s %s %s 'bad_certificate' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2458,7 +2458,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_BAD_CERTIFICATE */
 
-#ifdef SSL3_AD_UNSUPPORTED_CERTIFICATE
+#if defined(SSL3_AD_UNSUPPORTED_CERTIFICATE)
             case SSL3_AD_UNSUPPORTED_CERTIFICATE:
               tls_log("[msg] %s %s %s 'unsupported_certificate' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2466,7 +2466,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_UNSUPPORTED_CERTIFICATE */
 
-#ifdef SSL3_AD_CERTIFICATE_REVOKED
+#if defined(SSL3_AD_CERTIFICATE_REVOKED)
             case SSL3_AD_CERTIFICATE_REVOKED:
               tls_log("[msg] %s %s %s 'certificate_revoked' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2474,7 +2474,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_CERTIFICATE_REVOKED */
 
-#ifdef SSL3_AD_CERTIFICATE_EXPIRED
+#if defined(SSL3_AD_CERTIFICATE_EXPIRED)
             case SSL3_AD_CERTIFICATE_EXPIRED:
               tls_log("[msg] %s %s %s 'certificate_expired' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2482,7 +2482,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_CERTIFICATE_EXPIRED */
 
-#ifdef SSL3_AD_CERTIFICATE_UNKNOWN
+#if defined(SSL3_AD_CERTIFICATE_UNKNOWN)
             case SSL3_AD_CERTIFICATE_UNKNOWN:
               tls_log("[msg] %s %s %s 'certificate_unknown' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2490,7 +2490,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_AD_CERTIFICATE_UNKNOWN */
 
-#ifdef SSL3_AD_ILLEGAL_PARAMETER
+#if defined(SSL3_AD_ILLEGAL_PARAMETER)
             case SSL3_AD_ILLEGAL_PARAMETER:
               tls_log("[msg] %s %s %s 'illegal_parameter' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
@@ -2550,7 +2550,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
             }
 
-#ifdef SSL3_MT_NEWSESSION_TICKET
+#if defined(SSL3_MT_NEWSESSION_TICKET)
             case SSL3_MT_NEWSESSION_TICKET: {
               const unsigned char *msg;
               size_t msglen;
@@ -2607,7 +2607,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
                 action_str, version_str, (unsigned int) buflen, bytes_str);
               break;
 
-#ifdef SSL3_MT_CERTIFICATE_STATUS
+#if defined(SSL3_MT_CERTIFICATE_STATUS)
             case SSL3_MT_CERTIFICATE_STATUS:
               tls_log("[msg] %s %s 'CertificateStatus' Handshake message "
                 "(%u %s)", action_str, version_str, (unsigned int) buflen,
@@ -2615,7 +2615,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
 #endif /* SSL3_MT_CERTIFICATE_STATUS */
 
-#ifdef SSL3_MT_ENCRYPTED_EXTENSIONS
+#if defined(SSL3_MT_ENCRYPTED_EXTENSIONS)
             case SSL3_MT_ENCRYPTED_EXTENSIONS: {
               const unsigned char *msg;
               size_t msglen;
@@ -2753,7 +2753,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
         (unsigned int) buflen, bytes_str);
     }
 
-#ifdef SSL3_RT_HEADER
+#if defined(SSL3_RT_HEADER)
   } else if (version == 0 &&
              content_type == SSL3_RT_HEADER &&
              buflen == SSL3_RT_HEADER_LENGTH) {
@@ -2767,7 +2767,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
 
     tls_log("[msg] %s protocol record message (content type = %s, len = %d)",
       action_str, record_type, msg_len);
-#endif
+#endif /* SSL3_RT_HEADER */
 
   } else {
     /* This case might indicate an issue with OpenSSL itself; the version
@@ -9929,13 +9929,13 @@ static ssize_t tls_read(SSL *ssl, void *buf, size_t len) {
           /* Still missing data after timeout. Simulate an EINTR and return.
            */
           xerrno = EINTR;
-
-          /* If err < 0, i.e. some error from the select(), everything is
-           * already in place; errno is properly set and this function
-           * returns -1.
-           */
-          break;
         }
+
+        /* If err < 0, i.e. some error from the select(), everything is
+         * already in place; errno is properly set and this function
+         * returns -1.
+         */
+        break;
 
       case SSL_ERROR_WANT_WRITE:
         /* OpenSSL needs to write more data to the wire to finish the current
@@ -9952,13 +9952,13 @@ static ssize_t tls_read(SSL *ssl, void *buf, size_t len) {
           /* Still missing data after timeout. Simulate an EINTR and return.
            */
           xerrno = EINTR;
-
-          /* If err < 0, i.e. some error from the select(), everything is
-           * already in place; errno is properly set and this function
-           * returns -1.
-           */
-          break;
         }
+
+        /* If err < 0, i.e. some error from the select(), everything is
+         * already in place; errno is properly set and this function
+         * returns -1.
+         */
+        break;
 
       case SSL_ERROR_ZERO_RETURN:
         tls_log("read EOF from client");

--- a/modules/mod_core.c
+++ b/modules/mod_core.c
@@ -55,7 +55,7 @@ char AddressCollisionCheck = TRUE;
 static int core_scrub_timer_id = -1;
 static pr_fh_t *displayquit_fh = NULL;
 
-#ifdef PR_USE_TRACE
+#if defined(PR_USE_TRACE)
 static const char *trace_log = NULL;
 #endif /* PR_USE_TRACE */
 
@@ -1671,7 +1671,7 @@ MODRET set_group(cmd_rec *cmd) {
 
 /* usage: Trace ["session"] channel1:level1 ... */
 MODRET set_trace(cmd_rec *cmd) {
-#ifdef PR_USE_TRACE
+#if defined(PR_USE_TRACE)
   register unsigned int i;
   int per_session = FALSE, ctx = 0;
   unsigned int idx = 1;
@@ -1769,7 +1769,7 @@ MODRET set_trace(cmd_rec *cmd) {
 
 /* usage: TraceLog path */
 MODRET set_tracelog(cmd_rec *cmd) {
-#ifdef PR_USE_TRACE
+#if defined(PR_USE_TRACE)
   if (cmd->argc-1 != 1) {
     CONF_ERROR(cmd, "wrong number of parameters");
   }
@@ -1800,7 +1800,7 @@ MODRET set_tracelog(cmd_rec *cmd) {
 
 /* usage: TraceOptions opt1 ... optN */
 MODRET set_traceoptions(cmd_rec *cmd) {
-#ifdef PR_USE_TRACE
+#if defined(PR_USE_TRACE)
   register unsigned int i;
   int ctx;
   config_rec *c;
@@ -2093,13 +2093,13 @@ MODRET set_syslogfacility(cmd_rec *cmd) {
   } factable[] = {
   { "AUTH",		LOG_AUTHPRIV		},
   { "AUTHPRIV",		LOG_AUTHPRIV		},
-#ifdef HAVE_LOG_FTP
-  { "FTP",		LOG_FTP			},
-#endif
-#ifdef HAVE_LOG_CRON
+#if defined(HAVE_LOG_CRON)
   { "CRON",		LOG_CRON		},
-#endif
+#endif /* HAVE_LOG_CRON */
   { "DAEMON",		LOG_DAEMON		},
+#if defined(HAVE_LOG_FTP)
+  { "FTP",		LOG_FTP			},
+#endif /* HAVE_LOG_FTP */
   { "KERN",		LOG_KERN		},
   { "LOCAL0",		LOG_LOCAL0		},
   { "LOCAL1",		LOG_LOCAL1		},
@@ -2176,7 +2176,7 @@ MODRET set_timesgmt(cmd_rec *cmd) {
 }
 
 MODRET set_regex(cmd_rec *cmd, char *param, char *type) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   pr_regex_t *pre = NULL;
   config_rec *c = NULL;
   int regex_flags = REG_EXTENDED|REG_NOSUB, res = 0;
@@ -2230,15 +2230,15 @@ MODRET set_regex(cmd_rec *cmd, char *param, char *type) {
   c->flags |= CF_MERGEDOWN;
   return PR_HANDLED(cmd);
 
-#else /* no regular expression support at the moment */
+#else
   CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "The ", param, " directive cannot be "
     "used on this system, as you do not have POSIX compliant regex support",
     NULL));
-#endif
+#endif /* PR_USE_REGEX */
 }
 
 MODRET set_allowdenyfilter(cmd_rec *cmd) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   pr_regex_t *pre = NULL;
   config_rec *c = NULL;
   int regex_flags = REG_EXTENDED|REG_NOSUB, res = 0;
@@ -2292,11 +2292,11 @@ MODRET set_allowdenyfilter(cmd_rec *cmd) {
   c->flags |= CF_MERGEDOWN;
   return PR_HANDLED(cmd);
 
-#else /* no regular expression support at the moment */
+#else
   CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "The ", cmd->argv[0],
     " directive cannot be used on this system, as you do not have POSIX "
     "compliant regex support", NULL));
-#endif
+#endif /* PR_USE_REGEX */
 }
 
 MODRET set_passiveports(cmd_rec *cmd) {
@@ -2512,7 +2512,7 @@ MODRET add_directory(cmd_rec *cmd) {
 }
 
 MODRET set_hidefiles(cmd_rec *cmd) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   pr_regex_t *pre = NULL;
   config_rec *c = NULL;
   unsigned int precedence = 0;
@@ -2655,11 +2655,11 @@ MODRET set_hidefiles(cmd_rec *cmd) {
 
   return PR_HANDLED(cmd);
 
-#else /* no regular expression support at the moment */
+#else
   CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "The HideFiles directive cannot be "
     "used on this system, as you do not have POSIX compliant regex support",
     NULL));
-#endif
+#endif /* PR_USE_REGEX */
 }
 
 MODRET set_hidenoaccess(cmd_rec *cmd) {
@@ -3141,7 +3141,7 @@ MODRET set_allowdenyusergroupclass(cmd_rec *cmd) {
       argv = cmd->argv+1;
 
     } else if (strcasecmp(cmd->argv[1], "regex") == 0) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
       pr_regex_t *pre;
       int res;
 
@@ -3172,7 +3172,7 @@ MODRET set_allowdenyusergroupclass(cmd_rec *cmd) {
 #else
       CONF_ERROR(cmd, "The 'regex' parameter cannot be used on this system, "
         "as you do not have POSIX compliant regex support");
-#endif /* regex support */
+#endif /* PR_USE_REGEX */
 
     } else {
       argc = cmd->argc-1;
@@ -3650,7 +3650,7 @@ MODRET end_virtualhost(cmd_rec *cmd) {
   return PR_HANDLED(cmd);
 }
 
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
 MODRET regex_filters(cmd_rec *cmd) {
   pr_regex_t *allow_regex = NULL, *deny_regex = NULL;
 
@@ -3691,7 +3691,7 @@ MODRET regex_filters(cmd_rec *cmd) {
 
   return PR_DECLINED(cmd);
 }
-#endif /* regex support */
+#endif /* PR_USE_REGEX */
 
 MODRET core_pre_any(cmd_rec *cmd) {
   unsigned long cmd_delay = 0;
@@ -4355,6 +4355,7 @@ MODRET core_eprt(cmd_rec *cmd) {
         break;
       }
 #endif /* PR_USE_IPV6 */
+      /* FALLTHROUGH */
 
     default:
 #if defined(PR_USE_IPV6)
@@ -4658,6 +4659,7 @@ MODRET core_epsv(cmd_rec *cmd) {
           break;
         }
 #endif /* PR_USE_IPV6 */
+        /* FALLTHROUGH */
 
       default:
         family = 0;
@@ -4675,6 +4677,7 @@ MODRET core_epsv(cmd_rec *cmd) {
         break;
       }
 #endif /* PR_USE_IPV6 */
+      /* FALLTHROUGH */
 
     default:
 #if defined(PR_USE_IPV6)
@@ -6166,7 +6169,7 @@ MODRET core_dele(cmd_rec *cmd) {
     return PR_ERROR(cmd);
   }
 
-#ifdef EISDIR
+#if defined(EISDIR)
   /* If the path is a directory, try to return a good error message (e.g.
    * EISDIR).
    */
@@ -6185,7 +6188,7 @@ MODRET core_dele(cmd_rec *cmd) {
     errno = xerrno;
     return PR_ERROR(cmd);
   }
-#endif /* !EISDIR */
+#endif /* EISDIR */
 
   res = pr_fsio_unlink_with_error(cmd->pool, path, &err);
   if (res < 0) {
@@ -6771,7 +6774,7 @@ MODRET core_post_pass(cmd_rec *cmd) {
     }
   }
 
-#ifdef PR_USE_TRACE
+#if defined(PR_USE_TRACE)
   /* Handle any user/group-specific Trace settings. */
   c = find_config(main_server->conf, CONF_PARAM, "Trace", FALSE);
   if (c != NULL) {
@@ -7045,8 +7048,8 @@ static void core_restart_ev(const void *event_data, void *user_data) {
   pr_fs_statcache_reset();
   pr_scoreboard_scrub();
 
-#ifdef PR_USE_TRACE
-  if (trace_log) {
+#if defined(PR_USE_TRACE)
+  if (trace_log != NULL) {
     (void) pr_trace_set_levels(PR_TRACE_DEFAULT_CHANNEL, -1, -1);
     pr_trace_set_file(NULL);
     trace_log = NULL;
@@ -7670,9 +7673,9 @@ static conftable core_conftab[] = {
 };
 
 static cmdtable core_cmdtab[] = {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   { PRE_CMD, C_ANY, G_NONE,  regex_filters, FALSE, FALSE, CL_NONE },
-#endif
+#endif /* PR_USE_REGEX */
   { PRE_CMD, C_ANY, G_NONE, core_pre_any,FALSE, FALSE, CL_NONE },
   { CMD, C_HELP, G_NONE,  core_help,	FALSE,	FALSE, CL_INFO },
   { CMD, C_PORT, G_NONE,  core_port,	TRUE,	FALSE, CL_MISC },

--- a/src/error.c
+++ b/src/error.c
@@ -92,229 +92,229 @@ struct errno_info {
 };
 
 static struct errno_info errno_names[] = {
-#ifdef E2BIG
+#if defined(E2BIG)
   { E2BIG, "E2BIG" },
 #endif /* E2BIG */
-#ifdef EACCES
+#if defined(EACCES)
   { EACCES, "EACCES" },
 #endif /* EACCES */
-#ifdef EADDRINUSE
+#if defined(EADDRINUSE)
   { EADDRINUSE, "EADDRINUSE" },
 #endif /* EADDRINUSE */
-#ifdef EADDRNOTAVAIL
+#if defined(EADDRNOTAVAIL)
   { EADDRNOTAVAIL, "EADDRNOTAVAIL" },
 #endif /* EADDRNOTAVAIL */
-#ifdef EAFNOSUPPORT
+#if defined(EAFNOSUPPORT)
   { EAFNOSUPPORT, "EAFNOSUPPORT" },
 #endif /* EAFNOSUPPORT */
-#ifdef EAGAIN
+#if defined(EAGAIN)
   { EAGAIN, "EAGAIN" },
 #endif /* EAGAIN */
-#ifdef EALREADY
+#if defined(EALREADY)
   { EALREADY, "EALREADY" },
 #endif /* EALREADY */
-#ifdef EBADF
+#if defined(EBADF)
   { EBADF, "EBADF" },
 #endif /* EBADF */
-#ifdef EBADFD
+#if defined(EBADFD)
   { EBADFD, "EBADFD" },
 #endif /* EBADFD */
-#ifdef EBUSY
+#if defined(EBUSY)
   { EBUSY, "EBUSY" },
 #endif /* EBUSY */
-#ifdef ECANCELED
+#if defined(ECANCELED)
   { ECANCELED, "ECANCELED" },
 #endif /* ECANCELED */
-#ifdef ECOMM
+#if defined(ECOMM)
   { ECOMM, "ECOMM" },
 #endif /* ECOMM */
-#ifdef ECONNABORTED
+#if defined(ECONNABORTED)
   { ECONNABORTED, "ECONNABORTED" },
 #endif /* ECONNABORTED */
-#ifdef ECONNREFUSED
+#if defined(ECONNREFUSED)
   { ECONNREFUSED, "ECONNREFUSED" },
 #endif /* ECONNREFUSED */
-#ifdef ECONNRESET
+#if defined(ECONNRESET)
   { ECONNRESET, "ECONNRESET" },
 #endif /* ECONNRESET */
-#ifdef EDEADLK
+#if defined(EDEADLK)
   { EDEADLK, "EDEADLK" },
 #endif /* EDEADLK */
-#ifdef EDEADLOCK
+#if defined(EDEADLOCK)
   { EDEADLOCK, "EDEADLOCK" },
 #endif /* EDEADLOCK */
-#ifdef EDQUOT
+#if defined(EDQUOT)
   { EDQUOT, "EDQUOT" },
 #endif /* EDQUOT */
-#ifdef EEXIST
+#if defined(EEXIST)
   { EEXIST, "EEXIST" },
 #endif /* EEXIST */
-#ifdef EFAULT
+#if defined(EFAULT)
   { EFAULT, "EFAULT" },
 #endif /* EFAULT */
-#ifdef EFBIG
+#if defined(EFBIG)
   { EFBIG, "EFBIG" },
 #endif /* EFBIG */
-#ifdef EHOSTDOWN
+#if defined(EHOSTDOWN)
   { EHOSTDOWN, "EHOSTDOWN" },
 #endif /* EHOSTDOWN */
-#ifdef EHOSTUNREACH
+#if defined(EHOSTUNREACH)
   { EHOSTUNREACH, "EHOSTUNREACH" },
 #endif /* EHOSTUNREACH */
-#ifdef EILSEQ
+#if defined(EILSEQ)
   { EILSEQ, "EILSEQ" },
 #endif /* EILSEQ */
-#ifdef EINPROGRESS
+#if defined(EINPROGRESS)
   { EINPROGRESS, "EINPROGRESS" },
 #endif /* EINPROGRESS */
-#ifdef EINTR
+#if defined(EINTR)
   { EINTR, "EINTR" },
 #endif /* EINTR */
-#ifdef EINVAL
+#if defined(EINVAL)
   { EINVAL, "EINVAL" },
 #endif /* EINVAL */
-#ifdef EISCONN
+#if defined(EISCONN)
   { EISCONN, "EISCONN" },
 #endif /* EISCONN */
-#ifdef EISDIR
+#if defined(EISDIR)
   { EISDIR, "EISDIR" },
 #endif /* EISDIR */
-#ifdef EIO
+#if defined(EIO)
   { EIO, "EIO" },
 #endif /* EIO */
-#ifdef ELOOP
+#if defined(ELOOP)
   { ELOOP, "ELOOP" },
 #endif /* ELOOP */
-#ifdef EMFILE
+#if defined(EMFILE)
   { EMFILE, "EMFILE" },
 #endif /* EMFILE */
-#ifdef EMLINK
+#if defined(EMLINK)
   { EMLINK, "EMLINK" },
 #endif /* EMLINK */
-#ifdef EMSGSIZE
+#if defined(EMSGSIZE)
   { EMSGSIZE, "EMSGSIZE" },
 #endif /* EMSGSIZE */
-#ifdef ENAMETOOLONG
+#if defined(ENAMETOOLONG)
   { ENAMETOOLONG, "ENAMETOOLONG" },
 #endif /* ENAMETOOLONG */
-#ifdef ENFILE
+#if defined(ENFILE)
   { ENFILE, "ENFILE" },
 #endif /* ENFILE */
-#ifdef ENETDOWN
+#if defined(ENETDOWN)
   { ENETDOWN, "ENETDOWN" },
 #endif /* ENETDOWN */
-#ifdef ENETRESET
+#if defined(ENETRESET)
   { ENETRESET, "ENETRESET" },
 #endif /* ENETRESET */
-#ifdef ENETUNREACH
+#if defined(ENETUNREACH)
   { ENETUNREACH, "ENETUNREACH" },
 #endif /* ENETUNREACH */
-#ifdef ENOBUFS
+#if defined(ENOBUFS)
   { ENOBUFS, "ENOBUFS" },
 #endif /* ENOBUFS */
-#ifdef ENODATA
+#if defined(ENODATA)
   { ENODATA, "ENODATA" },
 #endif /* ENODATA */
-#ifdef ENOATTR
+#if defined(ENOATTR)
   { ENOATTR, "ENOATTR" },
 #endif /* ENOATTR */
-#ifdef ENOLCK
+#if defined(ENOLCK)
   { ENOLCK, "ENOLCK" },
 #endif /* ENOLCK */
-#ifdef ENOLINK
+#if defined(ENOLINK)
   { ENOLINK, "ENOLINK" },
 #endif /* ENOLINK */
-#ifdef ENOMEDIUM
+#if defined(ENOMEDIUM)
   { ENOMEDIUM, "ENOMEDIUM" },
 #endif /* ENOMEDIUM */
-#ifdef ENOMEM
+#if defined(ENOMEM)
   { ENOMEM, "ENOMEM" },
 #endif /* ENOMEM */
-#ifdef ENONET
+#if defined(ENONET)
   { ENONET, "ENONET" },
 #endif /* ENONET */
-#ifdef ENOTCONN
+#if defined(ENOTCONN)
   { ENOTCONN, "ENOTCONN" },
 #endif /* ENOTSCONN */
-#ifdef ENOTEMPTY
+#if defined(ENOTEMPTY)
   { ENOTEMPTY, "ENOTEMPTY" },
 #endif /* ENOTEMPTY */
-#ifdef ENOSPC
+#if defined(ENOSPC)
   { ENOSPC, "ENOSPC" },
 #endif /* ENOSPC */
-#ifdef ENOSYS
+#if defined(ENOSYS)
   { ENOSYS, "ENOSYS" },
 #endif /* ENOSYS */
-#ifdef ENXIO
+#if defined(ENXIO)
   { ENXIO, "ENXIO" },
 #endif /* ENXIO */
-#ifdef ENOENT
+#if defined(ENOENT)
   { ENOENT, "ENOENT" },
 #endif /* ENOENT */
-#ifdef ENOTDIR
+#if defined(ENOTDIR)
   { ENOTDIR, "ENOTDIR" },
 #endif /* ENOTDIR */
-#ifdef ENOTSOCK
+#if defined(ENOTSOCK)
   { ENOTSOCK, "ENOTSOCK" },
 #endif /* ENOTSOCK */
-#ifdef ENOTSUP
+#if defined(ENOTSUP)
   { ENOTSUP, "ENOTSUP" },
 #endif /* ENOTSUP */
-#ifdef EOPNOTSUPP
+#if defined(EOPNOTSUPP)
   { EOPNOTSUPP, "EOPNOTSUPP" },
 #endif /* EOPNOTSUPP */
-#ifdef EPERM
+#if defined(EPERM)
   { EPERM, "EPERM" },
 #endif /* EPERM */
-#ifdef EPFNOSUPPORT
+#if defined(EPFNOSUPPORT)
   { EPFNOSUPPORT, "EPFNOSUPPORT" },
 #endif /* EPFNOSUPPORT */
-#ifdef EPIPE
+#if defined(EPIPE)
   { EPIPE, "EPIPE" },
 #endif /* EPIPE */
-#ifdef EPROTO
+#if defined(EPROTO)
   { EPROTO, "EPROTO" },
 #endif /* EPROTO */
-#ifdef EPROTONOSUPPORT
+#if defined(EPROTONOSUPPORT)
   { EPROTONOSUPPORT, "EPROTONOSUPPORT" },
 #endif /* EPROTONOSUPPORT */
-#ifdef EPROTOOPT
+#if defined(EPROTOOPT)
   { EPROTOOPT, "EPROTOOPT" },
 #endif /* EPROTOOPT */
-#ifdef EPROTOTYPE
+#if defined(EPROTOTYPE)
   { EPROTOTYPE, "EPROTOTYPE" },
 #endif /* EPROTOTYPE */
-#ifdef ERANGE
+#if defined(ERANGE)
   { ERANGE, "ERANGE" },
 #endif /* ERANGE */
-#ifdef EROFS
+#if defined(EROFS)
   { EROFS, "EROFS" },
 #endif /* EROFS */
-#ifdef ESHUTDOWN
+#if defined(ESHUTDOWN)
   { ESHUTDOWN, "ESHUTDOWN" },
 #endif /* ESHUTDOWN */
-#ifdef ESPIPE
+#if defined(ESPIPE)
   { ESPIPE, "ESPIPE" },
 #endif /* ESPIPE */
-#ifdef ERESTART
+#if defined(ERESTART)
   { ERESTART, "ERESTART" },
 #endif /* ERESTART */
-#ifdef ESRCH
+#if defined(ESRCH)
   { ESRCH, "ESRCH" },
 #endif /* ESRCH */
-#ifdef ESTALE
+#if defined(ESTALE)
   { ESTALE, "ESTALE" },
 #endif /* ESTALE */
-#ifdef ETIMEDOUT
+#if defined(ETIMEDOUT)
   { ETIMEDOUT, "ETIMEDOUT" },
 #endif /* ETIMEDOUT */
-#ifdef ETXTBSY
+#if defined(ETXTBSY)
   { ETXTBSY, "ETXTBSY" },
 #endif /* ETXTBSY */
-#ifdef EWOULDBLOCK
+#if defined(EWOULDBLOCK)
   { EWOULDBLOCK, "EWOULDBLOCK" },
 #endif /* EWOULDBLOCK */
-#ifdef EXDEV
+#if defined(EXDEV)
   { EXDEV, "EXDEV" },
 #endif /* EXDEV */
 
@@ -804,20 +804,20 @@ const char *pr_error_strerror(pr_error_t *err, int use_format) {
 
   switch (use_format) {
     case PR_ERROR_FORMAT_USE_DETAILED:
-      if (!(error_formats & PR_ERROR_FORMAT_USE_DETAILED)) {
-        use_format = PR_ERROR_FORMAT_USE_TERSE;
-
-      } else {
+      if (error_formats & PR_ERROR_FORMAT_USE_DETAILED) {
         break;
       }
+
+      use_format = PR_ERROR_FORMAT_USE_TERSE;
+      /* FALLTHROUGH */
 
     case PR_ERROR_FORMAT_USE_TERSE:
-      if (!(error_formats & PR_ERROR_FORMAT_USE_TERSE)) {
-        use_format = PR_ERROR_FORMAT_USE_MINIMAL;
-
-      } else {
+      if (error_formats & PR_ERROR_FORMAT_USE_TERSE) {
         break;
       }
+
+      use_format = PR_ERROR_FORMAT_USE_MINIMAL;
+      /* FALLTHROUGH */
 
     case PR_ERROR_FORMAT_USE_MINIMAL:
       break;

--- a/src/jot.c
+++ b/src/jot.c
@@ -2100,7 +2100,7 @@ static int resolve_meta(pool *p, unsigned char **logfmt, pr_jot_ctx_t *ctx,
     case LOGFMT_META_ENV_VAR:
     case LOGFMT_META_NOTE_VAR:
     case LOGFMT_META_VAR_VAR:
-    case LOGFMT_META_TIME: {
+    case LOGFMT_META_TIME:
       if (*(ptr + 1) == LOGFMT_META_START &&
           *(ptr + 2) == LOGFMT_META_ARG) {
         logfmt_data = get_meta_arg(p, (ptr + 3), &logfmt_datalen);
@@ -2108,7 +2108,7 @@ static int resolve_meta(pool *p, unsigned char **logfmt, pr_jot_ctx_t *ctx,
         /* Skip past the META_START, META_ARG, META_ARG_END, and the data. */
         consumed_bytes += (3 + logfmt_datalen);
       }
-    }
+      /* FALLTHROUGH */
 
     default:
       consumed_bytes += 1;
@@ -3047,7 +3047,7 @@ static int scan_meta(pool *p, unsigned char **logfmt, pr_jot_ctx_t *ctx,
     case LOGFMT_META_ENV_VAR:
     case LOGFMT_META_NOTE_VAR:
     case LOGFMT_META_VAR_VAR:
-    case LOGFMT_META_TIME: {
+    case LOGFMT_META_TIME:
       if (*(ptr + 1) == LOGFMT_META_START &&
           *(ptr + 2) == LOGFMT_META_ARG) {
         size_t logfmt_datalen = 0;
@@ -3059,7 +3059,7 @@ static int scan_meta(pool *p, unsigned char **logfmt, pr_jot_ctx_t *ctx,
         consumed_bytes += (3 + logfmt_datalen);
         break;
       }
-    }
+      /* FALLTHROUGH */
 
     default:
       res = (on_meta)(p, ctx, logfmt_id, NULL, 0);

--- a/src/netaddr.c
+++ b/src/netaddr.c
@@ -48,7 +48,7 @@ static int have_sess_remote_addr = FALSE;
 static int reverse_dns = 1;
 
 /* Use IPv6? */
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
 static int use_ipv6 = TRUE;
 #else
 static int use_ipv6 = FALSE;
@@ -439,7 +439,7 @@ char *pr_netaddr_validate_dns_str(char *buf) {
     if (!PR_ISALNUM(*p) &&
         *p != '.' &&
         *p != '-'
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
         && *p != ':'
 #endif /* PR_USE_IPV6 */
         ) {
@@ -513,13 +513,13 @@ static pr_netaddr_t *get_addr_by_ip(pool *p, const char *name,
   pr_netaddr_t *na = NULL;
   int res;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   if (use_ipv6 == TRUE) {
     struct sockaddr_in6 v6;
     memset(&v6, 0, sizeof(v6));
     v6.sin6_family = AF_INET6;
 
-# ifdef SIN6_LEN
+# if defined(SIN6_LEN)
     v6.sin6_len = sizeof(struct sockaddr_in6);
 # endif /* SIN6_LEN */
 
@@ -555,9 +555,9 @@ static pr_netaddr_t *get_addr_by_ip(pool *p, const char *name,
   memset(&v4, 0, sizeof(v4));
   v4.sin_family = AF_INET;
 
-# ifdef SIN_LEN
+#if defined(SIN_LEN)
   v4.sin_len = sizeof(struct sockaddr_in);
-# endif /* SIN_LEN */
+#endif /* SIN_LEN */
 
   res = pr_inet_pton(AF_INET, name, &v4.sin_addr);
   if (res > 0) {
@@ -613,7 +613,7 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
     xerrno = errno;
 
     if (res != EAI_SYSTEM) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
       if (use_ipv6 == TRUE) {
         pr_trace_msg(trace_channel, 7,
           "unable to resolve '%s' to an IPv4 address: %s", name,
@@ -755,7 +755,7 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
     pr_freeaddrinfo(info);
   }
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   if (use_ipv6 == TRUE &&
       addrs != NULL) {
     /* Do the call again, this time for IPv6 addresses.
@@ -838,7 +838,7 @@ static pr_netaddr_t *get_addr_by_name(pool *p, const char *name,
 
 static pr_netaddr_t *get_addr_by_device(pool *p, const char *name,
     array_header **addrs, unsigned int flags) {
-#ifdef HAVE_GETIFADDRS
+#if defined(HAVE_GETIFADDRS)
   struct ifaddrs *ifaddr = NULL;
   pr_netaddr_t *na = NULL;
   int res, xerrno;
@@ -870,9 +870,9 @@ static pr_netaddr_t *get_addr_by_device(pool *p, const char *name,
 
       /* We're only looking for addresses, not stats. */
       if (ifa->ifa_addr->sa_family != AF_INET
-#ifdef PR_USE_IPV6
+# if defined(PR_USE_IPV6)
           && ifa->ifa_addr->sa_family != AF_INET6
-#endif /* PR_USE_IPV6 */
+# endif /* PR_USE_IPV6 */
          ) {
         continue;
       }
@@ -925,7 +925,7 @@ static pr_netaddr_t *get_addr_by_device(pool *p, const char *name,
       freeifaddrs(ifaddr);
     }
 
-    if (found_device) {
+    if (found_device == TRUE) {
       return na;
     }
   }
@@ -1042,20 +1042,21 @@ int pr_netaddr_set_family(pr_netaddr_t *na, int family) {
       na->na_addr.v4.sin_family = AF_INET;
       break;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (use_ipv6 == TRUE) {
         na->na_addr.v6.sin6_family = AF_INET6;
         break;
       }
 #endif /* PR_USE_IPV6 */
+      /* FALLTHROUGH */
 
     default:
-#ifdef EAFNOSUPPORT
+#if defined(EAFNOSUPPORT)
       errno = EAFNOSUPPORT;
 #else
       errno = EINVAL;
-#endif
+#endif /* EAFNOSUPPORT */
       return -1;
   }
 
@@ -1095,7 +1096,7 @@ size_t pr_netaddr_get_inaddr_len(const pr_netaddr_t *na) {
     case AF_INET:
       return sizeof(struct in_addr);
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       return sizeof(struct in6_addr);
 #endif /* PR_USE_IPV6 */
@@ -1164,7 +1165,7 @@ int pr_netaddr_set_sockaddr_any(pr_netaddr_t *na) {
       struct in_addr in4addr_any;
       in4addr_any.s_addr = htonl(INADDR_ANY);
       na->na_addr.v4.sin_family = AF_INET;
-#ifdef SIN_LEN
+#if defined(SIN_LEN)
       na->na_addr.v4.sin_len = sizeof(struct sockaddr_in);
 #endif /* SIN_LEN */
       memcpy(&na->na_addr.v4.sin_addr, &in4addr_any, sizeof(struct in_addr));
@@ -1175,13 +1176,13 @@ int pr_netaddr_set_sockaddr_any(pr_netaddr_t *na) {
       return 0;
     }
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (use_ipv6 == TRUE) {
         na->na_addr.v6.sin6_family = AF_INET6;
-#ifdef SIN6_LEN
+# if defined(SIN6_LEN)
         na->na_addr.v6.sin6_len = sizeof(struct sockaddr_in6);
-#endif /* SIN6_LEN */
+# endif /* SIN6_LEN */
         memcpy(&na->na_addr.v6.sin6_addr, &in6addr_any, sizeof(struct in6_addr));
         if (na->na_have_ipstr) {
           memset(na->na_ipstr, '\0', sizeof(na->na_ipstr));
@@ -1206,7 +1207,7 @@ void *pr_netaddr_get_inaddr(const pr_netaddr_t *na) {
     case AF_INET:
       return (void *) &na->na_addr.v4.sin_addr;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (use_ipv6 == TRUE) {
         return (void *) &na->na_addr.v6.sin6_addr;
@@ -1228,7 +1229,7 @@ unsigned int pr_netaddr_get_port(const pr_netaddr_t *na) {
     case AF_INET:
       return na->na_addr.v4.sin_port;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (use_ipv6 == TRUE) {
         return na->na_addr.v6.sin6_port;
@@ -1241,7 +1242,7 @@ unsigned int pr_netaddr_get_port(const pr_netaddr_t *na) {
 }
 
 int pr_netaddr_set_port(pr_netaddr_t *na, unsigned int port) {
-  if (!na) {
+  if (na == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -1251,9 +1252,9 @@ int pr_netaddr_set_port(pr_netaddr_t *na, unsigned int port) {
       na->na_addr.v4.sin_port = port;
       return 0;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
-      if (use_ipv6) {
+      if (use_ipv6 == TRUE) {
         na->na_addr.v6.sin6_port = port;
         return 0;
       }
@@ -1345,27 +1346,27 @@ int pr_netaddr_cmp(const pr_netaddr_t *na1, const pr_netaddr_t *na2) {
 
   switch (pr_netaddr_get_family(a)) {
     case AF_INET:
-      res = memcmp(&a->na_addr.v4.sin_addr, &b->na_addr.v4.sin_addr,
-        sizeof(struct in_addr));
+      if (a->na_addr.v4.sin_addr.s_addr == b->na_addr.v4.sin_addr.s_addr) {
+        res = 0;
 
-      if (res != 0) {
+      } else {
         pr_trace_msg(trace_channel, 4, "addr %s does not match addr %s",
           pr_netaddr_get_ipstr(a), pr_netaddr_get_ipstr(b));
+        res = -1;
       }
 
-      if (tmp_pool) {
+      if (tmp_pool != NULL) {
         destroy_pool(tmp_pool);
         tmp_pool = NULL;
       }
 
       return res;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
-      if (use_ipv6) {
+      if (use_ipv6 == TRUE) {
         res = memcmp(&a->na_addr.v6.sin6_addr, &b->na_addr.v6.sin6_addr,
           sizeof(struct in6_addr));
-
         if (res != 0) {
           pr_trace_msg(trace_channel, 4, "addr %s does not match addr %s",
             pr_netaddr_get_ipstr(a), pr_netaddr_get_ipstr(b));
@@ -1523,9 +1524,9 @@ int pr_netaddr_ncmp(const pr_netaddr_t *na1, const pr_netaddr_t *na2,
       break;
     }
 
-#ifdef PR_USE_IPV6
-    case AF_INET6: {
-      if (use_ipv6) {
+#if defined(PR_USE_IPV6)
+    case AF_INET6:
+      if (use_ipv6 == TRUE) {
         /* Make sure that the given number of bits is not more than supported
          * for IPv6 addresses (128).
          */
@@ -1536,8 +1537,8 @@ int pr_netaddr_ncmp(const pr_netaddr_t *na1, const pr_netaddr_t *na2,
 
         break;
       }
-    }
 #endif /* PR_USE_IPV6 */
+      /* FALLTHROUGH */
 
     default:
       errno = EPERM;
@@ -1550,7 +1551,7 @@ int pr_netaddr_ncmp(const pr_netaddr_t *na1, const pr_netaddr_t *na2,
 
   res = addr_ncmp(in1, in2, bitlen);
 
-  if (tmp_pool) {
+  if (tmp_pool != NULL) {
     destroy_pool(tmp_pool);
   }
 
@@ -1644,7 +1645,7 @@ const char *pr_netaddr_get_ipstr(const pr_netaddr_t *na) {
   /* If this pr_netaddr_t has already been resolved to an IP string, return the
    * cached string.
    */
-  if (na->na_have_ipstr) {
+  if (na->na_have_ipstr == TRUE) {
     return na->na_ipstr;
   }
 
@@ -1667,8 +1668,8 @@ const char *pr_netaddr_get_ipstr(const pr_netaddr_t *na) {
     return NULL;
   }
 
-#ifdef PR_USE_IPV6
-  if (use_ipv6 &&
+#if defined(PR_USE_IPV6)
+  if (use_ipv6 == TRUE &&
       pr_netaddr_get_family(na) == AF_INET6) {
     /* The getnameinfo(3) implementation might append the zone ID to an IPv6
      * name; we need to trim it off.
@@ -1708,17 +1709,17 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
     inaddr = get_v4inaddr(na);
   }
 
-#ifdef AI_CANONNAME
+# if defined(AI_CANONNAME)
   flags |= AI_CANONNAME;
-#endif
+# endif /* AI_CANONNAME */
 
-#ifdef AI_ALL
+# if defined(AI_ALL)
   flags |= AI_ALL;
-#endif
+# endif /* AI_ALL */
 
-#ifdef AI_V4MAPPED
+# if defined(AI_V4MAPPED)
   flags |= AI_V4MAPPED;
-#endif
+# endif /* AI_V4MAPPED */
 
   memset(&hints, 0, sizeof(hints));
 
@@ -1748,11 +1749,11 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
   }
 
   if (info != NULL) {
-#ifdef PR_USE_IPV6
+# if defined(PR_USE_IPV6)
     char buf[INET6_ADDRSTRLEN];
-#else
+# else
     char buf[INET_ADDRSTRLEN];
-#endif /* PR_USE_IPV6 */
+# endif /* PR_USE_IPV6 */
     struct addrinfo *ai;
     int xerrno;
 
@@ -1784,11 +1785,11 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
       "checking addresses associated with host '%s'", buf);
 
     for (ai = info->ai_next; ai; ai = ai->ai_next) {
-#ifdef PR_USE_IPV6
+# if defined(PR_USE_IPV6)
       char alias[INET6_ADDRSTRLEN];
-#else
+# else
       char alias[INET_ADDRSTRLEN];
-#endif /* PR_USE_IPV6 */
+# endif /* PR_USE_IPV6 */
 
       switch (ai->ai_family) {
         case AF_INET:
@@ -1807,9 +1808,10 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
           }
           break;
 
-#ifdef PR_USE_IPV6
+# if defined(PR_USE_IPV6)
         case AF_INET6:
-          if (use_ipv6 && family == AF_INET6) {
+          if (use_ipv6 == TRUE &&
+              family == AF_INET6) {
             if (memcmp(ai->ai_addr, inaddr, ai->ai_addrlen) == 0) {
               memset(alias, '\0', sizeof(alias));
               res = pr_getnameinfo(ai->ai_addr, ai->ai_addrlen, alias,
@@ -1823,7 +1825,7 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
             }
           }
           break;
-#endif /* PR_USE_IPV6 */
+# endif /* PR_USE_IPV6 */
       }
     }
 
@@ -1834,7 +1836,7 @@ static int netaddr_get_dnsstr_getaddrinfo(const pr_netaddr_t *na,
 }
 #endif /* HAVE_GETADDRINFO and not HAVE_GETHOSTBYNAME2 */
 
-#ifdef HAVE_GETHOSTBYNAME2
+#if defined(HAVE_GETHOSTBYNAME2)
 static int netaddr_get_dnsstr_gethostbyname(const pr_netaddr_t *na,
     const char *name) {
   struct hostent *hent = NULL;
@@ -1854,7 +1856,6 @@ static int netaddr_get_dnsstr_gethostbyname(const pr_netaddr_t *na,
   }
 
   hent = gethostbyname2(name, family);
-
   if (hent != NULL) {
     char **checkaddr;
 
@@ -1891,13 +1892,14 @@ static int netaddr_get_dnsstr_gethostbyname(const pr_netaddr_t *na,
 
 # if defined(PR_USE_IPV6)
       case AF_INET6:
-        if (use_ipv6 && family == AF_INET6) {
+        if (use_ipv6 == TRUE &&
+            family == AF_INET6) {
           for (checkaddr = hent->h_addr_list; *checkaddr; ++checkaddr) {
             if (memcmp(*checkaddr, inaddr, hent->h_length) == 0) {
               char **alias;
 
               for (alias = hent->h_aliases; *alias; ++alias) {
-                if (hent->h_name) {
+                if (hent->h_name != NULL) {
                   pr_trace_msg(trace_channel, 10,
                     "host '%s' has alias '%s'", hent->h_name, *alias);
                   netaddr_ipcache_set(*alias, na);
@@ -1937,8 +1939,8 @@ const char *pr_netaddr_get_dnsstr(const pr_netaddr_t *na) {
   }
 
   cache = netaddr_ipcache_get(NULL, pr_netaddr_get_ipstr(na));
-  if (cache &&
-      cache->na_have_dnsstr) {
+  if (cache != NULL &&
+      cache->na_have_dnsstr == TRUE) {
     addr = (pr_netaddr_t *) na;
     memset(addr->na_dnsstr, '\0', sizeof(addr->na_dnsstr));
     sstrncpy(addr->na_dnsstr, cache->na_dnsstr, sizeof(addr->na_dnsstr));
@@ -1950,11 +1952,11 @@ const char *pr_netaddr_get_dnsstr(const pr_netaddr_t *na) {
   /* If this pr_netaddr_t has already been resolved to an DNS string, return the
    * cached string.
    */
-  if (na->na_have_dnsstr) {
+  if (na->na_have_dnsstr == TRUE) {
     return na->na_dnsstr;
   }
 
-  if (reverse_dns) {
+  if (reverse_dns == TRUE) {
     int res = 0;
 
     pr_trace_msg(trace_channel, 3,
@@ -1972,7 +1974,7 @@ const char *pr_netaddr_get_dnsstr(const pr_netaddr_t *na) {
        * addresses properly; we thus prefer gethostbyname2(3) on systems
        * which have it, for such older systems.
        */
-#ifdef HAVE_GETHOSTBYNAME2
+#if defined(HAVE_GETHOSTBYNAME2)
       res = netaddr_get_dnsstr_gethostbyname(na, dns_buf);
 #else
       res = netaddr_get_dnsstr_getaddrinfo(na, dns_buf);
@@ -1996,7 +1998,7 @@ const char *pr_netaddr_get_dnsstr(const pr_netaddr_t *na) {
       "UseReverseDNS off, returning IP address instead of DNS name");
   }
 
-  if (name) {
+  if (name != NULL) {
     name = pr_netaddr_validate_dns_str(name);
 
   } else {
@@ -2029,7 +2031,7 @@ array_header *pr_netaddr_get_dnsstr_list(pool *p, const pr_netaddr_t *na) {
     return NULL;
   }
 
-  if (!reverse_dns) {
+  if (reverse_dns == FALSE) {
     /* If UseReverseDNS is off, then we won't have any names that we trust.
      * So return an empty list.
      */
@@ -2054,7 +2056,7 @@ const char *pr_netaddr_get_localaddr_str(pool *p) {
     return NULL;
   }
 
-  if (have_localaddr_str) {
+  if (have_localaddr_str == TRUE) {
     return pr_netaddr_validate_dns_str(pstrdup(p, localaddr_str));
   }
 
@@ -2071,17 +2073,17 @@ const char *pr_netaddr_get_localaddr_str(pool *p) {
      * that function, for it is possible that the configured hostname for
      * a machine only resolves to an IPv6 address.
      */
-#ifdef HAVE_GETHOSTBYNAME2
+#if defined(HAVE_GETHOSTBYNAME2)
     host = gethostbyname2(buf, AF_INET);
     if (host == NULL &&
         h_errno == HOST_NOT_FOUND) {
-# ifdef AF_INET6
+# if defined(AF_INET6)
       host = gethostbyname2(buf, AF_INET6);
 # endif /* AF_INET6 */
     }
 #else
     host = gethostbyname(buf);
-#endif
+#endif /* HAVE_GETHOSTBYNAME2 */
     if (host != NULL) {
       return pr_netaddr_validate_dns_str(pstrdup(p, host->h_name));
     }
@@ -2119,7 +2121,7 @@ int pr_netaddr_is_loopback(const pr_netaddr_t *na) {
       return IN_IS_ADDR_LOOPBACK(
         (struct in_addr *) pr_netaddr_get_inaddr(na));
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (pr_netaddr_is_v4mappedv6(na) == TRUE) {
         pool *tmp_pool;
@@ -2144,13 +2146,13 @@ int pr_netaddr_is_loopback(const pr_netaddr_t *na) {
        * macros in terms of struct in6_addr *, so I'll go with that for now.
        * Joy. =P
        */
-# ifndef LINUX
+# if !defined(LINUX)
       return IN6_IS_ADDR_LOOPBACK(
         (struct in6_addr *) pr_netaddr_get_inaddr(na));
 # else
       return IN6_IS_ADDR_LOOPBACK(
         ((struct in6_addr *) pr_netaddr_get_inaddr(na))->s6_addr32);
-# endif
+# endif /* LINUX */
 #endif /* PR_USE_IPV6 */
   }
 
@@ -2208,7 +2210,7 @@ int pr_netaddr_is_rfc1918(const pr_netaddr_t *na) {
       break;
     }
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       if (pr_netaddr_is_v4mappedv6(na) == TRUE) {
         pool *tmp_pool;
@@ -2246,7 +2248,7 @@ uint32_t pr_netaddr_get_addrno(const pr_netaddr_t *na) {
     case AF_INET:
       return (uint32_t) na->na_addr.v4.sin_addr.s_addr;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6: {
 
       /* Linux defines s6_addr32 in its netinet/in.h header.
@@ -2281,9 +2283,9 @@ int pr_netaddr_is_v4(const char *name) {
   memset(&v4, 0, sizeof(v4));
   v4.sin_family = AF_INET;
 
-# ifdef SIN_LEN
+#if defined(SIN_LEN)
   v4.sin_len = sizeof(struct sockaddr_in);
-# endif /* SIN_LEN */
+#endif /* SIN_LEN */
 
   res = pr_inet_pton(AF_INET, name, &v4.sin_addr);
   if (res > 0) {
@@ -2299,15 +2301,15 @@ int pr_netaddr_is_v6(const char *name) {
     return -1;
   }
 
-#ifdef PR_USE_IPV6
-  if (use_ipv6) {
+#if defined(PR_USE_IPV6)
+  if (use_ipv6 == TRUE) {
     int res;
     struct sockaddr_in6 v6;
 
     memset(&v6, 0, sizeof(v6));
     v6.sin6_family = AF_INET6;
 
-# ifdef SIN6_LEN
+# if defined(SIN6_LEN)
     v6.sin6_len = sizeof(struct sockaddr_in6);
 # endif /* SIN6_LEN */
 
@@ -2320,11 +2322,11 @@ int pr_netaddr_is_v6(const char *name) {
   return FALSE;
 #else
   return FALSE;
-#endif /* !PR_USE_IPV6 */
+#endif /* PR_USE_IPV6 */
 }
 
 int pr_netaddr_is_v4mappedv6(const pr_netaddr_t *na) {
-  if (!na) {
+  if (na == NULL) {
     errno = EINVAL;
     return -1;
   }
@@ -2336,22 +2338,22 @@ int pr_netaddr_is_v4mappedv6(const pr_netaddr_t *na) {
       errno = EINVAL;
       return -1;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6: {
       int res;
 
-      if (!use_ipv6) {
+      if (use_ipv6 == FALSE) {
         errno = EINVAL;
         return -1;
       }
 
-# ifndef LINUX
+# if !defined(LINUX)
       res = IN6_IS_ADDR_V4MAPPED(
         (struct in6_addr *) pr_netaddr_get_inaddr(na));
 # else
       res = IN6_IS_ADDR_V4MAPPED(
         ((struct in6_addr *) pr_netaddr_get_inaddr(na))->s6_addr32);
-# endif
+# endif /* LINUX */
 
       if (res != TRUE) {
         errno = EINVAL;
@@ -2402,7 +2404,7 @@ pr_netaddr_t *pr_netaddr_v4tov6(pool *p, const pr_netaddr_t *na) {
     return NULL;
   }
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   res = (pr_netaddr_t *) pr_netaddr_get_addr(p,
     pstrcat(p, "::ffff:", pr_netaddr_get_ipstr(na), NULL), NULL);
   if (res != NULL) {
@@ -2418,7 +2420,7 @@ pr_netaddr_t *pr_netaddr_v4tov6(pool *p, const pr_netaddr_t *na) {
 }
 
 const pr_netaddr_t *pr_netaddr_get_sess_local_addr(void) {
-  if (have_sess_local_addr) {
+  if (have_sess_local_addr == TRUE) {
     return &sess_local_addr;
   }
 
@@ -2427,7 +2429,7 @@ const pr_netaddr_t *pr_netaddr_get_sess_local_addr(void) {
 }
 
 const pr_netaddr_t *pr_netaddr_get_sess_remote_addr(void) {
-  if (have_sess_remote_addr) {
+  if (have_sess_remote_addr == TRUE) {
     return &sess_remote_addr;
   }
 
@@ -2436,7 +2438,7 @@ const pr_netaddr_t *pr_netaddr_get_sess_remote_addr(void) {
 }
 
 const char *pr_netaddr_get_sess_remote_name(void) {
-  if (have_sess_remote_addr) {
+  if (have_sess_remote_addr == TRUE) {
     return sess_remote_name;
   }
 


### PR DESCRIPTION
While there, opportunistically address some stylistic nits, such as expanding `#ifdef` into the more verbose `#if defined`, for (subjectively) increased legibility.